### PR TITLE
update all github archives wraps to prefer using tar.gz

### DIFF
--- a/subprojects/catch.wrap
+++ b/subprojects/catch.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = Catch2-2.2.2
-source_url = https://github.com/catchorg/Catch2/archive/v2.2.2.zip
-source_filename = Catch2-2.2.2.zip
-source_hash = 7f6871b621eb961db642b032cdbd59f1b5cacfcf187ac985599397e4d9e862da
+source_url = https://github.com/catchorg/Catch2/archive/v2.2.2.tar.gz
+source_filename = Catch2-2.2.2.tar.gz
+source_hash = e93aacf012579093fe6b4e686ff0488975cabee1e6b4e4f27a0acd898e8f09fd
 patch_directory = catch
-

--- a/subprojects/catch2.wrap
+++ b/subprojects/catch2.wrap
@@ -1,10 +1,9 @@
 [wrap-file]
 directory = Catch2-2.13.7
-source_url = https://github.com/catchorg/Catch2/archive/v2.13.7.zip
-source_filename = Catch2-2.13.7.zip
-source_hash = 3f3ccd90ad3a8fbb1beeb15e6db440ccdcbebe378dfd125d07a1f9a587a927e9
+source_url = https://github.com/catchorg/Catch2/archive/v2.13.7.tar.gz
+source_filename = Catch2-2.13.7.tar.gz
+source_hash = 3cdb4138a072e4c0290034fe22d9f0a80d3bcfb8d7a8a5c49ad75d3a5da24fae
 patch_directory = catch2
 
 [provide]
 catch2 = catch2_dep
-

--- a/subprojects/catchorg-clara.wrap
+++ b/subprojects/catchorg-clara.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = Clara-1.1.5
-source_url = https://github.com/catchorg/Clara/archive/v1.1.5.zip
-source_filename = Clara-1.1.5.zip
-source_hash = 9649045c0f151d5854533507631214dfc8b1a6cb055b5985d987ed3b6f3dfbd2
+source_url = https://github.com/catchorg/Clara/archive/v1.1.5.tar.gz
+source_filename = Clara-1.1.5.tar.gz
+source_hash = 767dc1718e53678cbea00977adcd0a8a195802a505aec3c537664cf25a173142
 patch_directory = catchorg-clara
-

--- a/subprojects/cpputest.wrap
+++ b/subprojects/cpputest.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = cpputest-4.0
-source_url = https://github.com/cpputest/cpputest/archive/v4.0.zip
-source_filename = cpputest-4.0.zip
-source_hash = b81d0c34f300bc1ed39e152fb92e178555a784e294e1f1cefe074326c2588339
+source_url = https://github.com/cpputest/cpputest/archive/v4.0.tar.gz
+source_filename = cpputest-4.0.tar.gz
+source_hash = 0b66d20661f232d2a6af124c4455c8ccc9a4ce72d29f6ad4877eb385faaf5108
 patch_directory = cpputest
-

--- a/subprojects/cpr.wrap
+++ b/subprojects/cpr.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = cpr-1.5.0
-source_url = https://github.com/whoshuu/cpr/archive/1.5.0.zip
-source_filename = cpr-1.5.0.zip
-source_hash = e4805a5897acceab4c159f5dd47b92f9bbfc91bd984eed29af8b69ec6c368052
+source_url = https://github.com/whoshuu/cpr/archive/1.5.0.tar.gz
+source_filename = cpr-1.5.0.tar.gz
+source_hash = a1727794541bac6d1bb73c9c27ac3ef5b0d64edcc4f81dc8d79b3cf31b6144e9
 patch_directory = cpr
-

--- a/subprojects/emilk-loguru.wrap
+++ b/subprojects/emilk-loguru.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = loguru-2.1.0
-source_url = https://github.com/emilk/loguru/archive/v2.1.0.zip
-source_filename = loguru_2.1.0.zip
-source_hash = 8d2d28969a4e91f8ef71ae4c1ba140097d274f75b6587fb4f465ce9434402fd2
+source_url = https://github.com/emilk/loguru/archive/v2.1.0.tar.gz
+source_filename = loguru_2.1.0.tar.gz
+source_hash = 1a3be62ebec5609af60b1e094109a93b7412198b896bb88f31dcfe4d95b79ce7
 patch_directory = emilk-loguru
-

