### PR TITLE
tree-sitter: xml parser

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1563,6 +1563,14 @@
       "2.5.0-1"
     ]
   },
+  "tree-sitter-xml-parser": {
+    "dependency_names": [
+      "tree-sitter-xml-parser"
+    ],
+    "versions": [
+      "master"
+    ]
+  },
   "tracy": {
     "dependency_names": [
       "tracy"

--- a/subprojects/packagefiles/tree-sitter-xml-parser/meson.build
+++ b/subprojects/packagefiles/tree-sitter-xml-parser/meson.build
@@ -1,0 +1,11 @@
+project('tree-sitter-xml-parser', 'c')
+
+tree_sitter_xml_parser = static_library('tree-sitter-xml-parser', [
+    'src/parser.c',
+  ],
+  dependencies: tree_sitter_dep,
+)
+
+tree_sitter_xml_dep = declare_dependency(
+  link_with: tree_sitter_xml_parser,
+)

--- a/subprojects/tree-sitter-xml-parser.wrap
+++ b/subprojects/tree-sitter-xml-parser.wrap
@@ -1,0 +1,10 @@
+[wrap-git]
+directory = tree-sitter-xml-parser-master
+source_url = https://github.com/unhammer/tree-sitter
+source_filename = master
+source_hash = 98e91c7c6bf162bf90e4e70fdbc41a8188b9fa8de5ad840c401198014406ce9e
+patch_directory = tree-sitter-xml-parser
+
+[provide]
+libtree-sitter-xml-parser = libtree-sitter-xml-parser_dep
+


### PR DESCRIPTION
Provides an AST tree parser for xml contents.

Depends on #411 

Running example on https://gitlab.gnome.org/albfan/gtk-code-folding-vala