### PR TITLE
add MacOS CI

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -41,3 +41,21 @@ jobs:
       - name: Sanity Checks
         run: |
           python tools/sanity_checks.py
+
+  MacOS:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Fetch tags and unshallow
+        run: git fetch --unshallow --tags
+
+      - name: Install packages
+        run: |
+          brew update
+          brew install ninja python
+          python3 -m pip install --pre meson
+
+      - name: Sanity Checks
+        run: |
+          ./tools/sanity_checks.py

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ meson compile -C builddir
     should not be added here because it's better to test that fallbacks works.
     When running `tools/sanity_checks.py` locally, this list will be printed
     but not installed.
+  - `brew_packages`: (Optional) List of extra packages that will be installed
+    on MacOS CI runners.
   - `linux_only`: (Optional) If set to `true`, indicates the wrap should be tested
     only on Linux CI.
   - `fatal_warnings`: (Optional) If set to `false` removes --fatal-meson-warning.

--- a/ci_config.json
+++ b/ci_config.json
@@ -1,10 +1,10 @@
 {
   "_comment": ["This is intentionally undocumented in README.md, do not use it.",
                "Using it is an automatic CI error.",
-               "skip_linux and skip_windows are lists of wraps that are known",
+               "broken_linux, broken_windows and broken_macos are lists of wraps that are known",
                "to be broken on the CI and ***MUST*** get repaired before updates",
-               "will be accepted. If upstream does not support Windows, set that",
-               "wrap to linux_only instead.",
+               "will be accepted. If upstream does not support an Operating System,",
+               "explicitly disable that Operating System in build_on.",
                "Please remove projects from those lists once they are updated."],
   "broken_linux": [
     "arduinocore-avr", "cpr", "glew", "hinnant-date", "imgui-sfml",
@@ -24,13 +24,17 @@
     "quazip", "rdkafka", "reflex", "sdl2_image", "sdl2_mixer",
     "sdl2_net", "sdl2_ttf", "termbox", "unit-system", "zstd"
   ],
+  "broken_darwin": [
+  ],
 
   "epoxy": {
     "debian_packages": [
       "libgl-dev",
       "libegl-dev"
     ],
-    "linux_only": true
+    "build_on": {
+      "windows": false
+    }
   },
   "glib": {
     "_comment": ["- Disable unit tests because upstream does not run them on Windows and some are flaky on Linux."],
@@ -40,7 +44,9 @@
   },
   "htslib": {
     "_comment": ["- relies on lots of POSIX interfaces"],
-    "linux_only": true,
+    "build_on": {
+      "windows": false
+    },
     "build_options": [
       "htslib:tests=true"
     ]
@@ -55,10 +61,14 @@
   },
   "libccp4c": {
     "_comment": ["- upstream does not support building with MSVC"],
-    "linux_only": true
+    "build_on": {
+      "windows": false
+    }
   },
   "libdrm": {
-    "linux_only": true,
+    "build_on": {
+      "windows": false
+    },
     "debian_packages": [
       "libpciaccess-dev"
     ]
@@ -69,10 +79,14 @@
       "libmicrohttpd-dev"
     ],
     "_comment": ["libmicrohttpd is not available with MSVC CI"],
-    "linux_only": true
+    "build_on": {
+      "windows": false
+    }
   },
   "liburing": {
-    "linux_only": true
+    "build_on": {
+      "windows": false
+    }
   },
   "libxmlpp": {
     "debian_packages": [
@@ -87,14 +101,18 @@
     ]
   },
   "openssl": {
-    "linux_only": true,
+    "build_on": {
+      "windows": false
+    },
     "build_options": [
       "openssl:build_cli=true"
     ]
   },
   "orcus": {
     "_comment": ["- depends on Boost, which is not available on WrapDB"],
-    "linux_only": true,
+    "build_on": {
+      "windows": false
+    },
     "debian_packages": [
       "libmdds-dev",
       "libboost-filesystem-dev",
@@ -136,7 +154,9 @@
     ]
   },
   "sds": {
-    "linux_only": true,
+    "build_on": {
+      "windows": false
+    },
     "build_options": [
       "sds:tests=true"
     ]
@@ -150,17 +170,23 @@
     ]
   },
   "slirp": {
-    "_comment": ["- Limited to linux_only pending the addition of other POSIX-ish environments to the test matrix."],
-    "linux_only": true
+    "_comment": ["- relies on lots of POSIX interfaces"],
+    "build_on": {
+      "windows": false
+    }
   },
   "wayland": {
-    "linux_only": true,
+    "build_on": {
+      "windows": false
+    },
     "build_options": [
       "wayland:documentation=false"
     ]
   },
   "wayland-protocols": {
-    "linux_only": true,
+    "build_on": {
+      "windows": false
+    },
     "debian_packages": [
       "libwayland-bin",
       "libwayland-dev"

--- a/ci_config.json
+++ b/ci_config.json
@@ -25,6 +25,16 @@
     "sdl2_net", "sdl2_ttf", "termbox", "unit-system", "zstd"
   ],
   "broken_darwin": [
+    "abseil-cpp", "arduinocore-avr", "box2d", "check", "cli11",
+    "cpr", "docopt", "emilk-loguru", "flac", "flatbuffers",
+    "fluidsynth", "fmt", "freetype2", "fuse", "glib",
+    "google-benchmark", "google-woff2", "hinnant-date", "icu",
+    "imgui", "imgui-sfml", "jsoncpp", "libebml", "libgpiod",
+    "libmatroska", "libtomcrypt", "libwebsockets", "libxmlpp",
+    "libxslt", "lmdb", "lz4", "mocklibc", "mpdecimal",
+    "openal-soft", "openh264", "protobuf", "protobuf-c",
+    "quazip", "rdkafka", "re2", "rtaudio", "sdl2_image", "sfml",
+    "tinyply", "tinyxml2", "unit-system", "zstd"
   ],
 
   "epoxy": {

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -23,10 +23,9 @@ import typing as T
 import os
 import tempfile
 import platform
-import sysconfig
 
 from pathlib import Path
-from utils import Version, is_ci, is_debianlike, is_linux, is_windows
+from utils import Version, is_ci, is_debianlike, is_linux, is_macos
 
 PERMITTED_FILES = ['generator.sh', 'meson.build', 'meson_options.txt', 'LICENSE.build']
 PER_PROJECT_PERMITTED_FILES = {
@@ -63,7 +62,7 @@ class TestReleases(unittest.TestCase):
             fn = 'ci_config.json'
             with open(fn, 'r') as f:
                 cls.ci_config = json.load(f)
-        except json.decoder.JSONDecodeError as err:
+        except json.decoder.JSONDecodeError:
             raise RuntimeError(f'file {fn} is malformed')
 
         system = platform.system().lower()
@@ -226,9 +225,14 @@ class TestReleases(unittest.TestCase):
                         f'Version {version} not found in {source_url}')
 
     def check_new_release(self, name: str, builddir: str = '_build'):
+        system = platform.system().lower()
         ci = self.ci_config.get(name, {})
+        # kept for backwards compatibility
         if ci.get('linux_only', False) and not is_linux():
             return
+        elif not ci.get('build_on', {}).get(system, True):
+            return
+
         options = ['-Dpython.install_env=auto', f'-Dwraps={name}']
         if ci.get('fatal_warnings', True) and self.fatal_warnings:
             options.append('--fatal-meson-warnings')
@@ -236,12 +240,20 @@ class TestReleases(unittest.TestCase):
         if Path(builddir, 'meson-private', 'cmd_line.txt').exists():
             options.append('--wipe')
         debian_packages = ci.get('debian_packages', [])
+        brew_packages = ci.get('brew_packages', [])
         if debian_packages and is_debianlike():
             if is_ci():
                 subprocess.check_call(['sudo', 'apt-get', '-y', 'install'] + debian_packages)
             else:
                 s = ', '.join(debian_packages)
                 print(f'The following packages could be required: {s}')
+        elif brew_packages and is_macos():
+            if is_ci():
+                subprocess.check_call(['brew', 'install'] + brew_packages)
+            else:
+                s = ', '.join(brew_packages)
+                print(f'The following packages could be required: {s}')
+
         try:
             subprocess.check_call(['meson', 'setup', builddir] + options)
         except subprocess.CalledProcessError:

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -98,3 +98,6 @@ def is_linux() -> bool:
 def is_windows() -> bool:
     platname = platform.system().lower()
     return platname == 'windows'
+
+def is_macos():
+    return any(platform.mac_ver()[0])


### PR DESCRIPTION
This will need some fleshing out before it can get merged, which is why I am keeping as a draft for now.

Since there are now more than 2 CI options, `linux_only` no longer represents a binary choice.
Instead of adding a `<os>_only` for every single one, I suggest an array under `build_on` containing any combination of `linux`, `windows` and `darwin`.

Because up until now no one tested on MacOS, some work needs to be done to populate the `broken_darwin` array.