--- a/subprojects/google-benchmark.wrap
+++ b/subprojects/google-benchmark.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = benchmark-1.5.2
-source_url = https://github.com/google/benchmark/archive/v1.5.2.zip
-source_filename = benchmark-1.5.2.zip
-source_hash = 21e6e096c9a9a88076b46bd38c33660f565fa050ca427125f64c4a8bf60f336b
+source_url = https://github.com/google/benchmark/archive/v1.5.2.tar.gz
+source_filename = benchmark-1.5.2.tar.gz
+source_hash = dccbdab796baa1043f04982147e67bb6e118fe610da2c65f88912d73987e700c
 patch_directory = google-benchmark
-

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
 directory = googletest-release-1.11.0
-source_url = https://github.com/google/googletest/archive/release-1.11.0.zip
-source_filename = gtest-1.11.0.zip
-source_hash = 353571c2440176ded91c2de6d6cd88ddd41401d14692ec1f99e35d013feda55a
+source_url = https://github.com/google/googletest/archive/release-1.11.0.tar.gz
+source_filename = gtest-1.11.0.tar.gz
+source_hash = b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5
 patch_directory = gtest
 
 [provide]
@@ -10,4 +10,3 @@ gtest = gtest_dep
 gtest_main = gtest_main_dep
 gmock = gmock_dep
 gmock_main = gmock_main_dep
-

--- a/subprojects/htslib.wrap
+++ b/subprojects/htslib.wrap
@@ -1,10 +1,9 @@
 [wrap-file]
 directory = htslib-1.11
-source_url = https://github.com/samtools/htslib/archive/1.11.zip
-source_filename = 1.11.zip
-source_hash = 8b1c56c212b0b6c823d6136f364aa372c5f6f6c1666c701d1e84bf928ee82853
+source_url = https://github.com/samtools/htslib/archive/1.11.tar.gz
+source_filename = 1.11.tar.gz
+source_hash = 9977f388eb28191bd57e47df5a4b7d61b1ccfe97e9717d12cd283e6faf2e1e34
 patch_directory = htslib
 
 [provide]
 htslib = htslib_dep
-

--- a/subprojects/libsrtp2.wrap
+++ b/subprojects/libsrtp2.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
 directory = libsrtp-2.4.0
-source_url = https://github.com/cisco/libsrtp/archive/refs/tags/v2.4.0.zip
-source_filename = libsrtp-2.4.0.zip
-source_hash = 8c47eed1c98f3309b5748033b4363a9cb78ffaaba3f647e8c9152478ad6bdb30
+source_url = https://github.com/cisco/libsrtp/archive/refs/tags/v2.4.0.tar.gz
+source_filename = libsrtp-2.4.0.tar.gz
+source_hash = 713c5c1dc740707422307f39834c0b0fbb76769168d87e92c438a3cca8233d3d
 
 [provide]
 libsrtp2 = libsrtp2_dep

--- a/subprojects/libtiff.wrap
+++ b/subprojects/libtiff.wrap
@@ -1,10 +1,9 @@
 [wrap-file]
 directory = tiff-4.1.0
-source_url = http://download.osgeo.org/libtiff/tiff-4.1.0.zip
-source_filename = tiff-4.1.0.zip
-source_hash = 6f3dbed9d2ecfed33c7192b5c01884078970657fa21b4ad28e3cdf3438eb2419
+source_url = http://download.osgeo.org/libtiff/tiff-4.1.0.tar.gz
+source_filename = tiff-4.1.0.tar.gz
+source_hash = 5d29f32517dadb6dbcd1255ea5bbc93a2b54b94fbf83653b4d65c7d6775b8634
 patch_directory = libtiff
 
 [provide]
 libtiff-4 = libtiff4_dep
-

--- a/subprojects/libtomcrypt.wrap
+++ b/subprojects/libtomcrypt.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = libtomcrypt-1.17
-source_url = https://github.com/libtom/libtomcrypt/releases/download/1.17/crypt-1.17.zip
-source_filename = crypt-1.17.zip
-source_hash = e860ae8057e5bef12e544d38e097ccf9372509d3487a56dd01fb57224c5a3343
+source_url = https://github.com/libtom/libtomcrypt/releases/download/1.17/crypt-1.17.tar.bz2
+source_filename = crypt-1.17.tar.bz2
+source_hash = e33b47d77a495091c8703175a25c8228aff043140b2554c08a3c3cd71f79d116
 patch_directory = libtomcrypt
