### PR TITLE
Add wrap files for slirp-4.6.1

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -69,6 +69,13 @@
       "libxrandr-dev"
     ]
   },
+  "slirp": {
+    "_comment": ["- Limited to linux_only pending the addition of other POSIX-ish environments to the test matrix."],
+    "linux_only": true,
+    "build_options": [
+      "glib:tests=false"
+    ]
+  },
   "wayland-protocols": {
     "linux_only": true,
     "debian_packages": [

--- a/releases.json
+++ b/releases.json
@@ -1067,6 +1067,14 @@
       "2.5.1-1"
     ]
   },
+  "slirp": {
+    "dependency_names": [
+      "slirp"
+    ],
+    "versions": [
+      "4.6.1-1"
+    ]
+  },
   "spdlog": {
     "dependency_names": [
       "spdlog"

--- a/subprojects/slirp.wrap
+++ b/subprojects/slirp.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = libslirp-v4.6.1
+source_url = https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v4.6.1/libslirp-v4.6.1.tar.gz
+source_filename = libslirp-v4.6.1.tar.gz
+source_hash = 69ad4df0123742a29cc783b35de34771ed74d085482470df6313b6abeb799b11
+
+# the libslirp project uses a pkg-config name of slirp instead of libslirp
+[provide]
+slirp = slirp_dep


### PR DESCRIPTION
This PR depends on the Glib 2.70.2, which is submitted under: https://github.com/mesonbuild/wrapdb/pull/241