### PR TITLE
libmatroska: fix compilation with MSVC and macOS

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -28,7 +28,7 @@
     "fluidsynth", "fmt", "freetype2", "fuse", "glib",
     "google-benchmark", "google-woff2", "graphite2", "hinnant-date", "icu",
     "imgui", "imgui-sfml", "jsoncpp", "libgpiod",
-    "libmatroska", "libtomcrypt", "libwebsockets", "libxmlpp",
+    "libtomcrypt", "libwebsockets", "libxmlpp",
     "libxslt", "lmdb", "lz4", "mocklibc", "mpdecimal",
     "openal-soft", "openh264", "protobuf", "protobuf-c",
     "quazip", "rdkafka", "re2", "rtaudio", "sdl2_image", "sfml",
@@ -84,6 +84,11 @@
     ]
   },
   "libebml" : {
+    "build_options": [
+      "cpp_std=c++14"
+    ]
+  },
+  "libmatroska" : {
     "build_options": [
       "cpp_std=c++14"
     ]

--- a/subprojects/packagefiles/libmatroska/meson.build
+++ b/subprojects/packagefiles/libmatroska/meson.build
@@ -1,6 +1,6 @@
 project('libmatroska', 'cpp',
   version : '1.6.3',
-  default_options : ['warning_level=3', 'cpp_std=c++14'])
+  default_options : ['warning_level=1', 'cpp_std=c++14'])
 
 cpp = meson.get_compiler('cpp')
 if cpp.get_id() == 'msvc'


### PR DESCRIPTION
MSVC does not support C++11. 14 is the minimum.

macOS defaults to compiling C++ as C++98. Work around this by changing
the CI config.

Signed-off-by: Rosen Penev <rosenp@gmail.com>