### PR TITLE
spng: Should not need to force fallback for zlib any more

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -42,10 +42,5 @@
       "libudev-dev",
       "libxrandr-dev"
     ]
-  },
-  "spng": {
-    "build_options": [
-      "force_fallback_for=zlib"
-    ]
   }
 }


### PR DESCRIPTION
Meson has been fixed to ignore pkg-config that comes from Perl in
Windows CI.