### PR TITLE
Add script to update packagefiles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+
+[meson.build]
+indent_size = 2
+

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ meson compile -C builddir
   copied onto the upstream's source tree, but it is generally not accepted to
   override upstream files.
 
+- It is often easier to develop in `subprojects/my-project` directory and update
+  packagefiles directory at the end. This can be done using
+  `tools/update-packagefiles.py` script.
+
 - Add your release information in `releases.json`. It is a dictionary where the
   key is the wrap name and the value is a dictionary containing with the following
   keys:

--- a/README.md
+++ b/README.md
@@ -42,11 +42,19 @@ meson compile -C builddir
     `[provide]` section.
   - `program_names`: (Optional) List of program names (e.g. `glib-compile-resources`)
     provided by the wrap. It must match information from wrap's `[provide]` section.
-  - `skip_ci`: (Optional) If set to `true` indicates that the wrap cannot be built
-    as part of the CI, for example if specific environment or dependencies are
-    required.
+
+- Configure CI in `ci_config.json`. It is a dictionary where the key is the wrap
+  name and the value is a dictionary containing with the following keys:
   - `build_options`: (Optional) List of `option=value` strings that will be used
     to build the project on the CI.
+  - `debian_packages`: (Optional) List of extra packages that will be installed
+    on debian-like CI runners. Dependencies that can be provided by other wraps
+    should not be added here because it's better to test that fallbacks works.
+    When running `tools/sanity_checks.py` locally, this list will be printed
+    but not installed.
+
+- Test locally by running `tools/sanity_checks.py` script. It will be executed
+  on the CI and must always return success before merging any PR.
 
 - Create Pull Request with your changes.
 

--- a/ci_config.json
+++ b/ci_config.json
@@ -1,0 +1,8 @@
+{
+  "rdkafka": {
+    "build_options": [
+      "WITH_SASL=disabled",
+      "WITH_ZSTD=disabled"
+    ]
+  }
+}

--- a/releases.json
+++ b/releases.json
@@ -892,10 +892,6 @@
       "1.5.0-1",
       "1.4.4-1",
       "1.4.0-1"
-    ],
-    "build_options": [
-      "WITH_SASL=disabled",
-      "WITH_ZSTD=disabled"
     ]
   },
   "re2": {

--- a/tools/update-packagefiles.py
+++ b/tools/update-packagefiles.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 Xavier Claessens <xclaesse@gmail.com>
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import configparser
+import tarfile
+import zipfile
+import shutil
+from pathlib import Path
+
+def read_wrap(filename):
+    wrap = configparser.ConfigParser(interpolation=None)
+    wrap.read(filename)
+    return wrap[wrap.sections()[0]]
+
+def read_archive_files(path, base_path):
+    if path.suffix == '.zip':
+        with zipfile.ZipFile(path, 'r') as archive:
+            archive_files = set(base_path / i for i in archive.namelist())
+    else:
+        with tarfile.open(archive_path) as archive:
+            archive_files = set(base_path / i.name for i in archive)
+    return archive_files
+
+if __name__ == '__main__':
+    for f in Path('subprojects').glob('*.wrap'):
+        wrap_section = read_wrap(f)
+        patch_directory = wrap_section.get('patch_directory')
+        if not patch_directory:
+            continue
+        directory = Path('subprojects', wrap_section['directory'])
+        if not directory.is_dir():
+            continue
+        archive_path = Path('subprojects', 'packagecache', wrap_section['source_filename'])
+        if not archive_path.exists():
+            continue
+        lead_directory_missing = bool(wrap_section.get('lead_directory_missing', False))
+        base_path = directory if lead_directory_missing else Path('subprojects')
+        archive_files = read_archive_files(archive_path, base_path)
+        directory_files = set(directory.glob('**/*'))
+        new_files = directory_files - archive_files
+        packagefiles = Path('subprojects', 'packagefiles', patch_directory)
+        print(f'Updating {directory}')
+        shutil.rmtree(packagefiles)
+        for src_path in new_files:
+            if not src_path.is_file():
+                continue
+            rel_path = src_path.relative_to(directory)
+            dst_path = packagefiles / rel_path
+            print(f'Copy {rel_path}')
+            dst_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(src_path, dst_path)

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -14,6 +14,7 @@
 
 import operator
 import re
+import os
 import typing as T
 
 # a helper class which implements the same version ordering as RPM
@@ -83,3 +84,9 @@ class Version:
         # if equal length, all components have matched, so equal
         # otherwise, the version with a suffix remaining is greater
         return comparator(len(self._v), len(other._v))
+
+def is_ci() -> bool:
+    return 'CI' in os.environ
+
+def is_debianlike() -> bool:
+    return os.path.isfile('/etc/debian_version')


### PR DESCRIPTION
    This helps developping patch overlays, meson files can be created
    directly in the right position in source tree, and this script will copy
    them into packagefiles/ directory.
