### PR TITLE
pcre2: increase the stack size for test builds

### DIFF
--- a/subprojects/packagefiles/pcre2/meson.build
+++ b/subprojects/packagefiles/pcre2/meson.build
@@ -68,7 +68,7 @@ check_headers = [
 config_h_defs = []
 foreach h : check_headers
   if c_compiler.has_header(h)
-    config_h_defs += ['-DHAVE_' + h.underscorify().to_upper(]
+    config_h_defs += ['-DHAVE_' + h.underscorify().to_upper()]
   endif
 endforeach
 

--- a/subprojects/packagefiles/pcre2/meson.build
+++ b/subprojects/packagefiles/pcre2/meson.build
@@ -147,10 +147,16 @@ pkg.generate(libraries : pcre2_32_lib,
 #### tests
 
 if not meson.is_cross_build() # wine wrappers are not bat-friendly, this would need better testing
+  link_args = []
+  if host_machine.system() == 'windows'
+    link_args += '/STACK:2500000'
+  endif
+
   pcre2test = executable('pcre2test', ['src/pcre2test.c'],
     include_directories: includes,
     link_with: [pcre2_8_lib, pcre2_posix_lib, pcre2_16_lib, pcre2_32_lib],
-    c_args: config_h_defs + ['-DHAVE_CONFIG_H'])
+    c_args: config_h_defs + ['-DHAVE_CONFIG_H'],
+    link_args: link_args)
 
   if host_machine.system() == 'windows'
     runtest = find_program('RunTest.bat')


### PR DESCRIPTION
the reason tests on Windows were failing was because the program was running out of stack space while expanding a regex operation.