### PR TITLE
imgui: fix metal dependency on macos

### DIFF
--- a/subprojects/packagefiles/imgui/meson.build
+++ b/subprojects/packagefiles/imgui/meson.build
@@ -30,7 +30,7 @@ if dx12_dep.found()
     sources += 'backends/imgui_impl_dx12.cpp'
     dependencies += dx12_dep
 endif
-metal_dep = cpp.find_library('metal', required: get_option('metal'))
+metal_dep = dependency('metal', required: get_option('metal'))
 if get_option('metal').enabled()
     sources += 'backends/imgui_impl_metal.mm'
     dependencies += metal_dep


### PR DESCRIPTION
fix for finding metal as a dependency for imgui on macos

cpp.find_library doesn't find the framework to I changed it to dependency. 