### PR TITLE
Fix OpenSSL CI release due to missing dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install nasm for OpenSSL generator
-        run: sudo apt-get install --no-install-recommends nasm
       - name: Upload release assets
         run: |
           git fetch --unshallow --tags

--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -25,6 +25,7 @@ import subprocess
 import json
 
 from pathlib import Path
+from utils import is_ci, is_debianlike
 
 class CreateRelease:
     def __init__(self, repo: T.Optional[str], token: T.Optional[str], tag: str):
@@ -57,6 +58,21 @@ class CreateRelease:
 
         generator = Path(srcdir, 'generator.sh')
         if generator.exists():
+            try:
+                fn = 'ci_config.json'
+                with open(fn, 'r') as f:
+                    ci = json.load(f)
+            except json.decoder.JSONDecodeError:
+                raise RuntimeError(f'file {fn} is malformed')
+
+            debian_packages = ci.get(self.name, {}).get('debian_packages', [])
+            if debian_packages and is_debianlike():
+                if is_ci():
+                    subprocess.check_call(['sudo', 'apt-get', '-y', 'install'] + debian_packages)
+                else:
+                    s = ', '.join(debian_packages)
+                    print(f'The following packages could be required: {s}')
+
             subprocess.check_call([generator])
 
         # If no specific license is specified, copy wrapdb's


### PR DESCRIPTION
Fix for package missing in https://github.com/mesonbuild/wrapdb/pull/281 that led to error during release publish.

Would be nice for it to install packages from `debian_packages` automatically though.