-

--- a/subprojects/libwebsockets.wrap
+++ b/subprojects/libwebsockets.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = libwebsockets-v4.0.13
-source_url = https://libwebsockets.org/git/libwebsockets/snapshot/libwebsockets-v4.0.13.zip
-source_filename = libwebsockets-v4.0.13.zip
-source_hash = 42b9301947b1571b5df4c63e777cd6711768a96d04211a69bfe0f572ef7473ca
+source_url = https://libwebsockets.org/git/libwebsockets/snapshot/libwebsockets-v4.0.13.tar.xz
+source_filename = libwebsockets-v4.0.13.tar.xz
+source_hash = 82a30cb62ab9735d926990a75f166078101028af1923a30232032b39976f8879
 patch_directory = libwebsockets
-

--- a/subprojects/microsoft-gsl.wrap
+++ b/subprojects/microsoft-gsl.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = GSL-3.1.0
-source_url = https://github.com/microsoft/GSL/archive/v3.1.0.zip
-source_filename = GSL-3.1.0.zip
-source_hash = a1041e41e60f9cb3789036f1c84ea9b4298823cbe94d16b096971fdc3de485b7
+source_url = https://github.com/microsoft/GSL/archive/v3.1.0.tar.gz
+source_filename = GSL-3.1.0.tar.gz
+source_hash = d3234d7f94cea4389e3ca70619b82e8fb4c2f33bb3a070799f1e18eef500a083
 patch_directory = microsoft-gsl
-

--- a/subprojects/muellan-clipp.wrap
+++ b/subprojects/muellan-clipp.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = clipp-1.2.3
-source_url = https://github.com/muellan/clipp/archive/v1.2.3.zip
-source_filename = clipp-1.2.3.zip
-source_hash = 51f820de9f04866a9a94235258ec51ebfee12f3f3d0ca86a84cf4ddfe50411a3
+source_url = https://github.com/muellan/clipp/archive/v1.2.3.tar.gz
+source_filename = clipp-1.2.3.tar.gz
+source_hash = 73da8e3d354fececdea99f7deb79d0343647349563ace3eafb7f4cca6e86e90b
 patch_directory = muellan-clipp
-

--- a/subprojects/nng.wrap
+++ b/subprojects/nng.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = nng-1.3.2
-source_url = https://github.com/nanomsg/nng/archive/v1.3.2.zip
-source_filename = nng-1.3.2.zip
-source_hash = 2616110016c89ed3cbd458022ba41f4f545ab17f807546d2fdd0789b55d64471
+source_url = https://github.com/nanomsg/nng/archive/v1.3.2.tar.gz
+source_filename = nng-1.3.2.tar.gz
+source_hash = 0f8f2ede7f5ea2018c7fa615c76f48662eb06d39c71c3339f8ff38da44470855
 patch_directory = nng
-

--- a/subprojects/onqtam-doctest.wrap
+++ b/subprojects/onqtam-doctest.wrap
@@ -1,6 +1,6 @@
 
 [wrap-file]
 directory = doctest-2.4.0
-source_url = https://github.com/onqtam/doctest/archive/2.4.0.zip
-source_filename = doctest-2.4.0.zip
-source_hash = 7af678dc5d4b1780478f1ab071c8f19cac6cfcfbe2793dd9f5ba498648ae4e6b
+source_url = https://github.com/onqtam/doctest/archive/2.4.0.tar.gz
+source_filename = doctest-2.4.0.tar.gz
+source_hash = f689f48e92c088928d88d8481e769c8e804f0a608b484ab8ef3d6ab6045b5444

--- a/subprojects/pcre2.wrap
+++ b/subprojects/pcre2.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = pcre2-10.23
-source_url = https://ftp.pcre.org/pub/pcre/pcre2-10.23.zip
-source_filename = pcre2-10.23.zip
-source_hash = 6301a525a8a7e63a5fac0c2fbfa0374d3eb133e511d886771e097e427707094a
+source_url = https://ftp.pcre.org/pub/pcre/pcre2-10.23.tar.bz2
+source_filename = pcre2-10.23.tar.bz2
+source_hash = dfc79b918771f02d33968bd34a749ad7487fa1014aeb787fad29dd392b78c56e
 patch_directory = pcre2
-

