### PR TITLE
Add wrap for libccp4c

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -47,6 +47,10 @@
       "libvulkan-dev"
     ]
   },
+  "libccp4c": {
+    "_comment": ["- upstream does not support building with MSVC"],
+    "linux_only": true
+  },
   "liburing": {
     "linux_only": true
   },

--- a/releases.json
+++ b/releases.json
@@ -541,7 +541,15 @@
       "2.12-2",
       "2.12-1"
     ]
-},
+  },
+  "libccp4c": {
+    "dependency_names": [
+      "libccp4c"
+    ],
+    "versions": [
+      "6.5.1-1"
+    ]
+  },
   "libexif": {
     "dependency_names": [
       "libexif"

--- a/subprojects/libccp4c.wrap
+++ b/subprojects/libccp4c.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = libccp4-6.5.1
+source_url = ftp://ftp.ccp4.ac.uk/opensource/libccp4-6.5.1.tar.gz
+source_fallback_url = https://www.desy.de/~twhite/crystfel/libccp4-6.5.1.tar.gz
+source_filename = libccp4-6.5.1.tar.gz
+source_hash = 280b473d950cdf8837ef66147ec581104298b892399bd856f13b096f2395dbe5
+patch_directory = libccp4c
+
+[provide]
+libccp4c = libccp4c_dep

--- a/subprojects/packagefiles/libccp4c/LICENSE.build
+++ b/subprojects/packagefiles/libccp4c/LICENSE.build
@@ -1,0 +1,19 @@
+Copyright (c) 2021 The Meson development team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/subprojects/packagefiles/libccp4c/meson.build
+++ b/subprojects/packagefiles/libccp4c/meson.build
@@ -1,0 +1,108 @@
+# Meson file for libccp4c (CCP4 core libraries, C part only)
+project('libccp4c', ['c'],
+        version: '6.5.1',
+        meson_version: '>=0.49.0',
+        license: 'LGPL3')
+
+
+cc = meson.get_compiler('c')
+mdep = cc.find_library('m', required: false)
+
+if cc.get_id() == 'msvc'
+    error('libccp4c cannot be compiled using MSVC')
+endif
+
+# Note that the source code assumes that datadir='share'.
+# If it is not, programs using the library will not be able
+# to find 'environ.def'.
+datadir = get_option('datadir') / 'ccp4'
+
+
+add_project_arguments('-DPACKAGE_ROOT="' + get_option('prefix') + '"',
+                      language: 'c')
+add_project_arguments(cc.get_supported_arguments(['-Wno-uninitialized',
+                                                  '-Wno-unused-function',
+                                                  '-Wno-stringop-truncation',
+                                                  '-Wno-stringop-overflow',
+                                                  '-Wno-format-overflow',
+                                                  '-Wno-misleading-indentation',
+                                                  '-Wno-pointer-compare']),
+                      language: 'c')
+
+
+# C library
+libccp4c = library('ccp4c', ['ccp4/ccp4_array.c',
+                             'ccp4/cmap_accessor.c',
+                             'ccp4/cmap_open.c',
+                             'ccp4/csymlib.c',
+                             'ccp4/pack_c.c',
+                             'ccp4/ccp4_general.c',
+                             'ccp4/cmap_close.c',
+                             'ccp4/cmap_skew.c',
+                             'ccp4/cvecmat.c',
+                             'ccp4/ccp4_parser.c',
+                             'ccp4/cmap_data.c',
+                             'ccp4/cmap_stats.c',
+                             'ccp4/library_err.c',
+                             'ccp4/ccp4_program.c',
+                             'ccp4/cmap_header.c',
+                             'ccp4/cmap_symop.c',
+                             'ccp4/library_file.c',
+                             'ccp4/ccp4_unitcell.c',
+                             'ccp4/cmap_labels.c',
+                             'ccp4/cmtzlib.c',
+                             'ccp4/library_utils.c'],
+                   dependencies: [mdep],
+                   install: true)
+
+# CCP4 headers are included with prefix: <ccp4/header.h>
+incdir = include_directories('.')
+
+install_headers(['ccp4/ccp4_file_err.h',
+                 'ccp4/ccp4_program.h',
+                 'ccp4/ccp4_unitcell.h',
+                 'ccp4/cmap_errno.h',
+                 'ccp4/cmap_stats.h',
+                 'ccp4/csymlib.h',
+                 'ccp4/library_file.h',
+                 'ccp4/ccp4_fortran.h',
+                 'ccp4/ccp4_spg.h',
+                 'ccp4/ccp4_utils.h',
+                 'ccp4/cmap_header.h',
+                 'ccp4/cmaplib.h',
+                 'ccp4/cvecmat.h',
+                 'ccp4/mtzdata.h',
+                 'ccp4/ccp4_array.h',
+                 'ccp4/ccp4_general.h',
+                 'ccp4/ccp4_sysdep.h',
+                 'ccp4/ccp4_vars.h',
+                 'ccp4/cmap_labels.h',
+                 'ccp4/cmaplib_f.h',
+                 'ccp4/overview.h',
+                 'ccp4/ccp4_errno.h',
+                 'ccp4/ccp4_parser.h',
+                 'ccp4/ccp4_types.h',
+                 'ccp4/cmap_data.h',
+                 'ccp4/cmap_skew.h',
+                 'ccp4/cmtzlib.h',
+                 'ccp4/pack_c.h'],
+                subdir: 'ccp4')
+
+
+# Data files
+install_data(['data/atomsf_electron.lib',
+              'data/atomsf.lib',
+              'data/atomsf_neutron.lib',
+              'data/syminfo.lib',
+              'data/symop.lib'],
+             install_dir: datadir)
+
+
+# pkg-config file
+pkg = import('pkgconfig')
+pkg.generate(libccp4c,
+             filebase: 'libccp4c',
+             description: 'CCP4 core C libraries')
+
+libccp4c_dep = declare_dependency(include_directories: incdir,
+                                  link_with: libccp4c)


### PR DESCRIPTION
This adds a wrap for the C-language part of the [CCP4](https://www.ccp4.ac.uk/) core library.  The source code also includes a set of Fortran bindings, which are currently ignored but could be added as an optional extra if there were demand.

The license for this library is LGPL3, with liability disclaimer modified for UK law.  I've licensed my meson.build file as BSD to match the other wraps, but I'd also be happy to use LGPL3 instead with a view to eventually upstreaming the Meson file.  Note that LGPL applies only to this core library - the rest of the main CCP4 suite (which is huge), based on this library, has a proprietary licence.

The code is old (20 years, some parts older still) and there are a number of compiler warnings.  Following wrap guidelines, I haven't fixed them.  However, I did take the liberty of suppressing them with compiler options, to stop them from drowning warnings from the main project.

The only download source for the libraries is unfortunately an unreliable FTP server, so I've provided a more reliable fallback.  I've been in touch with the upstream authors to ask about hosting it on their [Github account](https://github.com/ccp4) and also fixing the compiler warnings.