### PR TITLE
protobuf: fix compilation with MSVC and macOS

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -17,8 +17,8 @@
     "google-woff2", "hinnant-date", "imgui-sfml", "jbigkit", "libexif",
     "libgpiod", "liblbfgs", "liblzma", "libwebsockets", "libxmlpp",
     "lzo2", "mocklibc", "mpdecimal", "netstring-c", "nng", "openh264",
-    "protobuf", "protobuf-c", "quazip", "rdkafka", "reflex", "termbox",
-    "unit-system", "zstd"
+    "protobuf-c", "quazip", "rdkafka", "reflex", "termbox","unit-system",
+    "zstd"
   ],
   "broken_darwin": [
     "abseil-cpp", "arduinocore-avr", "box2d", "check", "cli11", "cpr",
@@ -26,7 +26,7 @@
     "google-benchmark", "google-woff2", "graphite2", "hinnant-date",
     "imgui", "imgui-sfml", "libgpiod", "libwebsockets", "libxmlpp",
     "lmdb", "lz4", "mocklibc", "mpdecimal", "openal-soft",
-    "openh264", "protobuf", "protobuf-c", "quazip", "rdkafka", "re2",
+    "openh264", "protobuf-c", "quazip", "rdkafka", "re2",
     "rtaudio", "sdl2_image", "sfml", "tinyply", "tinyxml2", "unit-system",
     "zstd"
   ],
