### PR TITLE
ftxui: remove pointless minimum version

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -366,6 +366,7 @@
       "ftxui-component"
     ],
     "versions": [
+      "2.0.0-2",
       "2.0.0-1"
     ]
   },

--- a/subprojects/packagefiles/ftxui/meson.build
+++ b/subprojects/packagefiles/ftxui/meson.build
@@ -1,6 +1,5 @@
 project('ftxui', 'cpp',
     version: '2.0.0',
-    meson_version: '>= 0.62.0',
     default_options: ['cpp_std=c++17'],
 )
 


### PR DESCRIPTION
There are no needed features used.

Signed-off-by: Rosen Penev <rosenp@gmail.com>