### PR TITLE
Update flatbuffers to 2.0.0 and fix Windows builds

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -14,7 +14,7 @@
   ],
   "broken_windows": [
     "arduinocore-avr", "box2d", "cjson", "cpr", "docopt",
-    "emilk-loguru", "enet", "facil", "flatbuffers",
+    "emilk-loguru", "enet", "facil",
     "fuse", "gdbm", "google-snappy", "google-woff2",
     "hinnant-date", "imgui-sfml", "inih", "jbigkit",
     "libexif", "libgpiod", "liblbfgs", "liblzma",

--- a/releases.json
+++ b/releases.json
@@ -233,7 +233,8 @@
   },
   "flatbuffers": {
     "dependency_names": [
-      "flatbuffers"
+      "flatbuffers",
+      "flatc_library"
     ],
     "program_names": [
       "flatc",

--- a/releases.json
+++ b/releases.json
@@ -232,7 +232,15 @@
     ]
   },
   "flatbuffers": {
+    "dependency_names": [
+      "flatbuffers"
+    ],
+    "program_names": [
+      "flatc",
+      "flathash"
+    ],
     "versions": [
+      "2.0.0-1",
       "1.11.0-1"
     ]
   },

--- a/subprojects/flatbuffers.wrap
+++ b/subprojects/flatbuffers.wrap
@@ -1,7 +1,10 @@
 [wrap-file]
-directory = flatbuffers-1.11.0
-source_url = https://github.com/google/flatbuffers/archive/v1.11.0.tar.gz
-source_filename = flatbuffers-1.11.0.tar.gz
-source_hash = 3f4a286642094f45b1b77228656fbd7ea123964f19502f9ecfd29933fd23a50b
+directory = flatbuffers-2.0.0
+source_url = https://github.com/google/flatbuffers/archive/refs/tags/v2.0.0.tar.gz
+source_filename = flatbuffers-2.0.0.tar.gz
+source_hash = 9ddb9031798f4f8754d00fca2f1a68ecf9d0f83dfac7239af1311e4fd9a565c4
 patch_directory = flatbuffers
 
+[provide]
+flatbuffers = flatbuffers_dep
+program_names = flatc, flathash

--- a/subprojects/flatbuffers.wrap
+++ b/subprojects/flatbuffers.wrap
@@ -7,4 +7,5 @@ patch_directory = flatbuffers
 
 [provide]
 flatbuffers = flatbuffers_dep
+flatc_library = flatc_lib_dep
 program_names = flatc, flathash

--- a/subprojects/packagefiles/flatbuffers/meson.build
+++ b/subprojects/packagefiles/flatbuffers/meson.build
@@ -1,18 +1,26 @@
 project(
     'flatbuffers',
     'cpp',
-    version : '1.11.0',
+    version : '2.0.0',
     license : 'Apache-2.0'
 )
 
 cpp = meson.get_compiler('cpp')
 
-cpp_args = [
-    '-Wall',
-    '-pedantic',
-    '-Werror',
-    '-Wextra'
-]
+cpp_args = []
+
+if host_machine.system() == 'windows'
+    cpp_args += '-D_CRT_SECURE_NO_WARNINGS'
+endif
+
+if cpp.get_argument_syntax() == 'gcc'
+    cpp_args += [
+        '-Wall',
+        '-pedantic',
+        '-Werror',
+        '-Wextra'
+    ]
+endif
 
 # Certain platforms such as ARM do not use signed chars by default
 # which causes issues with certain bounds checks.
@@ -20,13 +28,14 @@ if cpp.has_argument('-fsigned-char')
    cpp_args += '-fsigned-char'
 endif
 
+
 includes = include_directories(['include', 'grpc'])
 
