### PR TITLE
Add wrap for LodePNG

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -627,6 +627,15 @@
       "3.0.1-1"
     ]
   },
+  "lodepng": {
+    "dependency_names": [
+      "lodepng",
+      "lodepng_c"
+    ],
+    "versions": [
+      "20210627-1"
+    ]
+  },
   "lua": {
     "dependency_names": [
       "lua-5.4"

--- a/subprojects/lodepng.wrap
+++ b/subprojects/lodepng.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = lodepng-8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a
+source_url = https://github.com/lvandeve/lodepng/archive/8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a.tar.gz
+source_filename = 8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a.tar.gz
+source_hash = f45359be529f5f478ebeb3159859a8f49462df35866e227c12d1440f17451a82
+patch_directory = lodepng
+
+[provide]
+dependency_names = lodepng, lodepng_c

--- a/subprojects/packagefiles/lodepng/meson.build
+++ b/subprojects/packagefiles/lodepng/meson.build
@@ -1,0 +1,18 @@
+project('lodepng', ['c', 'cpp'],
+    version: '20210627',
+    license: 'zlib')
+
+# C++ version
+lodepng_dep = declare_dependency(
+    include_directories: include_directories('.'),
+    sources: files('lodepng.cpp'))
+
+# C89 version
+copy = find_program('cp', 'copy', required: true)
+run_command(copy, 'lodepng.cpp', 'lodepng.c')
+lodepng_c_dep = declare_dependency(
+    include_directories: include_directories('.'),
+    sources: files('lodepng.c'))
+
+meson.override_dependency('lodepng', lodepng_dep)
+meson.override_dependency('lodepng_c', lodepng_c_dep)

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -159,8 +159,8 @@ class TestReleases(unittest.TestCase):
             version = segs[0] + segs[1] + '0' + segs[2]
         elif name == 're2':
             version = f'{version[:4]}-{version[4:6]}-{version[6:8]}'
-        elif name == 'netstring-c':
-            # There is no specific version for netstring-c
+        elif name in ['netstring-c', 'lodepng']:
+            # There is no specific version for these libraries
             return True
         source_url = wrap_section['source_url']
         version_ = version.replace('.', '_')


### PR DESCRIPTION
Wrap for [lvandeve/lodepng](https://github.com/lvandeve/lodepng).

LodePNG doesn't use any build system. It's intended to be dropped into source tree. The library consists of only two files: source (`lodepng.cpp`) and header (`lodepng.h`). Also this means that there is no need to build any static/shared library.

It supports both C and C++, but there is a caveat: to use it in C project, you have to rename `lodepng.cpp` to `lodepng.c`.

LodePNG is written in C89 with a thin C++ wrapper on top of it, but technically it's still C++. So attempt to use `lodepng.cpp` in C project leads to linkage errors. To address this problem specifically for this wrap, I might've tried to patch lodepng.h and add `extern "C"` here and there... or just duplicate `lodepng.cpp` and provide two separate dependencies for C and C++. I decided to go with the latter option.

This wrap ignores all testing utilities from upstream.

The upstream repository doesn't have any releases/tags, but the library is kinda versioned.