### PR TITLE
Add wraps for xtl, xtensor, and xtensor-python

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1183,6 +1183,22 @@
       "0.3.0-1"
     ]
   },
+  "xtensor": {
+    "dependency_names": [
+      "xtensor"
+    ],
+    "versions": [
+      "0.21.5-1"
+    ]
+  },
+  "xtl": {
+    "dependency_names": [
+      "xtl"
+    ],
+    "versions": [
+      "0.6.12-1"
+    ]
+  },
   "xxhash": {
     "dependency_names": [
       "libxxhash"

--- a/subprojects/packagefiles/xtensor/meson.build
+++ b/subprojects/packagefiles/xtensor/meson.build
@@ -1,0 +1,43 @@
+project('xtensor', 'cpp',
+        version:'0.21.5',
+        license:'BSD-3-Clause',
+        default_options : ['warning_level=3', 'cpp_std=c++14'])
+
+xtl_dep = dependency('xtl',
+    version:['>=0.6.12', '<1.0.0'])
+
+json_dep = dependency('nlohmann_json',
+    version:'>=3.1.1')
+
+xsimd_dep = dependency('xsimd',
+    required: get_option('xsimd'),
+    version: ['>=7.4.6', '<8.0.0'])
+
+if xsimd_dep.found()
+    xtensor_cpp_arg = ['-Duse_xsimd']
+else
+    xtensor_cpp_arg = []
+endif
+
+xtensor_dep = declare_dependency(
+    include_directories:include_directories('include', is_system: true),
+    dependencies: [xtl_dep, json_dep, xsimd_dep],
+    compile_args: xtensor_cpp_arg)
+
+extra_cflags = []
+
+# Workaround from issue: https://github.com/mesonbuild/meson/issues/2550
+if meson.is_subproject()
+    install_dir = get_option('subproj_includedir')
+    extra_cflags += '-I' + get_option('prefix') / install_dir
+else
+    install_dir = get_option('includedir')
+endif
+
+install_subdir('include/xtensor', install_dir: install_dir)
+
+pkgconfig = import('pkgconfig')
+pkgconfig.generate(name: meson.project_name(),
+    version: meson.project_version(),
+    description: 'xtensor is a C++ library meant for numerical analysis with multi-dimensional array expressions.',
+    extra_cflags: extra_cflags)

--- a/subprojects/packagefiles/xtensor/meson_options.txt
+++ b/subprojects/packagefiles/xtensor/meson_options.txt
@@ -1,0 +1,6 @@
+option('xsimd', type: 'feature', value: 'auto', description: 'simd acceleration for xtensor')
+option('subproj_includedir',
+    type: 'string',
+    value: 'include',
+    description: 'Header file directory when built as subproject',
+    yield: true)

--- a/subprojects/packagefiles/xtl/meson.build
+++ b/subprojects/packagefiles/xtl/meson.build
@@ -1,0 +1,26 @@
+project('xtl', 'cpp', version:'0.6.12', license:'BSD-3-Clause', default_options : ['warning_level=3', 'cpp_std=c++14'])
+
+json_dep = dependency('nlohmann_json',
+    version:'>=3.1.1')
+
+xtl_dep = declare_dependency(
+    include_directories:include_directories('include', is_system: true),
+    dependencies: [json_dep])
+
+extra_cflags = []
+
+# Workaround from issue: https://github.com/mesonbuild/meson/issues/2550
+if meson.is_subproject()
+    install_dir = get_option('subproj_includedir')
+    extra_cflags += '-I' + get_option('prefix') / install_dir
+else
+    install_dir = get_option('includedir')
+endif
+
+install_subdir('include/xtl', install_dir: install_dir)
+
+pkgconfig = import('pkgconfig')
+pkgconfig.generate(name: meson.project_name(),
+    version: meson.project_version(),
+    description: 'Basic tools (containers, algorithms) used by other quantstack packages.',
+    extra_cflags: extra_cflags)

--- a/subprojects/packagefiles/xtl/meson_options.txt
+++ b/subprojects/packagefiles/xtl/meson_options.txt
@@ -1,0 +1,6 @@
+
+option('subproj_includedir',
+    type: 'string',
+    value: 'include',
+    description: 'Header file directory when built as subproject',
+    yield: true)

--- a/subprojects/xtensor.wrap
+++ b/subprojects/xtensor.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = xtensor-0.21.5
+source_url = https://github.com/xtensor-stack/xtensor/archive/0.21.5.tar.gz
+source_filename = xtensor-0.21.5.tar.gz
+source_hash = 30cb896b6686683ddaefb12c98bf1109fdfe666136dd027aba1a1e9aa825c241
+patch_directory = xtensor
+
+[provide]
+xtensor = xtensor_dep

--- a/subprojects/xtl.wrap
+++ b/subprojects/xtl.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = xtl-0.6.12
+source_url = https://github.com/xtensor-stack/xtl/archive/0.6.12.tar.gz
+source_filename = xtl-0.6.12.tar.gz
+source_hash = 25a16958195f939e6fb7c8feccad89b3e450a18124be6aee119c69a1ee2b308c
+patch_directory = xtl
+
+[provide]
+xtl = xtl_dep


### PR DESCRIPTION
Add wraps for xtensor and xtl from the [xtensor-stack](https://github.com/xtensor-stack)

NOTE: Shows gtest commit even though this has already been merged into `wrapdb`.  Somewhat new to the whole forking process, so not sure how I should've changed my process.