+# flatbuffers
 install_headers([
     'include/flatbuffers/base.h',
     'include/flatbuffers/code_generators.h',
     'include/flatbuffers/flatbuffers.h',
-    'include/flatbuffers/flatc.h',
     'include/flatbuffers/flexbuffers.h',
     'include/flatbuffers/grpc.h',
     'include/flatbuffers/hash.h',
@@ -41,13 +50,14 @@ install_headers([
 
 flatbuffers_lib_sources = [
     'src/code_generators.cpp',
-    'src/idl_parser.cpp',
+    'src/idl_gen_fbs.cpp',
     'src/idl_gen_text.cpp',
+    'src/idl_parser.cpp',
     'src/reflection.cpp',
     'src/util.cpp'
 ]
 
-flatbuffers_lib = library(
+flatbuffers_lib = static_library(
     'flatbuffers',
     flatbuffers_lib_sources,
     include_directories : includes,
@@ -55,26 +65,109 @@ flatbuffers_lib = library(
     install: true
 )
 
+flatbuffers_dep = declare_dependency(
+    include_directories : includes,
+    link_with: flatbuffers_lib
+)
+
+# grpc libraries
+cpp_gen_lib =  static_library(
+    'cpp_generator',
+    [
+        'grpc/src/compiler/cpp_generator.cc'
+    ],
+    include_directories: includes,
+    cpp_args : cpp_args
+)
+
+# grpc libraries
+go_gen_lib =  static_library(
+    'go_generator',
+    [
+        'grpc/src/compiler/go_generator.cc'
+    ],
+    include_directories: includes,
+    cpp_args : cpp_args
+)
+
+java_gen_lib =  static_library(
+    'java_generator',
+    [
+        'grpc/src/compiler/java_generator.cc'
+    ],
+    include_directories: includes,
+    cpp_args : cpp_args
+)
+
+python_gen_lib =  static_library(
+    'python_generator',
+    [
+        'grpc/src/compiler/python_generator.cc'
+    ],
+    include_directories: includes,
+    cpp_args : cpp_args
+)
+
+swift_gen_lib =  static_library(
+    'swift_generator',
+    [
+        'grpc/src/compiler/swift_generator.cc'
+    ],
+    include_directories: includes,
+    cpp_args : cpp_args
+)
+
+ts_gen_lib =  static_library(
+    'ts_generator',
+    [
+        'grpc/src/compiler/ts_generator.cc'
+    ],
+    include_directories: includes,
+    cpp_args : cpp_args
+)
+
+# flatc_library
+install_headers([
+    'include/flatbuffers/flatc.h'
+], subdir: 'flatbuffers')
+
+flatc_lib_sources = [
+    'src/flatc.cpp'
+]
+
+flatc_lib = static_library(
+    'flatc_library',
+    flatc_lib_sources,
+    include_directories: includes,
+    cpp_args: cpp_args,
+    install: true,
+    link_with: flatbuffers_lib
+)
+
+flatc_lib_dep = declare_dependency(
+    include_directories : includes,
+    link_with: flatc_lib,
+)
+
 flatc_sources = [
-    flatbuffers_lib_sources,
+    'src/flatc_main.cpp',
     'src/idl_gen_cpp.cpp',
+    'src/idl_gen_csharp.cpp',
     'src/idl_gen_dart.cpp',
-    'src/idl_gen_general.cpp',
     'src/idl_gen_go.cpp',
-    'src/idl_gen_js_ts.cpp',
-    'src/idl_gen_php.cpp',
-    'src/idl_gen_python.cpp',
+    'src/idl_gen_grpc.cpp',
+    'src/idl_gen_java.cpp',
+    'src/idl_gen_json_schema.cpp',
+    'src/idl_gen_kotlin.cpp',
     'src/idl_gen_lobster.cpp',
     'src/idl_gen_lua.cpp',
+    'src/idl_gen_php.cpp',
+    'src/idl_gen_python.cpp',
     'src/idl_gen_rust.cpp',
-    'src/idl_gen_fbs.cpp',
-    'src/idl_gen_grpc.cpp',
-    'src/idl_gen_json_schema.cpp',
-    'src/flatc.cpp',
-    'src/flatc_main.cpp',
-    'grpc/src/compiler/cpp_generator.cc',
-    'grpc/src/compiler/go_generator.cc',
-    'grpc/src/compiler/java_generator.cc'
+    'src/idl_gen_swift.cpp',
+    'src/idl_gen_text.cpp',
+    'src/idl_gen_ts.cpp',
+    'src/util.cpp',
 ]
 
 flatc = executable(
@@ -82,7 +175,16 @@ flatc = executable(
     flatc_sources,
     include_directories : includes,
     cpp_args : cpp_args,
-    install: true
+    install: true,
+    link_with: [
+        flatc_lib,
+        cpp_gen_lib,
+        go_gen_lib,
+        java_gen_lib,
+        python_gen_lib,
+        swift_gen_lib,
+        ts_gen_lib
+    ]
 )
 
 flathash_sources = [
@@ -94,9 +196,4 @@ flathash = executable(
     flathash_sources,
     include_directories : includes,
     cpp_args : cpp_args
-)
-
-flatbuffers_dep = declare_dependency(
-    include_directories : includes,
-    link_with: flatbuffers_lib
 )

--- a/subprojects/packagefiles/flatbuffers/meson.build
+++ b/subprojects/packagefiles/flatbuffers/meson.build
@@ -2,7 +2,11 @@ project(
     'flatbuffers',
     'cpp',
     version : '2.0.0',
-    license : 'Apache-2.0'
+    license : 'Apache-2.0',
+    default_options: [
+        'werror=true',
+        'warning_level=3'
+    ]
 )
 
 cpp = meson.get_compiler('cpp')
@@ -13,21 +17,11 @@ if host_machine.system() == 'windows'
     cpp_args += '-D_CRT_SECURE_NO_WARNINGS'
 endif
 
-if cpp.get_argument_syntax() == 'gcc'
-    cpp_args += [
-        '-Wall',
-        '-pedantic',
-        '-Werror',
-        '-Wextra'
-    ]
-endif
-
 # Certain platforms such as ARM do not use signed chars by default
 # which causes issues with certain bounds checks.
 if cpp.has_argument('-fsigned-char')
    cpp_args += '-fsigned-char'
 endif
-
 
 includes = include_directories(['include', 'grpc'])
 
@@ -197,3 +191,6 @@ flathash = executable(
     include_directories : includes,
     cpp_args : cpp_args
 )
+
+meson.override_find_program('flatc', flatc)
+meson.override_find_program('flathash', flathash)


### PR DESCRIPTION
Also added in the flatc and flathash executables.