### PR TITLE
Use the RawConfigParser to not have to escape URLs

### DIFF
--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -69,7 +69,7 @@ class TestReleases(unittest.TestCase):
                 extra_checks = latest_tag not in self.tags
 
                 # Make sure we can load wrap file
-                config = configparser.ConfigParser()
+                config = configparser.RawConfigParser()
                 config.read(f'subprojects/{name}.wrap')
 
                 # Basic checks


### PR DESCRIPTION
URL encoded strings have percents in them. Percents are interpolated by
ConfigParser, so use RawConfigParser to avoid the interpolation
completely.

Fixes #151