### PR TITLE
Add cairo subproject as used in harfbuzz

### DIFF
--- a/subprojects/cairo.wrap
+++ b/subprojects/cairo.wrap
@@ -1,0 +1,7 @@
+directory=cairo
+url=https://gitlab.freedesktop.org/cairo/cairo.git
+depth=1
+revision=1.17.6
+
+[provide]
+dependency_names = cairo, cairo-ft


### PR DESCRIPTION
As per https://github.com/harfbuzz/harfbuzz/blob/main/subprojects/cairo.wrap
and also
https://github.com/harfbuzz/harfbuzz/pull/3501/files