### PR TITLE
sanity-checks: Make it run locally

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -16,8 +16,6 @@ jobs:
           sudo apt-get -y install build-essential python3-pip ninja-build
           pip install meson
 
-      - uses: trilom/file-changes-action@v1.2.3
-
       - name: Sanity Checks
         run: |
           ./tools/sanity_checks.py


### PR DESCRIPTION
trilom/file-changes-action action has issues and it prevents running
sanity checks locally. Instead of relying on the changed files to know
which wraps are modified by a PR, rely on the added release tags.

Fixes: #121.