### PR TITLE
libuv: Require C99 for C++ style comments

### DIFF
--- a/subprojects/packagefiles/libuv/meson.build
+++ b/subprojects/packagefiles/libuv/meson.build
@@ -1,7 +1,7 @@
 project('libuv', 'c',
   version : '1.43.0',
   license : 'libuv',
-  default_options : [ 'c_std=c89' ],
+  default_options : [ 'c_std=c99' ],
 )
 
 # get compiler type


### PR DESCRIPTION
The c_std=c89 option on subproject was previously ignored by Meson, but
with master (used by build-all CI) this started to fail.