### PR TITLE
onqtam-doctest: Update to 2.4.8

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -172,6 +172,14 @@
       "0.6.3-1"
     ]
   },
+  "doctest": {
+    "dependency_names": [
+      "doctest"
+    ],
+    "versions": [
+      "2.4.8-1"
+    ]
+  },
   "dragonbox": {
     "dependency_names": [
       "dragonbox"

--- a/subprojects/doctest.wrap
+++ b/subprojects/doctest.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = doctest-2.4.8
+source_url = https://github.com/doctest/doctest/archive/refs/tags/v2.4.8.tar.gz
+source_filename = doctest-2.4.8.tar.gz
+source_hash = f52763630aa17bd9772b54e14b6cdd632c87adf0169455a86a49bd94abf2cd83
+
+[provide]
+dependency_names = doctest


### PR DESCRIPTION
Update doctest to latest stable version, 2.4.8. In the meantime the project has moved from github.com/onqtam/doctest to its own org - github.com/doctest/doctest. So not sure if the wrap file should be renamed (doctest-doctest.wrap?). I don't know if there is any policy around renaming wraps.