--- a/subprojects/protobuf.wrap
+++ b/subprojects/protobuf.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = protobuf-3.12.2
-source_url = https://github.com/protocolbuffers/protobuf/releases/download/v3.12.2/protobuf-all-3.12.2.zip
-source_filename = protobuf-all-3.12.2.zip
-source_hash = af6a9cf80a99090a38a027e4b1a0545220f368368d8b03b3309ff760cb60d92d
+source_url = https://github.com/protocolbuffers/protobuf/releases/download/v3.12.2/protobuf-all-3.12.2.tar.gz
+source_filename = protobuf-all-3.12.2.tar.gz
+source_hash = e610c6633763bceec08a647d0605f5df0f9c960028ef32c0730e3df23164fb0d
 patch_directory = protobuf
-

--- a/subprojects/range-v3.wrap
+++ b/subprojects/range-v3.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = range-v3-0.10.0
-source_url = https://github.com/ericniebler/range-v3/archive/0.10.0.zip
-source_filename = range-v3-0.10.0.zip
-source_hash = 4884dc4f62cb9fdc3b803cb44a862448853146f6a26bc37c6f3d53d786168a87
+source_url = https://github.com/ericniebler/range-v3/archive/0.10.0.tar.gz
+source_filename = range-v3-0.10.0.tar.gz
+source_hash = 5a1cd44e7315d0e8dcb1eee4df6802221456a9d1dbeac53da02ac7bd4ea150cd
 patch_directory = range-v3
-

--- a/subprojects/rapidjson.wrap
+++ b/subprojects/rapidjson.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = rapidjson-1.1.0
-source_url = https://github.com/Tencent/rapidjson/archive/v1.1.0.zip
-source_filename = rapidjson-1.1.0.zip
-source_hash = 8e00c38829d6785a2dfb951bb87c6974fa07dfe488aa5b25deec4b8bc0f6a3ab
+source_url = https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz
+source_filename = rapidjson-1.1.0.tar.gz
+source_hash = bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e
 patch_directory = rapidjson
-

--- a/subprojects/rxcpp.wrap
+++ b/subprojects/rxcpp.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = RxCpp-4.1.0
-source_url = https://github.com/ReactiveX/RxCpp/archive/4.1.0.zip
-source_filename = RxCpp-4.1.0.zip
-source_hash = d2ee5579b81b3676c0fb7efd02aae58575f2e9148a6d8f2b469cf9c020760ccb
+source_url = https://github.com/ReactiveX/RxCpp/archive/4.1.0.tar.gz
+source_filename = RxCpp-4.1.0.tar.gz
+source_hash = d3bb49c7ac6b5c43235df710510fce87d827bb88a1b78242017f190d2acbbdea
 patch_directory = rxcpp
-

--- a/subprojects/sdl2_image.wrap
+++ b/subprojects/sdl2_image.wrap
@@ -7,4 +7,3 @@ patch_directory = sdl2_image
 
 [provide]
 sdl2_image = sdl2_image_dep
-

--- a/subprojects/sdl2_net.wrap
+++ b/subprojects/sdl2_net.wrap
@@ -1,10 +1,9 @@
 [wrap-file]
 directory = SDL2_net-2.0.1
-source_url = https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.0.1.zip
-source_filename = SDL2_net-2.0.1.zip
-source_hash = 52031ed9d08a5eb1eda40e9a0409248bf532dde5e8babff5780ef1925657d59f
+source_url = https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.0.1.tar.gz
+source_filename = SDL2_net-2.0.1.tar.gz
+source_hash = 15ce8a7e5a23dafe8177c8df6e6c79b6749a03fff1e8196742d3571657609d21
 patch_directory = sdl2_net
 
 [provide]
 sdl2_net = sdl2_net_dep
-

--- a/subprojects/sdl2_ttf.wrap
+++ b/subprojects/sdl2_ttf.wrap
@@ -1,10 +1,9 @@
 [wrap-file]
 directory = SDL2_ttf-2.0.12
-source_url = https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.12.zip
-source_filename = SDL2_ttf-2.0.12.zip
-source_hash = eb909b4e5717b86e87dad7ee15adbbc5f26a33bd2dc22b93a77517bb0ba7fec8
+source_url = https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.12.tar.gz
+source_filename = SDL2_ttf-2.0.12.tar.gz
+source_hash = 8728605443ea1cca5cad501dc34dc0cb15135d1e575551da6d151d213d356f6e
 patch_directory = sdl2_ttf
 
 [provide]
 sdl2_ttf = sdl2_ttf_dep
