### PR TITLE
glib: Rename gio-win32-2.0 to gio-windows-2.0

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -429,7 +429,7 @@
       "gmodule-2.0",
       "glib-2.0",
       "gio-2.0",
-      "gio-win32-2.0",
+      "gio-windows-2.0",
       "gio-unix-2.0"
     ],
     "program_names": [
@@ -441,6 +441,7 @@
       "gdbus-codegen"
     ],
     "versions": [
+      "2.72.2-1",
       "2.72.1-1",
       "2.70.4-1",
       "2.70.2-1",

--- a/subprojects/glib.wrap
+++ b/subprojects/glib.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = glib-2.72.1
+directory = glib-2.72.2
 
-source_url = https://download.gnome.org/sources/glib/2.72/glib-2.72.1.tar.xz
-source_filename = glib-2.72.1.tar.xz
-source_hash = c07e57147b254cef92ce80a0378dc0c02a4358e7de4702e9f403069781095fe2
+source_url = https://download.gnome.org/sources/glib/2.72/glib-2.72.2.tar.xz
+source_filename = glib-2.72.2.tar.xz
+source_hash = 78d599a133dba7fe2036dfa8db8fb6131ab9642783fc9578b07a20995252d2de
 
 [provide]
-dependency_names = gthread-2.0, gobject-2.0, gmodule-no-export-2.0, gmodule-export-2.0, gmodule-2.0, glib-2.0, gio-2.0, gio-win32-2.0, gio-unix-2.0
+dependency_names = gthread-2.0, gobject-2.0, gmodule-no-export-2.0, gmodule-export-2.0, gmodule-2.0, glib-2.0, gio-2.0, gio-windows-2.0, gio-unix-2.0
 program_names = glib-genmarshal, glib-mkenums, glib-compile-schemas, glib-compile-resources, gio-querymodules, gdbus-codegen


### PR DESCRIPTION
This is to match the pkg-config dependency name. Unfortunately the
override_dependency() was wrong in glib too, will be fixed in the next
stable release. See
https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2616.