### PR TITLE
ci: Run apt-get update to fix missing package

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -20,6 +20,7 @@ jobs:
 
       - name: Install packages
         run: |
+          sudo apt-get update
           sudo apt-get -y install build-essential python3-pip ninja-build nasm
           pip install git+https://github.com/mesonbuild/meson
 

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -13,6 +13,7 @@ jobs:
 
       - name: Install packages
         run: |
+          sudo apt-get update
           sudo apt-get -y install build-essential python3-pip ninja-build nasm
           pip install --pre meson
 

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -240,7 +240,7 @@ class TestReleases(unittest.TestCase):
         debian_packages = ci.get('debian_packages', [])
         if debian_packages and is_debianlike():
             if is_ci():
-                subprocess.check_call(['sudo', 'apt', 'install'] + debian_packages)
+                subprocess.check_call(['sudo', 'apt-get', '-y', 'install'] + debian_packages)
             else:
                 s = ', '.join(debian_packages)
                 print(f'The following packages could be required: {s}')


### PR DESCRIPTION
The apt cache seems sometimes outdated in docker image and installing
packages fails. Always update apt first.

Also use "apt-get" instead of "apt" in scripts to avoid warning about
unstable CI interface.