### PR TITLE
Add hse to wrapdb

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -389,6 +389,17 @@
       "2.4.1-1"
     ]
   },
+  "hse": {
+    "dependency_names": [
+      "hse-2"
+    ],
+    "program_names": [
+      "hse2"
+    ],
+    "versions": [
+      "2.0.0-1"
+    ]
+  },
   "htslib": {
     "dependency_names": [
       "htslib"

--- a/subprojects/hse.wrap
+++ b/subprojects/hse.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = hse-r2.0.0
+source_url = https://github.com/hse-project/hse/archive/refs/tags/r2.0.0.tar.gz
+source_filename = r2.0.0.tar.gz
+source_hash = 6f9d5a2c08441bf35eff736f9ec1e9a251e841684d834e6f6207d5563e0696fc
+
+[provide]
+program_names = hse2
+dependency_names = hse-2


### PR DESCRIPTION
HSE aims to be parallel-installable with itself, but a project should only use one version. HSE provides the following:

* hse2 - CLI
* hse_dep - Dependency object for correctly linking/compiling with HSE