### PR TITLE
sanity_checks: No need to check project version in test_build_all().

### DIFF
--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -191,9 +191,7 @@ class TestReleases(unittest.TestCase):
                 with tempfile.TemporaryDirectory() as d:
                     self.check_new_release(name, d)
                     passed.append(name)
-                    self.check_meson_version(name, current_version,
-                        self.get_patch_path(wrap_section), d)
-            except subprocess. CalledProcessError:
+            except subprocess.CalledProcessError:
                 failed.append(name)
         print(f'{len(passed)} passed:', ', '.join(passed))
         print(f'{len(skipped)} skipped:', ', '.join(skipped))


### PR DESCRIPTION
That test only ensure that we can still build all wraps, it is meant as
a meson regression test.

This hopwfully will fix weird CI failure on Windows:
https://github.com/mesonbuild/wrapdb/runs/3940962881