### PR TITLE
opencl-headers: add

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -868,6 +868,14 @@
       "1.21.0-1"
     ]
   },
+  "opencl-headers": {
+    "dependency_names": [
+      "openclheaders"
+    ],
+    "versions": [
+      "2021.06.30-1"
+    ]
+  },
   "openh264": {
     "versions": [
       "1.7.0-1"

--- a/subprojects/opencl-headers.wrap
+++ b/subprojects/opencl-headers.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = OpenCL-Headers-2021.06.30
+source_url = https://github.com/KhronosGroup/OpenCL-Headers/archive/refs/tags/v2021.06.30.tar.gz
+source_filename = OpenCL-Headers-2021.06.30.tar.gz
+source_hash = 6640d590c30d90f89351f5e3043ae6363feeb19ac5e64bc35f8cfa1a6cd5498e
+patch_directory = opencl-headers
+
+[provide]
+OpenCLHeaders = opencl_headers_dep

--- a/subprojects/packagefiles/opencl-headers/meson.build
+++ b/subprojects/packagefiles/opencl-headers/meson.build
@@ -1,0 +1,38 @@
+project(
+  'OpenCLHeaders',
+  'c',
+  license : 'Apache-2.0',
+  version : '2021.06.30',
+)
+
+install_headers(
+  'CL/cl_d3d10.h',
+  'CL/cl_d3d11.h',
+  'CL/cl_dx9_media_sharing.h',
+  'CL/cl_dx9_media_sharing_intel.h',
+  'CL/cl_egl.h',
+  'CL/cl_ext.h',
+  'CL/cl_ext_intel.h',
+  'CL/cl_gl_ext.h',
+  'CL/cl_gl.h',
+  'CL/cl.h',
+  'CL/cl_half.h',
+  'CL/cl_icd.h',
+  'CL/cl_layer.h',
+  'CL/cl_platform.h',
+  'CL/cl_va_api_media_sharing_intel.h',
+  'CL/cl_version.h',
+  'CL/opencl.h',
+  subdir : 'CL',
+)
+
+pkgc = import('pkgconfig')
+pkgc.generate(name: 'OpenCLHeaders',
+  version: '2.2',
+  description: 'C language headers for the OpenCL API'
+)
+
+opencl_headers_dep = declare_dependency(
+  include_directories : include_directories('.'),
+  version : '2.2',
+)


### PR DESCRIPTION
Added OpenCLHeaders as the name as upstream uses that for its cmake
configuration files.

Signed-off-by: Rosen Penev <rosenp@gmail.com>