### PR TITLE
nonstd-expected-lite: add overrides

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -861,7 +861,11 @@
     ]
   },
   "nonstd-expected-lite": {
+    "dependency_names": [
+      "expected-lite"
+    ],
     "versions": [
+      "0.3.0-2",
       "0.3.0-1"
     ]
   },

--- a/subprojects/nonstd-expected-lite.wrap
+++ b/subprojects/nonstd-expected-lite.wrap
@@ -5,3 +5,5 @@ source_filename = expected-lite-0.3.0.tar.gz
 source_hash = fc942ce0614e9498bff6f35f1ee8d58f83026bac904d9ab427a2e822b5bdfcbd
 patch_directory = nonstd-expected-lite
 
+[provide]
+expected-lite = nonstd_expected_lite_dep

--- a/subprojects/packagefiles/nonstd-expected-lite/meson.build
+++ b/subprojects/packagefiles/nonstd-expected-lite/meson.build
@@ -3,3 +3,7 @@ project('nonstd-expected-lite', 'cpp', version: '0.3.0', license: 'BSL-1.0')
 includes = include_directories('include')
 
 nonstd_expected_lite_dep = declare_dependency(include_directories: includes)
+
+if meson.version().version_compare('>= 0.54.0')
+  meson.override_dependency('expected-lite', nonstd_expected_lite_dep)
+endif


### PR DESCRIPTION
So that explicit fallbacks are not required