### PR TITLE
WIP: Add GStreamer project

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -365,6 +365,29 @@
       "1.0.2-1"
     ]
   },
+  "gstreamer-full": {
+    "dependency_names": [
+      "gstreamer-1.0",
+      "gstreamer-base-1.0",
+      "gstreamer-pbutils-1.0",
+      "gstreamer-rtsp-1.0",
+      "gstreamer-allocators-1.0",
+      "gstreamer-controller-1.0",
+      "gstreamer-plugins-base-1.0",
+      "gstreamer-sdp-1.0",
+      "gstreamer-app-1.0",
+      "gstreamer-fft-1.0",
+      "gstreamer-riff-1.0",
+      "gstreamer-tag-1.0",
+      "gstreamer-audio-1.0",
+      "gstreamer-net-1.0",
+      "gstreamer-rtp-1.0",
+      "gstreamer-video-1.0"
+    ],
+    "versions": [
+      "1.19.3-1"
+    ]
+  },
   "gtest": {
     "dependency_names": [
       "gtest",

--- a/subprojects/gstreamer-full.wrap
+++ b/subprojects/gstreamer-full.wrap
@@ -1,0 +1,9 @@
+[wrap-git]
+directory=gstreamer
+url=https://gitlab.freedesktop.org/gstreamer/gstreamer.git
+revision=main
+depth=1
+
+[provide]
+dependency_names = gstreamer-1.0, gstreamer-base-1.0, gstreamer-pbutils-1.0, gstreamer-rtsp-1.0, gstreamer-allocators-1.0, gstreamer-controller-1.0, gstreamer-plugins-base-1.0, gstreamer-sdp-1.0, gstreamer-app-1.0, gstreamer-fft-1.0, gstreamer-riff-1.0, gstreamer-tag-1.0, gstreamer-audio-1.0, gstreamer-net-1.0, gstreamer-rtp-1.0, gstreamer-video-1.0
+


### PR DESCRIPTION
Notes:
- I had to name it `gstreamer-full.wrap` because we cannot have 2 subprojects with the same name, and gstreamer monorepo has itself a subproject named `gstreamer`.
- Currently uses git because 1.19.3 release does not have tarball for the monorepo, only its subprojects. @tp-m I think we should make gstreamer-full.tar.gz as part of the official release for 1.20, what do you think?
- The `[provide]` section contains only libraries we always build, I took the list of pc files generated when configuring with `-Dauto_features=disabled`.