### PR TITLE
new wrap: libobsd

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -126,6 +126,10 @@
       "cpp_std=c++14"
     ]
   },
+  "libobsd": {
+    "_comment": ["Doesn't build with MSVC"],
+    "linux_only": true
+  },
   "liburing": {
     "_comment": ["- relies on Linux-specific APIs"],
     "build_on": {

--- a/releases.json
+++ b/releases.json
@@ -692,6 +692,15 @@
       "4.2.1-1"
     ]
   },
+  "libobsd": {
+    "dependency_names": [
+      "libbsd-overlay",
+      "libobsd"
+    ],
+    "versions": [
+      "1.0.0-1"
+    ]
+  },
   "libopenjp2": {
     "dependency_names": [
       "libopenjp2"

--- a/subprojects/libobsd.wrap
+++ b/subprojects/libobsd.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = libobsd-1.0.0
+source_url = https://github.com/guijan/libobsd/releases/download/v1.0.0/libobsd-1.0.0.tar.xz
+source_filename = libobsd-1.0.0.tar.xz
+source_hash = 332af327156d7768b6cc813d84847ad3dd0bfa760f88613ccc051c082cb6dbc8
+
+[provide]
+libbsd-overlay = libobsd_dep
+libobsd = libobsd_dep
+


### PR DESCRIPTION
Hi, I want to add my library to the wrapdb.

The library is like libbsd but focused on OpenBSD in specific; I wrote it primarily because I found libbsd's portability lacking and it seemed easier to rewrite it than to port the original. At the moment, it's behind libbsd on the list of functions it provides.

Beyond the automated testing in the [CI](https://github.com/guijan/libobsd/runs/5420433741), I've tested it with my [dictpw](https://github.com/guijan/dictpw) project and [scrot](https://github.com/resurrecting-open-source-projects/scrot).