### PR TITLE
Add OpenSSL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install nasm for OpenSSL generator
+        run: sudo apt-get install --no-install-recommends nasm
       - name: Upload release assets
         run: |
           git fetch --unshallow --tags

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -11,9 +11,9 @@ jobs:
       - name: Fetch tags and unshallow
         run: git fetch --unshallow --tags
 
-      - name: Install package
+      - name: Install packages
         run: |
-          sudo apt-get -y install build-essential python3-pip ninja-build
+          sudo apt-get -y install build-essential python3-pip ninja-build nasm
           pip install meson
 
       - name: Sanity Checks

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 __pycache__
+.idea
 .vscode
+
+subprojects/packagecache
+subprojects/packagefiles/openssl/generated-config

--- a/releases.json
+++ b/releases.json
@@ -748,6 +748,16 @@
       "1.7.0-1"
     ]
   },
+  "openssl": {
+    "dependency_names": [
+      "libcrypto",
+      "libssl",
+      "openssl"
+    ],
+    "versions": [
+      "1.1.1k-1"
+    ]
+  },
   "pcg": {
     "versions": [
       "0.98.1-2",

--- a/subprojects/openssl.wrap
+++ b/subprojects/openssl.wrap
@@ -1,0 +1,11 @@
+[wrap-file]
+directory = openssl-1.1.1k
+source_url = https://www.openssl.org/source/openssl-1.1.1k.tar.gz
+source_filename = openssl-1.1.1k.tar.gz
+source_hash = 892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5
+patch_directory = openssl
+
+[provide]
+libcrypto = libcrypto_dep
+libssl = libssl_dep
+openssl = openssl_dep

--- a/subprojects/packagefiles/openssl/LICENSE.build
+++ b/subprojects/packagefiles/openssl/LICENSE.build
@@ -1,0 +1,19 @@
+Copyright (c) 2021 The Meson development team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/subprojects/packagefiles/openssl/README.md
+++ b/subprojects/packagefiles/openssl/README.md
@@ -1,0 +1,23 @@
+# OpenSSL for Meson
+
+## How this works?
+TL;DR: this wrap abuses OpenSSL build system within Node.js.
+
+Node.js has OpenSSL built-in with additional scripting around it to generate configs for GYP build system and thus bypass OpenSSL's native build system.
+
+This wrap abuses that feature by replacing bundled OpenSSL with upstream version, patching mentioned mechanism to also generate a bunch of `meson.build` files for different platforms and uses top-level `meson.build` to wire everything together.
+
+During installation unmodified Node.js tarball will be downloaded, its bundled OpenSSL will be replaced with upstream version and patched with `meson.build` files, enabling ability to build OpenSSL with Meson 🎉.
+
+## How to update to newer release
+Unless Node.js changes the mechanism we abuse above (unlikely, but possible, please check the diff between corresponding versions), `generator.sh` file can be used.
+
+Just update OpenSSL version in wrap file, update Node.js version in `generator.sh` file to such that contains matching OpenSSL version bundled with it and run `generator.sh` from the root of the repository:
+```
+subprojects/packagefiles/openssl/generator.sh
+```
+
+Generated files in `generated-config` directory, after which you can try to build it. `create_release.py` will run it as part of the release process, so it doesn't need to be included in Git.
+
+## Acknowledgement
+This OpenSSL port wouldn't be possible without [Node.js project](https://github.com/nodejs/node) under [MIT license](https://github.com/nodejs/node/blob/master/LICENSE), whose OpenSSL build system was decomposed and heavily refactored.

--- a/subprojects/packagefiles/openssl/generate_gypi.pl.patch
+++ b/subprojects/packagefiles/openssl/generate_gypi.pl.patch
@@ -1,0 +1,39 @@
+diff --git a/openssl/config/generate_gypi.pl b/openssl/config/generate_gypi.pl
+--- a/openssl/config/generate_gypi.pl
++++ b/openssl/config/generate_gypi.pl
+@@ -171,7 +171,34 @@
+ print CLGYPI "$clgypi";
+ close(CLGYPI);
+
++# Create meson.build
++my $mtemplate =
++    Text::Template->new(TYPE => 'FILE',
++                        SOURCE => 'meson.build.tmpl',
++                        DELIMITERS => [ "%%-", "-%%" ]
++                        );
++
++my $meson = $mtemplate->fill_in(
++    HASH => {
++        libssl_srcs => \@libssl_srcs,
++        libcrypto_srcs => \@libcrypto_srcs,
++        generated_srcs => \@generated_srcs,
++        apps_openssl_srcs => \@apps_openssl_srcs,
++        libapps_srcs => \@libapps_srcs,
++        config => \%config,
++        target => \%target,
++        cflags => \@cflags,
++        asm => \$asm,
++        arch => \$arch,
++        lib_cppflags => \@lib_cppflags,
++        is_win => \$is_win,
++    });
++
++open(MESON, "> ./archs/$arch/$asm/meson.build");
++print MESON "$meson";
++close(MESON);
++
+ # Clean Up
+ my $cmd2 ="cd $src_dir; make -f $makefile clean; make -f $makefile distclean;" .
+-    "git clean -f $src_dir/crypto";
++    "git clean -f crypto";
+ system($cmd2) == 0 or die "Error in system($cmd2)";

--- a/subprojects/packagefiles/openssl/generator.sh
+++ b/subprojects/packagefiles/openssl/generator.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Node.js version should bundle OpenSSL of matching version to one specified in wrap file
+node_version=v16.5.0
+openssl_version="$OPENSSL_VERSION"
+
+if [ -z "$openssl_version" ]; then
+  openssl_version=$(grep 'directory = ' ../../openssl.wrap | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[a-z]')
+fi
+
+rm -rf node
+git clone --depth 1 --branch $node_version https://github.com/nodejs/node.git
+
+rm -rf generated-config
+
+pushd node/deps/openssl
+
+# Apply patch that will allow us generate `meson.build` for different targets
+patch -u config/generate_gypi.pl -i ../../../generate_gypi.pl.patch
+# Copy `meson.build` template file
+cp ../../../meson.build.tmpl config/
+
+# Swap bundled OpenSSL in Node.js with upstream
+rm -rf openssl
+git clone --depth 1 --branch "OpenSSL_$(echo $openssl_version | tr . _)" https://github.com/openssl/openssl.git
+
+rm -rf config/archs
+LANG=C make -C config
+
+# Copy generated files back into correct place
+find config/archs -name 'meson.build' | xargs -I % sh -c 'mkdir -p ../../../generated-$(dirname %); cp % ../../../generated-%'
+find config/archs -name '*.h' | xargs -I % sh -c 'mkdir -p ../../../generated-$(dirname %); cp % ../../../generated-%'
+find config/archs -name '*.s' | xargs -I % sh -c 'mkdir -p ../../../generated-$(dirname %); cp % ../../../generated-%'
+
+# AIX is not supported by Meson
+rm -rf ../../../generated-config/archs/aix*
+# Remove build info files, we use hardcoded deterministic one instead
+rm -rf ../../../generated-config/archs/*/*/crypto/buildinf.h
+
+popd
+
+rm -rf node

--- a/subprojects/packagefiles/openssl/include/buildinf.h
+++ b/subprojects/packagefiles/openssl/include/buildinf.h
@@ -1,0 +1,12 @@
+#define PLATFORM "platform: (see uname)"
+#define DATE "built on: the date it was built on, see https://reproducible-builds.org for why this doesn't matter"
+
+/*
+ * Generate compiler_flags as an array of individual characters. This is a
+ * workaround for the situation where CFLAGS gets too long for a C90 string
+ * literal
+ */
+static const char compiler_flags[] = {
+    'c','o','m','p','i','l','e','r',':',' ','a','n','o','n','y','m',
+    'o','u','s','\0'
+};

--- a/subprojects/packagefiles/openssl/include/crypto/bn_conf.h
+++ b/subprojects/packagefiles/openssl/include/crypto/bn_conf.h
@@ -1,0 +1,1 @@
+#include "crypto/include/internal/bn_conf.h"

--- a/subprojects/packagefiles/openssl/include/crypto/dso_conf.h
+++ b/subprojects/packagefiles/openssl/include/crypto/dso_conf.h
@@ -1,0 +1,1 @@
+#include "crypto/include/internal/dso_conf.h"

--- a/subprojects/packagefiles/openssl/meson.build
+++ b/subprojects/packagefiles/openssl/meson.build
@@ -1,0 +1,405 @@
+project(
+  'openssl',
+  'c',
+  version: '1.1.1k',
+  license : 'Apache-2.0',
+  meson_version: '>= 0.55',
+  default_options: [
+    'warning_level=1',
+  ],
+)
+
+# Make sure to generate configs in case they are not already
+fs = import('fs')
+if not fs.exists('generated-config')
+  message('Generating OpenSSL configs...')
+  run_command(
+    'generator.sh',
+    check: true,
+    env: ['OPENSSL_VERSION=' + meson.project_version()],
+  )
+endif
+
+include_directories = [
+  'include',
+  'crypto',
+  'crypto/modes',
+  'crypto/ec/curve448',
+  'crypto/ec/curve448/arch_32',
+]
+
+compiler = meson.get_compiler('c')
+
+dependencies = [
+  # TODO: Make this optionally added once we have threading configurable via options
+  dependency('threads'),
+]
+defines = [
+  # Compile out hardware engines. Most are stubs that dynamically load
+  # the real driver but that poses a security liability when an attacker
+  # is able to create a malicious DLL in one of the default search paths.
+  'OPENSSL_NO_HW',
+]
+c_args = []
+
+asm_opt = get_option('asm')
+
+if asm_opt.disabled()
+  new_gas_or_nasm = false
+  any_gas_or_nasm = false
+else
+  new_gas_or_nasm = (
+    find_program('as', required: false, version: '>=2.26').found() or
+    find_program('nasm', required: false, version: '>=2.11.8').found()
+  )
+  any_gas_or_nasm = (
+    new_gas_or_nasm or
+    find_program('as', required: false).found() or
+    find_program('nasm', required: false).found()
+  )
+endif
+
+if new_gas_or_nasm
+  asm = 'asm'
+
+  # Require AVX512IFMA supported. See
+  # https://www.openssl.org/docs/man1.1.1/man3/OPENSSL_ia32cap.html
+  # Currently crypto/poly1305/asm/poly1305-x86_64.pl requires AVX512IFMA.
+  if host_machine.cpu_family() == 'ppc' and host_machine.system() == 'linux'
+    arch_subdir = 'linux-ppc'
+  elif host_machine.cpu_family() == 'ppc64' and host_machine.system() == 'linux' and host_machine.endian() == 'little'
+    arch_subdir = 'linux-ppc64le'
+  elif host_machine.cpu_family() == 'ppc64' and host_machine.system() == 'linux'
+    arch_subdir = 'linux-ppc64'
+  elif host_machine.cpu_family() == 's390x' and host_machine.system() == 'linux'
+    arch_subdir = 'linux64-s390x'
+  elif host_machine.cpu_family() == 'arm' and host_machine.system() in ['linux', 'android']
+    arch_subdir = 'linux-armv4'
+  elif host_machine.cpu_family() == 'aarch64' and host_machine.system() in ['linux', 'android']
+    arch_subdir = 'linux-aarch64'
+  elif host_machine.cpu_family() == 'x86' and host_machine.system() in ['dragonfly', 'freebsd', 'netbsd', 'openbsd']
+    arch_subdir = 'BSD-x86'
+  elif host_machine.cpu_family() == 'x86' and host_machine.system() in ['linux', 'android']
+    arch_subdir = 'linux-elf'
+  elif host_machine.cpu_family() == 'x86' and host_machine.system() == 'darwin'
+    arch_subdir = 'darwin-i386-cc'
+  elif host_machine.cpu_family() == 'x86' and host_machine.system() == 'sunos'
+    arch_subdir = 'solaris-x86-gcc'
+  elif host_machine.cpu_family() == 'x86' and host_machine.system() == 'windows'
+    warning('x86 + windows combo does not support ASM yet, please contribute')
+    asm = 'no-asm'
+    # TODO: Port this for Windows and uncomment
+    # arch_subdir = 'VC-WIN32'
+    # asm = 'asm'
+    #'rules': [
+    #  {
+    #    'rule_name': 'Assemble',
+    #    'extension': 'asm',
+    #    'inputs': [],
+    #    'outputs': [
+    #      '<(INTERMEDIATE_DIR)/<(RULE_INPUT_ROOT).obj',
+    #    ],
+    #    'action': [
+    #      'nasm.exe',
+    #      '-f win32',
+    #      '-o', '<(INTERMEDIATE_DIR)/<(RULE_INPUT_ROOT).obj',
+    #      '<(RULE_INPUT_PATH)',
+    #    ],
+    #  }
+    #],
+  elif host_machine.cpu_family() == 'x86_64' and host_machine.system() in ['dragonfly', 'freebsd', 'netbsd', 'openbsd']
+    arch_subdir = 'BSD-x86_64'
+  elif host_machine.cpu_family() == 'x86_64' and host_machine.system() == 'darwin'
+    arch_subdir = 'darwin64-x86_64-cc'
+  elif host_machine.cpu_family() == 'aarch64' and host_machine.system() == 'darwin'
+    arch_subdir = 'darwin64-arm64-cc'
+  elif host_machine.cpu_family() == 'x86_64' and host_machine.system() == 'sunos'
+    arch_subdir = 'solaris64-x86_64-gcc'
+  elif host_machine.cpu_family() == 'x86_64' and host_machine.system() == 'windows'
+    warning('x86_64 + windows combo does not support ASM yet, please contribute')
+    asm = 'no-asm'
+    # TODO: Port this for Windows and uncomment
+    # arch_subdir = 'VC-WIN64A'
+    # asm = 'asm'
+    #'rules': [
+    #  {
+    #    'rule_name': 'Assemble',
+    #    'extension': 'asm',
+    #    'inputs': [],
+    #    'outputs': [
+    #      '<(INTERMEDIATE_DIR)/<(RULE_INPUT_ROOT).obj',
+    #    ],
+    #    'action': [
+    #      'nasm.exe',
+    #      '-f win64',
+    #      '-DNEAR',
+    #      '-Ox',
+    #      '-g',
+    #      '-o', '<(INTERMEDIATE_DIR)/<(RULE_INPUT_ROOT).obj',
+    #      '<(RULE_INPUT_PATH)',
+    #    ],
+    #  }
+    #],
+  elif host_machine.cpu_family() == 'x86_64' and host_machine.system() in ['linux', 'android']
+    arch_subdir = 'linux-x86_64'
+  elif host_machine.cpu_family() == 'mips64' and host_machine.system() == 'linux'
+    arch_subdir = 'linux64-mips64'
+  else
+    asm = 'no-asm'
+  endif
+elif any_gas_or_nasm
+  asm = 'asm_avx2'
+
+  if host_machine.cpu_family() == 'ppc' and host_machine.system() == 'linux'
+    arch_subdir = 'linux-ppc'
+  elif host_machine.cpu_family() == 'ppc64' and host_machine.system() == 'linux' and host_machine.endian() == 'little'
+    arch_subdir = 'linux-ppc64le'
+  elif host_machine.cpu_family() == 'ppc64' and host_machine.system() == 'linux'
+    arch_subdir = 'linux-ppc64'
+  elif host_machine.cpu_family() == 's390x' and host_machine.system() == 'linux'
+    arch_subdir = 'linux64-s390x'
+  elif host_machine.cpu_family() == 'arm' and host_machine.system() in ['linux', 'android']
+    arch_subdir = 'linux-armv4'
+  elif host_machine.cpu_family() == 'aarch64' and host_machine.system() in ['linux', 'android']
+    arch_subdir = 'linux-aarch64'
+  elif host_machine.cpu_family() == 'x86' and host_machine.system() in ['dragonfly', 'freebsd', 'netbsd', 'openbsd']
+    arch_subdir = 'BSD-x86'
+  elif host_machine.cpu_family() == 'x86' and host_machine.system() in ['linux', 'android']
+    arch_subdir = 'linux-elf'
+  elif host_machine.cpu_family() == 'x86' and host_machine.system() == 'darwin'
+    arch_subdir = 'darwin-i386-cc'
+  elif host_machine.cpu_family() == 'x86' and host_machine.system() == 'sunos'
+    arch_subdir = 'solaris-x86-gcc'
+  elif host_machine.cpu_family() == 'x86' and host_machine.system() == 'windows'
+    warning('x86 + windows combo does not support ASM yet, please contribute')
+    asm = 'no-asm'
+    # TODO: Port this for Windows and uncomment
+    # arch_subdir = 'VC-WIN32'
+    # asm = 'asm_avx2'
+    #'rules': [
+    #  {
+    #    'rule_name': 'Assemble',
+    #    'extension': 'asm',
+    #    'inputs': [],
+    #    'outputs': [
+    #      '<(INTERMEDIATE_DIR)/<(RULE_INPUT_ROOT).obj',
+    #    ],
+    #    'action': [
+    #      'nasm.exe',
+    #      '-f win32',
+    #      '-o', '<(INTERMEDIATE_DIR)/<(RULE_INPUT_ROOT).obj',
+    #      '<(RULE_INPUT_PATH)',
+    #    ],
+    #  }
+    #],
+  elif host_machine.cpu_family() == 'x86_64' and host_machine.system() in ['dragonfly', 'freebsd', 'netbsd', 'openbsd']
+    arch_subdir = 'BSD-x86_64'
+  elif host_machine.cpu_family() == 'x86_64' and host_machine.system() == 'darwin'
+    arch_subdir = 'darwin64-x86_64-cc'
+  elif host_machine.cpu_family() == 'aarch64' and host_machine.system() == 'darwin'
+    arch_subdir = 'darwin64-arm64-cc'
+  elif host_machine.cpu_family() == 'x86_64' and host_machine.system() == 'sunos'
+    arch_subdir = 'solaris64-x86_64-gcc'
+  elif host_machine.cpu_family() == 'x86_64' and host_machine.system() == 'windows'
+    warning('x86_64 + windows combo does not support ASM yet, please contribute')
+    asm = 'no-asm'
+    # TODO: Port this for Windows and uncomment
+    # arch_subdir = 'VC-WIN64A'
+    # asm = 'asm_avx2'
+    #'rules': [
+    #  {
+    #    'rule_name': 'Assemble',
+    #    'extension': 'asm',
+    #    'inputs': [],
+    #    'outputs': [
+    #      '<(INTERMEDIATE_DIR)/<(RULE_INPUT_ROOT).obj',
+    #    ],
+    #    'action': [
+    #      'nasm.exe',
+    #      '-f win64',
+    #      '-DNEAR',
+    #      '-Ox',
+    #      '-g',
+    #      '-o', '<(INTERMEDIATE_DIR)/<(RULE_INPUT_ROOT).obj',
+    #      '<(RULE_INPUT_PATH)',
+    #    ],
+    #  }
+    #],
+  elif host_machine.cpu_family() == 'x86_64' and host_machine.system() == ['linux', 'android']
+    arch_subdir = 'linux-x86_64'
+  else
+    asm = 'no-asm'
+  endif
+elif asm_opt.enabled()
+  error('Neither GNU Assembler nor Netwide Assembler were found, cannot use use "asm=enabled" option')
+else
+  asm = 'no-asm'
+endif
+
+if asm == 'no-asm'
+  defines += ['OPENSSL_NO_ASM']
+  if host_machine.cpu_family() == 'ppc' and host_machine.system() == 'linux'
+    arch_subdir = 'linux-ppc'
+  elif host_machine.cpu_family() == 'ppc64' and host_machine.system() == 'linux' and host_machine.endian() == 'little'
+    arch_subdir = 'linux-ppc64le'
+  elif host_machine.cpu_family() == 'ppc64' and host_machine.system() == 'linux'
+    arch_subdir = 'linux-ppc64'
+  elif host_machine.cpu_family() == 's390x' and host_machine.system() == 'linux'
+    arch_subdir = 'linux64-s390x'
+  elif host_machine.cpu_family() == 'arm' and host_machine.system() in ['linux', 'android']
+    arch_subdir = 'linux-armv4'
+  elif host_machine.cpu_family() == 'aarch64' and host_machine.system() in ['linux', 'android']
+    arch_subdir = 'linux-aarch64'
+  elif host_machine.cpu_family() == 'x86' and host_machine.system() in ['dragonfly', 'freebsd', 'netbsd', 'openbsd']
+    arch_subdir = 'BSD-x86'
+  elif host_machine.cpu_family() == 'x86' and host_machine.system() in ['linux', 'android']
+    arch_subdir = 'linux-elf'
+  elif host_machine.cpu_family() == 'x86' and host_machine.system() == 'darwin'
+    arch_subdir = 'darwin-i386-cc'
+  elif host_machine.cpu_family() == 'x86' and host_machine.system() == 'sunos'
+    arch_subdir = 'solaris-x86-gcc'
+  elif host_machine.cpu_family() == 'x86' and host_machine.system() == 'windows'
+    arch_subdir = 'VC-WIN32'
+  elif host_machine.cpu_family() == 'x86_64' and host_machine.system() in ['dragonfly', 'freebsd', 'netbsd', 'openbsd']
+    arch_subdir = 'BSD-x86_64'
+  elif host_machine.cpu_family() == 'x86_64' and host_machine.system() == 'darwin'
+    arch_subdir = 'darwin64-x86_64-cc'
+  elif host_machine.cpu_family() == 'aarch64' and host_machine.system() == 'darwin'
+    arch_subdir = 'darwin64-arm64-cc'
+  elif host_machine.cpu_family() == 'x86_64' and host_machine.system() == 'sunos'
+    arch_subdir = 'solaris64-x86_64-gcc'
+  elif host_machine.cpu_family() == 'x86_64' and host_machine.system() == 'windows'
+    arch_subdir = 'VC-WIN64A'
+  elif host_machine.cpu_family() == 'aarch64' and host_machine.system() == 'windows'
+    arch_subdir = 'VC-WIN64-ARM'
+  elif host_machine.cpu_family() == 'x86_64' and host_machine.system() == 'linux'
+    arch_subdir = 'linux-x86_64'
+  elif host_machine.cpu_family() == 'mips64' and host_machine.system() == 'linux'
+    arch_subdir = 'linux64-mips64'
+  else
+    error('Unsupported arch+OS combo: ' + host_machine.cpu_family() + ' + ' + host_machine.system())
+  endif
+
+  message('OpenSSL is configured without ASM support')
+else
+  message('OpenSSL is configured with ASM support')
+endif
+
+subdir('generated-config/archs' / arch_subdir / asm)
+
+# Build options specific to OS, engines are disabled on purpose for the same reasons as `OPENSSL_NO_HW` above
+if host_machine.system() == 'windows'
+  defines += [
+    ## default of Win. See INSTALL in openssl repo.
+    'OPENSSLDIR="C:\\Program Files\\Common Files\\SSL"',
+    'ENGINESDIR="NUL"',
+    'OPENSSL_SYS_WIN32', 'WIN32_LEAN_AND_MEAN', 'L_ENDIAN',
+    '_CRT_SECURE_NO_DEPRECATE', 'UNICODE', '_UNICODE',
+  ]
+  if compiler.get_id() == 'msvc'
+    c_args += [
+      '-wd4090', '-Gs0', '-GF', '-Gy', '-nologo',
+    ]
+  endif
+elif host_machine.system() == 'darwin'
+  defines += [
+    'OPENSSLDIR="/System/Library/OpenSSL/"',
+    'ENGINESDIR="/dev/null"',
+  ]
+  c_args += [
+    '-Wno-missing-field-initializers',
+  ]
+elif host_machine.system() == 'sunos'
+  defines += [
+   'OPENSSLDIR="/etc/ssl"',
+   'ENGINESDIR="/dev/null"',
+   '__EXTENSIONS__'
+ ]
+else
+  # linux and others
+  defines += [
+    'OPENSSLDIR="/etc/ssl"',
+    'ENGINESDIR="/dev/null"',
+  ]
+  c_args += [
+    '-Wno-missing-field-initializers',
+  ]
+  if compiler.get_id() != 'clang'
+    c_args += [
+      '-Wno-old-style-declaration',
+    ]
+  endif
+endif
+
+# MSVC fails with "ERROR: C static library 'ws2_32' not found"
+try_static_libs = get_option('default_library') == 'static' and compiler.get_id() != 'msvc'
+foreach library: openssl_libraries
+  dependencies += [
+    compiler.find_library(
+      library,
+      static: try_static_libs,
+    ),
+  ]
+endforeach
+
+# We may need to add some defines for static builds
+if get_option('default_library') == 'static'
+  defines += [
+    'OSSL_CRYPTO_DSO_CONF_H',
+    'DSO_NONE',
+    'DSO_EXTENSION=.so',
+    'OPENSSL_NO_DSO',
+  ]
+endif
+
+foreach define : defines + openssl_defines
+  c_args += ['-D' + define]
+endforeach
+
+c_args += openssl_cflags
+
+include_directories += openssl_include_directories
+
+libcrypto_lib = library(
+  'crypto',
+  dependencies: dependencies,
+  sources: libcrypto_sources,
+  include_directories: include_directories,
+  c_args: c_args,
+  install: true,
+)
+
+libcrypto_dep = declare_dependency(
+  include_directories: include_directories,
+  dependencies: dependencies,
+  link_with: libcrypto_lib,
+)
+
+libssl_lib = library(
+  'ssl',
+  dependencies: dependencies + [libcrypto_dep],
+  sources: libssl_sources,
+  include_directories: include_directories,
+  c_args: c_args,
+  install: true,
+)
+
+libssl_dep = declare_dependency(
+  include_directories: include_directories,
+  dependencies: dependencies + [libcrypto_dep],
+  link_with: libssl_lib,
+)
+
+openssl_dep = declare_dependency(
+  dependencies: [libcrypto_dep, libssl_dep],
+)
+
+openssl_cli = executable(
+  'openssl',
+  build_by_default: false,
+  dependencies: dependencies + [openssl_dep],
+  sources: openssl_cli_sources,
+  include_directories: include_directories,
+  c_args: c_args,
+  install: true,
+)

--- a/subprojects/packagefiles/openssl/meson.build.tmpl
+++ b/subprojects/packagefiles/openssl/meson.build.tmpl
@@ -1,0 +1,91 @@
+# OpenSSL library
+libcrypto_sources = [
+%%-
+foreach $src (@libcrypto_srcs) {
+  $OUT .= "  '$src',\n";
+}
+foreach $src (@generated_srcs) {
+  $OUT .= "  'generated-config/archs/$arch/$asm/$src',\n";
+}
+-%%]
+libssl_sources = [
+%%-
+foreach $src (@libssl_srcs) {
+  $OUT .= "  '$src',\n";
+}
+-%%]
+openssl_defines = [
+%%-
+foreach $define (@{$config{defines}}) {
+  # We rely on Meson's `b_ndebug` instead
+  if ($define ne 'NDEBUG') {
+    $OUT .= "  '$define',\n";
+  }
+}
+foreach $define (@lib_cppflags) {
+  $OUT .= "  '$define',\n";
+}
+foreach $define (@{$target{defines}}) {
+  $OUT .= "  '$define',\n";
+}
+foreach $define (@{$config{lib_defines}}) {
+  $OUT .= "  '$define',\n";
+}
+-%%]
+openssl_cflags = [
+%%-
+my %cflags_used;
+if (!$is_win) {
+  foreach $cflag (@cflags) {
+    foreach $single_cflag (split / /, $cflag) {
+      # Warning and optimization levels are configured on Meson level now, threads will be handled in the root `meson.build`
+      if (
+        $single_cflag ne '-Wall' &&
+        $single_cflag ne '-O3' &&
+        $single_cflag ne '-pthread' &&
+        !exists($cflags_used{$single_cflag} )
+      ) {
+        $OUT .= "  '$single_cflag',\n";
+        $cflags_used{$single_cflag} = true;
+      }
+    }
+  }
+}
+-%%]
+openssl_libraries = [
+%%-
+foreach $ex_lib (split / /, $target{ex_libs}) {
+  # Threads will be handled in the root `meson.build`
+  if ($ex_lib ne '-pthread') {
+    # *nix
+    if (substr($ex_lib, 0, 2) eq '-l') {
+      $ex_lib = substr($ex_lib, 2);
+      $OUT .= "  '$ex_lib',\n";
+    }
+    # Windows
+    if ($ex_lib =~ /\.lib$/) {
+      $ex_lib = substr($ex_lib, 0, length($ex_lib) - 4);
+      $OUT .= "  '$ex_lib',\n";
+    }
+  }
+}
+-%%]
+openssl_include_directories = [
+  'generated-config/archs/%%-$arch-%%/%%-$asm-%%',
+  'generated-config/archs/%%-$arch-%%/%%-$asm-%%/include',
+  'generated-config/archs/%%-$arch-%%/%%-$asm-%%/crypto',
+  'generated-config/archs/%%-$arch-%%/%%-$asm-%%/crypto/include/internal',
+]
+
+# OpenSSL CLI
+openssl_cli_sources = [
+%%-
+foreach $src (@apps_openssl_srcs) {
+  unless ($src eq "apps/openssl.rc") {
+    $OUT .= "  '$src',\n";
+  }
+}
+foreach $src (@libapps_srcs) {
+  $OUT .= "  '$src',\n";
+}
+-%%]

--- a/subprojects/packagefiles/openssl/meson_options.txt
+++ b/subprojects/packagefiles/openssl/meson_options.txt
@@ -1,0 +1,1 @@
+option('asm', type : 'feature', value : 'auto', description : 'Enable platform-specific assembly optimizations')

--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -53,6 +53,11 @@ class CreateRelease:
         directory = self.wrap_section.get('directory', self.name)
         srcdir = Path('subprojects', 'packagefiles', patch_directory)
         destdir = Path(self.tempdir, directory)
+
+        generator = Path(srcdir, 'generator.sh')
+        if generator.exists():
+            subprocess.check_call([generator])
+
         shutil.copytree(srcdir, destdir)
         base_name = Path(self.tempdir, f'{self.tag}_patch')
         shutil.make_archive(base_name.as_posix(), 'zip', root_dir=self.tempdir, base_dir=directory)


### PR DESCRIPTION
This adds OpenSSL 1.1.1k

Important notes:
* abuses Node.js
* doesn't support ASM on Windows (there are TODOs in code if anyone cares to test)
* includes scripting for building release archive with generated files, will generate files with `meson setup` if those aren't present already
* includes readme that describes design decisions and other important details
* can build both libraries (libcrypto and libssl) and openssl executable
* tested on Linux x86-64 (Ubuntu and Alpine), macOS 11 x86-64 and Windows Server 2019 (MinWG GCC 8.1.0, Clang 12.0.1 and MSVC 19.29.30038.1 with GitHub Actions)

Fixes #109