### PR TITLE
Set minimum meson version to 0.55.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,6 @@
-project('wrapdb')
+project('wrapdb',
+  meson_version: '>=0.55.0'
+)
 
 wraps = get_option('wraps')
 


### PR DESCRIPTION
It is required for our usage of patch_directory in wrap files. Note that
it affects only wrapdb project itself, not subprojects that can still
require older meson version.