@@ -179,6 +179,11 @@
     ],
     "build_options": [
       "cpp_std=c++17"
+    ]
+  },
+  "protobuf" : {
+    "build_options": [
+      "cpp_std=c++14"
     ]
   },
   "rdkafka": {

--- a/releases.json
+++ b/releases.json
@@ -1131,7 +1131,12 @@
     ]
   },
   "protobuf": {
+    "dependency_names": [
+      "protobuf-lite",
+      "protobuf"
+    ],
     "versions": [
+      "3.20.0-1",
       "3.12.2-2",
       "3.12.2-1",
       "3.5.1-3",

--- a/subprojects/packagefiles/protobuf/meson.build
+++ b/subprojects/packagefiles/protobuf/meson.build
@@ -1,6 +1,14 @@
-project('protobuf', 'cpp', version: '3.12.2', license: 'protobuf')
+project('protobuf', 'cpp', version: '3.20.0', license: 'protobuf')
 
 cc = meson.get_compiler('cpp')
+
+ttype = cc.get_id() == 'msvc' ? 'static_library' : 'library'
+
+if get_option('default_library') != 'static'
+  add_project_arguments('-DPROTOBUF_USE_DLLS', language : 'cpp')
+  add_project_arguments('-DLIBPROTOBUF_EXPORTS', language : 'cpp')
+  add_project_arguments('-DLIBPROTOC_EXPORTS', language : 'cpp')
+endif
 
 flags = cc.get_supported_arguments([
   '-DHAVE_PTHREAD',
@@ -17,20 +25,25 @@ deps = dependency('threads')
 libprotobuf_lite_src = [
   'src/google/protobuf/any_lite.cc',
   'src/google/protobuf/arena.cc',
+  'src/google/protobuf/arenastring.cc',
+  'src/google/protobuf/arenaz_sampler.cc',
   'src/google/protobuf/extension_set.cc',
   'src/google/protobuf/generated_enum_util.cc',
-  'src/google/protobuf/generated_message_table_driven_lite.cc',
+  'src/google/protobuf/generated_message_tctable_lite.cc',
   'src/google/protobuf/generated_message_util.cc',
   'src/google/protobuf/implicit_weak_message.cc',
+  'src/google/protobuf/inlined_string_field.cc',
   'src/google/protobuf/io/coded_stream.cc',
   'src/google/protobuf/io/io_win32.cc',
   'src/google/protobuf/io/strtod.cc',
   'src/google/protobuf/io/zero_copy_stream.cc',
   'src/google/protobuf/io/zero_copy_stream_impl.cc',
   'src/google/protobuf/io/zero_copy_stream_impl_lite.cc',
+  'src/google/protobuf/map.cc',
   'src/google/protobuf/message_lite.cc',
   'src/google/protobuf/parse_context.cc',
   'src/google/protobuf/repeated_field.cc',
+  'src/google/protobuf/repeated_ptr_field.cc',
   'src/google/protobuf/stubs/bytestream.cc',
   'src/google/protobuf/stubs/common.cc',
   'src/google/protobuf/stubs/int128.cc',
@@ -43,11 +56,12 @@ libprotobuf_lite_src = [
   'src/google/protobuf/stubs/time.cc',
   'src/google/protobuf/wire_format_lite.cc',
 ]
-libprotobuf_lite = library(
+libprotobuf_lite = build_target(
   'protobuf-lite',
   libprotobuf_lite_src,
   cpp_args: flags,
   dependencies: deps,
+  target_type: ttype,
   include_directories: include_directories('src'),
 )
 protobuf_lite_dep = declare_dependency(
@@ -70,8 +84,9 @@ libprotobuf_src = [
   'src/google/protobuf/empty.pb.cc',
   'src/google/protobuf/extension_set_heavy.cc',
   'src/google/protobuf/field_mask.pb.cc',
+  'src/google/protobuf/generated_message_bases.cc',
   'src/google/protobuf/generated_message_reflection.cc',
-  'src/google/protobuf/generated_message_table_driven.cc',
+  'src/google/protobuf/generated_message_tctable_full.cc',
   'src/google/protobuf/io/gzip_stream.cc',
   'src/google/protobuf/io/printer.cc',
   'src/google/protobuf/io/tokenizer.cc',
@@ -110,10 +125,11 @@ libprotobuf_src = [
   'src/google/protobuf/wire_format.cc',
   'src/google/protobuf/wrappers.pb.cc',
 ]
-libprotobuf = library(
+libprotobuf = build_target(
   'protobuf',
   libprotobuf_src,
   cpp_args: flags,
+  target_type: ttype,
   link_with: libprotobuf_lite,
   include_directories: include_directories('src')
 )
@@ -136,6 +152,7 @@ libprotoc_src = [
   'src/google/protobuf/compiler/cpp/cpp_message.cc',
   'src/google/protobuf/compiler/cpp/cpp_message_field.cc',
   'src/google/protobuf/compiler/cpp/cpp_padding_optimizer.cc',
+  'src/google/protobuf/compiler/cpp/cpp_parse_function_generator.cc',
   'src/google/protobuf/compiler/cpp/cpp_primitive_field.cc',
   'src/google/protobuf/compiler/cpp/cpp_service.cc',
   'src/google/protobuf/compiler/cpp/cpp_string_field.cc',
@@ -168,6 +185,7 @@ libprotoc_src = [
   'src/google/protobuf/compiler/java/java_generator.cc',
   'src/google/protobuf/compiler/java/java_generator_factory.cc',
   'src/google/protobuf/compiler/java/java_helpers.cc',
+  'src/google/protobuf/compiler/java/java_kotlin_generator.cc',
   'src/google/protobuf/compiler/java/java_map_field.cc',
   'src/google/protobuf/compiler/java/java_map_field_lite.cc',
   'src/google/protobuf/compiler/java/java_message.cc',
@@ -201,47 +219,19 @@ libprotoc_src = [
   'src/google/protobuf/compiler/plugin.cc',
   'src/google/protobuf/compiler/plugin.pb.cc',
   'src/google/protobuf/compiler/python/python_generator.cc',
+  'src/google/protobuf/compiler/python/python_helpers.cc',
+  'src/google/protobuf/compiler/python/python_pyi_generator.cc',
   'src/google/protobuf/compiler/ruby/ruby_generator.cc',
   'src/google/protobuf/compiler/subprocess.cc',
   'src/google/protobuf/compiler/zip_writer.cc',
 ]
-libprotoc = library(
+libprotoc = static_library(
   'protoc',
   libprotoc_src,
   cpp_args: flags,
+  gnu_symbol_visibility : 'hidden',
   link_with: [libprotobuf_lite, libprotobuf],
   include_directories: include_directories('src')
 )
-protoc_dep = declare_dependency(
-  link_with: [libprotobuf_lite, libprotobuf, libprotoc],
-  include_directories: include_directories('src')
-)
 
-
-protoc_src = [ 'src/google/protobuf/compiler/main.cc' ]
-protoc = executable(
-  'protoc',
-  protoc_src,
-  cpp_args: flags,
-  include_directories: include_directories('src'),
-  link_with: [libprotobuf_lite, libprotoc]
-)
-
-
-if meson.is_cross_build()
-  protoc_native = executable(
-    'protoc-native',
-    [libprotobuf_lite_src, libprotobuf_src, libprotoc_src, protoc_src],
-    native: true,
-    cpp_args: flags,
-    include_directories: include_directories('src'),
-    dependencies: dependency('threads', native: true),
-  )
-else
-  protoc_native = protoc
-endif
-
-protoc_gen = generator(protoc_native,
-  output: ['@BASENAME@.pb.cc', '@BASENAME@.pb.h'],
-  arguments: ['@EXTRA_ARGS@', '--proto_path=' + meson.current_source_dir()/'src', '--cpp_out=@BUILD_DIR@', '@INPUT@']
-)
+subdir('src')

--- a/subprojects/packagefiles/protobuf/src/meson.build
+++ b/subprojects/packagefiles/protobuf/src/meson.build
@@ -1,0 +1,27 @@
+protoc_src = [ 'google/protobuf/compiler/main.cc' ]
+protoc = executable(
+  'protoc',
+  protoc_src,
+  cpp_args: flags,
+  include_directories: include_directories('.'),
+  link_with: libprotoc
+)
+
+
+if meson.is_cross_build()
+  protoc_native = executable(
+    'protoc-native',
+    [libprotobuf_lite_src, libprotobuf_src, libprotoc_src, protoc_src],
+    native: true,
+    cpp_args: flags,
+    include_directories: include_directories('.'),
+    dependencies: dependency('threads', native: true),
+  )
+else
+  protoc_native = protoc
+endif
+
+protoc_gen = generator(protoc_native,
+  output: ['@BASENAME@.pb.cc', '@BASENAME@.pb.h'],
+  arguments: ['@EXTRA_ARGS@', '--proto_path=' + meson.current_source_dir(), '--cpp_out=@BUILD_DIR@', '@INPUT@']
+)

--- a/subprojects/protobuf.wrap
+++ b/subprojects/protobuf.wrap
@@ -1,6 +1,10 @@
 [wrap-file]
-directory = protobuf-3.12.2
-source_url = https://github.com/protocolbuffers/protobuf/releases/download/v3.12.2/protobuf-all-3.12.2.tar.gz
-source_filename = protobuf-all-3.12.2.tar.gz
-source_hash = e610c6633763bceec08a647d0605f5df0f9c960028ef32c0730e3df23164fb0d
+directory = protobuf-3.20.0
+source_url = https://github.com/protocolbuffers/protobuf/releases/download/v3.20.0/protobuf-all-3.20.0.tar.gz
+source_filename = protobuf-all-3.20.0.tar.gz
+source_hash = a1c076e83f45b64b9e30ae89a990ba4aae9f7dc18aca90f7690f458dc5ae0681
 patch_directory = protobuf
+
+[provide]
+protobuf = protobuf_dep
+protobuf-lite = protobuf_lite_dep


### PR DESCRIPTION
MSVC does not support C++11. 14 is the minimum.

macOS defaults to compiling C++ as C++98. Work around this by changing
the CI config.

Signed-off-by: Rosen Penev <rosenp@gmail.com>