-

--- a/subprojects/termbox.wrap
+++ b/subprojects/termbox.wrap
@@ -1,10 +1,9 @@
 [wrap-file]
 directory = termbox-1.1.2
-source_url = https://github.com/nsf/termbox/archive/v1.1.2.zip
-source_filename = v1.1.2.zip
-source_hash = 428dc9559243f4ddf2ca52015b01c8334c1a1eb55f974b68468c309d24dc0dfd
+source_url = https://github.com/nsf/termbox/archive/v1.1.2.tar.gz
+source_filename = v1.1.2.tar.gz
+source_hash = 61c9940b42b3ac44bf0cba67eacba75e3c02088b8c695149528c77def04d69b1
 patch_directory = termbox
 
 [provide]
 termbox = termbox_dep
-

--- a/subprojects/tinyply.wrap
+++ b/subprojects/tinyply.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
-source_url = https://github.com/ddiakopoulos/tinyply/archive/2.2.zip
-source_filename = tinyply-2.2.zip
+source_url = https://github.com/ddiakopoulos/tinyply/archive/2.2.tar.gz
+source_filename = tinyply-2.2.tar.gz
 directory = tinyply-2.2
-source_hash = f9e4078a1f82557bf1d5c80525492c569e3ef8a4f5b28a847996ee91a2e8f4e6
+source_hash = c01446e1d03f160123756a28e4be8769ecf35e4da5c34e7a9a9bf561334f32dc
 patch_directory = tinyply
 
 [provide]

--- a/subprojects/trompeloeil.wrap
+++ b/subprojects/trompeloeil.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = trompeloeil-39
-source_url = https://github.com/rollbear/trompeloeil/archive/v39.zip
-source_filename = trompeloeil-39.zip
-source_hash = 62c92f13f08d349fdd955de09bc7a2b14ae957b08f7b2356494090b62bb39309
+source_url = https://github.com/rollbear/trompeloeil/archive/v39.tar.gz
+source_filename = trompeloeil-39.tar.gz
+source_hash = 10506e48abd605740bc9ed43e34059f5068bc80af14476bd129a3ed3b54d522f
 patch_directory = trompeloeil
-

--- a/subprojects/unittest-cpp.wrap
+++ b/subprojects/unittest-cpp.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = unittest-cpp-2.0.0
-source_url = https://github.com/unittest-cpp/unittest-cpp/archive/v2.0.0.zip
-source_filename = unittest-cpp-2.0.0.zip
-source_hash = 3ba4f8b6c6e75ca8c79dd6008c78e95fb08554fbf2e0f1195fb78a4bf5a8a805
+source_url = https://github.com/unittest-cpp/unittest-cpp/archive/v2.0.0.tar.gz
+source_filename = unittest-cpp-2.0.0.tar.gz
+source_hash = 74852198877dc2fdebdc4e5e9bd074018bf8ee03a13de139bfe41f4585b2f5b9
 patch_directory = unittest-cpp
-

--- a/subprojects/utfcpp.wrap
+++ b/subprojects/utfcpp.wrap
@@ -1,7 +1,6 @@
 [wrap-file]
 directory = utfcpp-2.3.5
-source_url = https://github.com/nemtrif/utfcpp/archive/v2.3.5.zip
-source_filename = utfcpp-2.3.5.zip
-source_hash = 1d5cb7d908202d734ec35b84087400013f352ffb4612e978ffb948986b76df14
+source_url = https://github.com/nemtrif/utfcpp/archive/v2.3.5.tar.gz
+source_filename = utfcpp-2.3.5.tar.gz
+source_hash = f3ffe0ef6c02f48ebafe42369cbd741e844143baad27c13baad1cd14b863983d
 patch_directory = utfcpp
-


### PR DESCRIPTION
tarballs are nicer than zips, if for no other reason than they compress better. It's not a huge deal but it is slightly nicer on user bandwidth...

Making new releases for this is not necessary.

```
meson subprojects download catch catch2 catchorg-clara cpputest cpr emilk-loguru google-benchmark gtest htslib libsrtp2 microsoft-gsl muellan-clipp nng onqtam-doctest range-v3 rapidjson rxcpp termbox tinyply trompeloeil unittest-cpp utfcpp
```

before and after yields consistent savings in subprojects/packagefiles/