### PR TITLE
Sanity checks improvements

### DIFF
--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -88,6 +88,7 @@ class TestReleases(unittest.TestCase):
                 if extra_checks:
                     with self.subTest(step='provide'):
                         self.assertIn('provide', config.sections())
+                        self.assertTrue(config.items('provide'))
 
                 patch_directory = wrap_section.get('patch_directory')
                 if patch_directory:


### PR DESCRIPTION
From #140

@danielcjacobs advised:
> Also, seems like there may be a bug, since it passed the sanity check just by adding [provide]. Might want it to check for the specific dependencies it's supposed to provide. Would also allow it to provide more specific error messages.

So I have, at least, made this actually be an error. Thanks for pointing this out!

...

I have also taken the opportunity while I'm there, to fix a gripe of mine and make it use better failure reporting. The test no longer aborts at the first assertion failure, but rather, keeps going in order to report all possible errors. And, it tells you which wrap the error came from.

Both of these improvements come via unittest subtests. A more thorough mechanism would probably involve using pytest parameterization across the test class and breaking everything up into individual test functions, but this is more work and adds more dependencies, and really doesn't do much of anything other than to cause the success reporting to be able to report one dot per wrap, or report the names of each class per wrap when using `pytest -v` -- currently unittest sees everything as one, now two, tests (plus a lot of subtests).