### PR TITLE
libwebsockets: update to 4.0.21

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -14,7 +14,7 @@
   "broken_windows": [
     "arduinocore-avr",
     "google-woff2", "jbigkit",
-    "libgpiod", "liblbfgs", "libwebsockets",
+    "libgpiod", "liblbfgs",
     "mocklibc", "netstring-c", "openh264",
     "protobuf-c", "termbox","unit-system",
     "zstd"
@@ -22,7 +22,7 @@
   "broken_darwin": [
     "arduinocore-avr",
     "google-benchmark", "google-woff2", "graphite2",
-    "libgpiod", "libwebsockets",
+    "libgpiod",
     "lz4", "mocklibc", "openal-soft",
     "openh264", "protobuf-c",
     "rtaudio", "sdl2_image", "tinyxml2", "unit-system",

--- a/releases.json
+++ b/releases.json
@@ -938,7 +938,11 @@
     ]
   },
   "libwebsockets": {
+    "dependency_names": [
+      "libwebsockets"
+    ],
     "versions": [
+      "4.0.21-1",
       "4.0.13-1"
     ]
   },

--- a/subprojects/libwebsockets.wrap
+++ b/subprojects/libwebsockets.wrap
@@ -1,6 +1,9 @@
 [wrap-file]
-directory = libwebsockets-v4.0.13
-source_url = https://libwebsockets.org/git/libwebsockets/snapshot/libwebsockets-v4.0.13.tar.xz
-source_filename = libwebsockets-v4.0.13.tar.xz
-source_hash = 82a30cb62ab9735d926990a75f166078101028af1923a30232032b39976f8879
+directory = libwebsockets-v4.0.21
+source_url = https://libwebsockets.org/git/libwebsockets/snapshot/libwebsockets-v4.0.21.tar.xz
+source_filename = libwebsockets-v4.0.21.tar.xz
+source_hash = 57ef0c4c951b056532d88ad618badd5c3615b7c71418dd26800dc886032a32b4
 patch_directory = libwebsockets
+
+[provide]
+libwebsockets = libwebsockets_dep

--- a/subprojects/packagefiles/libwebsockets/meson.build
+++ b/subprojects/packagefiles/libwebsockets/meson.build
@@ -1,13 +1,13 @@
 project('libwebsockets', 'c', version: '4.0.13', license: 'MIT')
 
 lws_library_version = meson.project_version()
-lws_library_version_major  = '4'
-lws_library_version_minor  = '0'
-lws_library_version_patch  = '13'
+lws_library_version_major = '4'
+lws_library_version_minor = '0'
+lws_library_version_patch = '13'
 lws_library_version_number = 16
 
-lws_incdirs = [ ]
-lws_dependencies = [ ]
+lws_incdirs = []
+lws_dependencies = []
 lws_c_args = []
 
 
@@ -17,7 +17,7 @@ ios = false
 apple = false
 mingw = false
 win32 = build_machine.system() == 'win32'
-unix  = build_machine.system() == 'linux'
+unix = build_machine.system() == 'linux'
 
 # Initialize
 lws_max_smp = ''
@@ -52,7 +52,7 @@ lws_role_ws = get_option('LWS_ROLE_WS')
 lws_role_mqtt = get_option('LWS_ROLE_MQTT')
 lws_role_dbus = get_option('LWS_ROLE_DBUS')
 lws_role_raw_proxy = get_option('LWS_ROLE_RAW_PROXY')
- 
+
 lws_role_raw_file = get_option('LWS_ROLE_RAW_FILE')
 lws_with_http2 = get_option('LWS_WITH_HTTP2')
 lws_with_lwsws = get_option('LWS_WITH_LWSWS')
@@ -79,7 +79,7 @@ lws_with_fts = get_option('LWS_WITH_FTS')
 lws_with_sys_async_dns = get_option('LWS_WITH_SYS_ASYNC_DNS')
 lws_with_sys_ntpclient = get_option('LWS_WITH_SYS_NTPCLIENT')
 lws_with_sys_dhcp_client = get_option('LWS_WITH_SYS_DHCP_CLIENT')
- 
+
 lws_with_http_basic_auth = get_option('LWS_WITH_HTTP_BASIC_AUTH')
 lws_with_http_uncommon_headers = get_option('LWS_WITH_HTTP_UNCOMMON_HEADERS')
 
@@ -87,7 +87,7 @@ lws_with_http_uncommon_headers = get_option('LWS_WITH_HTTP_UNCOMMON_HEADERS')
 lws_with_secure_streams = get_option('LWS_WITH_SECURE_STREAMS')
 lws_with_secure_streams_proxy_api = get_option('LWS_WITH_SECURE_STREAMS_PROXY_API')
 lws_with_secure_streams_sys_auth_api_amazon_com = get_option('LWS_WITH_SECURE_STREAMS_SYS_AUTH_API_AMAZON_COM')
- 
+
 # TLS library
 lws_with_ssl = get_option('LWS_WITH_SSL')
 lws_with_mbedtls = get_option('LWS_WITH_MBEDTLS')
@@ -95,7 +95,7 @@ lws_with_boringssl = get_option('LWS_WITH_BORINGSSL')
 lws_with_cyassl = get_option('LWS_WITH_CYASSL')
 lws_with_wolfssl = get_option('LWS_WITH_WOLFSSL')
 lws_ssl_client_use_os_ca_certs = get_option('LWS_SSL_CLIENT_USE_OS_CA_CERTS')
- 
+
 # Event library options
 lws_with_libev = get_option('LWS_WITH_LIBEV')
 lws_with_libuv = get_option('LWS_WITH_LIBUV')
@@ -114,7 +114,7 @@ lws_with_esp32_helper = get_option('LWS_WITH_ESP32_HELPER')
 lws_plat_optee = get_option('LWS_PLAT_OPTEE')
 lws_plat_freertos = get_option('LWS_PLAT_FREERTOS')
 lws_plat_android = get_option('LWS_PLAT_ANDROID')
- 
+
 # Client / Server / Test Apps build control
 lws_without_client = get_option('LWS_WITHOUT_CLIENT')
 lws_without_server = get_option('LWS_WITHOUT_SERVER')
@@ -123,7 +123,7 @@ lws_without_test_server = get_option('LWS_WITHOUT_TEST_SERVER')
 lws_without_test_server_extpoll = get_option('LWS_WITHOUT_TEST_SERVER_EXTPOLL')
 lws_without_test_ping = get_option('LWS_WITHOUT_TEST_PING')
 lws_without_test_client = get_option('LWS_WITHOUT_TEST_CLIENT')
- 
+
 # Extensions
 lws_without_extensions = get_option('LWS_WITHOUT_EXTENSIONS')
 
@@ -320,10 +320,7 @@ if win32
     win32_version_data.set('LWS_LIBRARY_VERSION_MINOR', lws_library_version_minor)
     win32_version_data.set('LWS_LIBRARY_VERSION_PATCH', lws_library_version_patch)
     win32_version_data.set('LWS_LIBRARY_PACKAGE', 'libwebsockets')
-    configure_file(input: 'win32port/version.rc.in',
-        output: 'win32port/version.rc',
-        configuration: conf_data,
-        format: 'cmake')
+    configure_file(input: 'win32port/version.rc.in', output: 'win32port/version.rc', configuration: conf_data, format: 'cmake')
 endif
 
 # translate old functionality enables to set up ROLE enables so nothing changes
@@ -344,7 +341,7 @@ if not lws_role_ws
 endif
 
 if lws_with_mbedtls
-    lws_incdirs += [ 'lib/tls/mbedtls/wrapper/include' ]
+    lws_incdirs += ['lib/tls/mbedtls/wrapper/include']
 endif
 
 lws_incdirs += [
@@ -374,7 +371,8 @@ lws_incdirs += [
     'lib/roles/raw-proxy',
     'lib/abstract',
     'lib/system/async-dns',
-    'lib/roles/mqtt']
+    'lib/roles/mqtt',
+]
 
 if lws_with_secure_streams
     lws_with_secure_streams_sys_auth_api_amazon_com = true
@@ -656,15 +654,19 @@ lws_sha1_use_openssl_name = lws_without_builtin_sha1
 
 c_compiler = meson.get_compiler('c')
 
-lws_have_malloc_trim = c_compiler.compiles('''
+lws_have_malloc_trim = c_compiler.compiles(
+    '''
     #include <malloc.h>
-	int main(int argc, char **argv) { return malloc_trim(0); }
-	''')
+    int main(int argc, char **argv) { return malloc_trim(0); }
+    ''',
+)
 
-lws_have_malloc_usable_size = c_compiler.compiles('''
-	#include <malloc.h>
-	int main(int argc, char **argv) { return (int)malloc_usable_size((void *)0); }
-	''')
+lws_have_malloc_usable_size = c_compiler.compiles(
+    '''
+    #include <malloc.h>
+    int main(int argc, char **argv) { return (int)malloc_usable_size((void *)0); }
+    ''',
+)
 
 
 lws_have_fork = c_compiler.has_function('fork')
@@ -688,10 +690,10 @@ lws_have_clock_gettime = c_compiler.has_function('clock_gettime')
 lws_have_eventfd = c_compiler.has_function('eventfd')
 
 if not lws_have_getifaddrs
-	if lws_without_builtin_getifaddrs
-		error('No getifaddrs was found on the system. Turn off the LWS_WITHOUT_BUILTIN_GETIFADDRS compile option to use the supplied BSD version.')
-	endif
-	lws_builtin_getifaddrs = true
+    if lws_without_builtin_getifaddrs
+        error('No getifaddrs was found on the system. Turn off the LWS_WITHOUT_BUILTIN_GETIFADDRS compile option to use the supplied BSD version.')
+    endif
+    lws_builtin_getifaddrs = true
 endif
 
 lws_have_dlfcn_h = c_compiler.has_header('dlfcn.h')
@@ -733,15 +735,21 @@ endif
 lws_have_evbackend_linuxaio = false
 lws_have_evbackend_iouring = false
 if lws_with_libev
-	lws_have_evbackend_linuxaio = c_compiler.compiles('''
+    lws_have_evbackend_linuxaio = c_compiler.compiles(
+        '''
         #include <ev.h>
         int main(int argc, char **argv) { return EVBACKEND_LINUXAIO; }
-        ''', dependencies: [libev_dep])
+        ''',
+        dependencies: [libev_dep],
+    )
 
-	lws_have_evbackend_iouring = c_compiler.compiles('''(
+    lws_have_evbackend_iouring = c_compiler.compiles(
+        '''(
         #include <ev.h>
-	    int main(int argc, char **argv) { return EVBACKEND_IOURING; }
-        ''', dependencies: [libev_dep])
+        int main(int argc, char **argv) { return EVBACKEND_IOURING; }
+        ''',
+        dependencies: [libev_dep],
+    )
 endif
 
 if lws_with_zlib and not lws_with_bundled_zlib
@@ -756,32 +764,38 @@ endif
 lws_have_working_fork = lws_have_fork
 lws_have_working_vfork = lws_have_vfork
 
-lws_has_intptr_t = c_compiler.compiles('''
+lws_has_intptr_t = c_compiler.compiles(
+    '''
     #include <stdint.h>
     int main(void) {
         intptr_t test = 1;
         return 0;
-    }''')
+    }''',
+)
 
 lws_has_pthread_setname_np = false
 if lws_have_pthread_h
-    lws_has_pthread_setname_np = c_compiler.compiles('''
+    lws_has_pthread_setname_np = c_compiler.compiles(
+        '''
         #define _GNU_SOURCE
-		#include <pthread.h>
-		int main(void) {
-			pthread_t th = 0;
-			pthread_setname_np(th, NULL);
-			return 0;
-        }''')
+        #include <pthread.h>
+        int main(void) {
+            pthread_t th = 0;
+            pthread_setname_np(th, NULL);
+            return 0;
+        }''',
+    )
 endif
 
-lws_has_getopt_long = c_compiler.compiles('''
+lws_has_getopt_long = c_compiler.compiles(
+    '''
     #include <stddef.h>
-	#include <getopt.h>
-	int main(void) {
-		void *p = (void *)getopt_long;
-		return p != NULL;
-	}''')
+    #include <getopt.h>
+    int main(void) {
+        void *p = (void *)getopt_long;
+        return p != NULL;
+    }''',
+)
 
 varia = ''
 
@@ -808,36 +822,42 @@ lws_have_rsa_verify_pss_mgf1 = c_compiler.has_function(varia + 'RSA_verify_pss_m
 lws_have_hmac_ctx_new = c_compiler.has_function(varia + 'HMAC_CTX_new', dependencies: [openssl_dep])
 lws_have_ssl_ctx_set_ciphersuites = c_compiler.has_function(varia + 'SSL_CTX_set_ciphersuites', dependencies: [openssl_dep])
 if (lws_with_ssl and not lws_with_mbedtls)
-    lws_have_ssl_extra_chain_certs = c_compiler.compiles('#include <openssl/ssl.h>\nint main(void) { STACK_OF(X509) *c = NULL; SSL_CTX *ctx = NULL; return (int)SSL_CTX_get_extra_chain_certs_only(ctx, &c); }\n', dependencies: [openssl_dep])
-    lws_have_evp_md_ctx_free = c_compiler.compiles('#include <openssl/ssl.h>\nint main(void) { EVP_MD_CTX *md_ctx = NULL; EVP_MD_CTX_free(md_ctx); return 0; }\n', dependencies: [openssl_dep])
+    lws_have_ssl_extra_chain_certs = c_compiler.compiles(
+        '#include <openssl/ssl.h>\nint main(void) { STACK_OF(X509) *c = NULL; SSL_CTX *ctx = NULL; return (int)SSL_CTX_get_extra_chain_certs_only(ctx, &c); }\n',
+        dependencies: [openssl_dep],
+    )
+    lws_have_evp_md_ctx_free = c_compiler.compiles(
+        '#include <openssl/ssl.h>\nint main(void) { EVP_MD_CTX *md_ctx = NULL; EVP_MD_CTX_free(md_ctx); return 0; }\n',
+        dependencies: [openssl_dep],
+    )
     lws_have_ecdsa_sig_set0 = c_compiler.has_function(varia + 'ECDSA_SIG_set0', dependencies: [openssl_dep])
     lws_have_bn_bn2binpad = c_compiler.has_function(varia + 'BN_bn2binpad', dependencies: [openssl_dep])
     lws_have_evp_aes_128_wrap = c_compiler.has_function(varia + 'EVP_aes_128_wrap', dependencies: [openssl_dep])
     lws_have_ec_point_get_affine_coordinates = c_compiler.has_function(varia + 'EC_POINT_get_affine_coordinates', dependencies: [openssl_dep])
 endif
 if lws_with_mbedtls
-	lws_have_tls_client_method = true
-	if not lws_plat_freertos
-		# not supported in esp-idf openssl wrapper yet, but is in our version
-		lws_have_x509_verify_param_set1_host = true
-	endif
+    lws_have_tls_client_method = true
+    if not lws_plat_freertos
+        # not supported in esp-idf openssl wrapper yet, but is in our version
+        lws_have_x509_verify_param_set1_host = true
+    endif
 
-	lws_have_mbedtls_ssl_conf_alpn_protocols = c_compiler.has_function('mbedtls_ssl_conf_alpn_protocols')
-	lws_have_mbedtls_ssl_get_alpn_protocol = c_compiler.has_function('mbedtls_ssl_get_alpn_protocol')
-	lws_have_mbedtls_ssl_conf_sni = c_compiler.has_function('mbedtls_ssl_conf_sni')
-	lws_have_mbedtls_ssl_set_hs_ca_chain = c_compiler.has_function('mbedtls_ssl_set_hs_ca_chain')
-	lws_have_mbedtls_ssl_set_hs_own_cert = c_compiler.has_function('mbedtls_ssl_set_hs_own_cert')
-	lws_have_mbedtls_ssl_set_hs_authmode = c_compiler.has_function('mbedtls_ssl_set_hs_authmode')
-	lws_have_mbedtls_net_init = c_compiler.has_function('mbedtls_net_init')
+    lws_have_mbedtls_ssl_conf_alpn_protocols = c_compiler.has_function('mbedtls_ssl_conf_alpn_protocols')
+    lws_have_mbedtls_ssl_get_alpn_protocol = c_compiler.has_function('mbedtls_ssl_get_alpn_protocol')
+    lws_have_mbedtls_ssl_conf_sni = c_compiler.has_function('mbedtls_ssl_conf_sni')
+    lws_have_mbedtls_ssl_set_hs_ca_chain = c_compiler.has_function('mbedtls_ssl_set_hs_ca_chain')
+    lws_have_mbedtls_ssl_set_hs_own_cert = c_compiler.has_function('mbedtls_ssl_set_hs_own_cert')
+    lws_have_mbedtls_ssl_set_hs_authmode = c_compiler.has_function('mbedtls_ssl_set_hs_authmode')
+    lws_have_mbedtls_net_init = c_compiler.has_function('mbedtls_net_init')
     lws_have_tlsv1_2_client_method = false
 else
-	lws_have_mbedtls_ssl_conf_alpn_protocols = false
-	lws_have_mbedtls_ssl_get_alpn_protocol = false
-	lws_have_mbedtls_ssl_conf_sni = false
-	lws_have_mbedtls_ssl_set_hs_ca_chain = false
-	lws_have_mbedtls_ssl_set_hs_own_cert = false
-	lws_have_mbedtls_ssl_set_hs_authmode = false
-	lws_have_mbedtls_net_init = false
+    lws_have_mbedtls_ssl_conf_alpn_protocols = false
+    lws_have_mbedtls_ssl_get_alpn_protocol = false
+    lws_have_mbedtls_ssl_conf_sni = false
+    lws_have_mbedtls_ssl_set_hs_ca_chain = false
+    lws_have_mbedtls_ssl_set_hs_own_cert = false
+    lws_have_mbedtls_ssl_set_hs_authmode = false
+    lws_have_mbedtls_net_init = false
 
     lws_have_tls_client_method = c_compiler.has_function(varia + 'TLS_client_method')
     lws_have_tlsv1_2_client_method = c_compiler.has_function(varia + 'TLSv1_2_client_method')
@@ -860,15 +880,17 @@ lws_have_tcp_user_timeout = c_compiler.compiles('#include <netinet/tcp.h>\nint m
 
 lws_includes = include_directories(lws_incdirs)
 
-lws_sources = ['lib/core/alloc.c',
-	'lib/core/buflist.c',
-	'lib/core/context.c',
-	'lib/core/lws_dll2.c',
-	'lib/core/libwebsockets.c',
-	'lib/core/logs.c',
-	'lib/system/system.c',
-	'lib/misc/base64-decode.c',
-	'lib/misc/lws-ring.c']
+lws_sources = [
+    'lib/core/alloc.c',
+    'lib/core/buflist.c',
+    'lib/core/context.c',
+    'lib/core/lws_dll2.c',
+    'lib/core/libwebsockets.c',
+    'lib/core/logs.c',
+    'lib/system/system.c',
+    'lib/misc/base64-decode.c',
+    'lib/misc/lws-ring.c',
+]
 
 if lws_with_spawn
     lws_sources += ['lib/misc/spawn.c']
@@ -888,25 +910,24 @@ endif
 
 if lws_with_network
     lws_sources += [
-		'lib/core-net/dummy-callback.c',
-		'lib/core-net/output.c',
-		'lib/core-net/close.c',
-		'lib/core-net/network.c',
-		'lib/core-net/vhost.c',
-		'lib/core-net/pollfd.c',
-		'lib/core-net/service.c',
-		'lib/core-net/sorted-usec-list.c',
-		'lib/core-net/state.c',
-		'lib/core-net/stats.c',
-		'lib/core-net/wsi.c',
-		'lib/core-net/wsi-timeout.c',
-		'lib/core-net/adopt.c',
-		'lib/roles/pipe/ops-pipe.c']
+        'lib/core-net/dummy-callback.c',
+        'lib/core-net/output.c',
+        'lib/core-net/close.c',
+        'lib/core-net/network.c',
+        'lib/core-net/vhost.c',
+        'lib/core-net/pollfd.c',
+        'lib/core-net/service.c',
+        'lib/core-net/sorted-usec-list.c',
+        'lib/core-net/state.c',
+        'lib/core-net/stats.c',
+        'lib/core-net/wsi.c',
+        'lib/core-net/wsi-timeout.c',
+        'lib/core-net/adopt.c',
+        'lib/roles/pipe/ops-pipe.c',
+    ]
 
     if lws_with_sys_async_dns
-        lws_sources += [
-            'lib/system/async-dns/async-dns.c',
-            'lib/system/async-dns/async-dns-parse.c']
+        lws_sources += ['lib/system/async-dns/async-dns.c', 'lib/system/async-dns/async-dns-parse.c']
     endif
 
     if lws_with_sys_ntpclient
@@ -938,11 +959,7 @@ if lws_with_network
     endif
 
     if lws_with_secure_streams
-        lws_sources += [
-            'lib/secure-streams/secure-streams.c',
-            'lib/secure-streams/policy.c',
-            'lib/secure-streams/system/fetch-policy/fetch-policy.c'
-        ]
+        lws_sources += ['lib/secure-streams/secure-streams.c', 'lib/secure-streams/policy.c', 'lib/secure-streams/system/fetch-policy/fetch-policy.c']
 
         if lws_role_h1
             lws_sources += ['lib/secure-streams/protocols/ss-h1.c']
@@ -961,9 +978,7 @@ if lws_with_network
         endif
 
         if lws_with_secure_streams_proxy_api
-            lws_sources += [
-                'lib/secure-streams/secure-streams-serialize.c',
-                'lib/secure-streams/secure-streams-client.c']
+            lws_sources += ['lib/secure-streams/secure-streams-serialize.c', 'lib/secure-streams/secure-streams-client.c']
         endif
 
         if lws_with_secure_streams_proxy_api
@@ -990,7 +1005,8 @@ if lws_role_mqtt and lws_with_client
         'lib/roles/mqtt/ops-mqtt.c',
         'lib/roles/mqtt/primitives.c',
         'lib/roles/mqtt/client/client-mqtt.c',
-        'lib/roles/mqtt/client/client-mqtt-handshake.c']
+        'lib/roles/mqtt/client/client-mqtt-handshake.c',
+    ]
 endif
 
 if lws_with_threadpool and unix and lws_have_pthread_h
@@ -998,14 +1014,10 @@ if lws_with_threadpool and unix and lws_have_pthread_h
 endif
 
 if lws_role_h1 or lws_role_h2
-    lws_sources += [
-        'lib/roles/http/header.c',
-        'lib/roles/http/parsers.c']
+    lws_sources += ['lib/roles/http/header.c', 'lib/roles/http/parsers.c']
 
     if lws_with_http_stream_compression
-        lws_sources += [
-            'lib/roles/http/compression/stream.c',
-            'lib/roles/http/compression/deflate/deflate.c']
+        lws_sources += ['lib/roles/http/compression/stream.c', 'lib/roles/http/compression/deflate/deflate.c']
         if lws_with_http_brotli
             lws_sources += ['lib/roles/http/compression/brotli/brotli.c']
         endif
@@ -1019,9 +1031,7 @@ endif
 if lws_role_ws
     lws_sources += ['lib/roles/ws/ops-ws.c']
     if not lws_without_client
-        lws_sources += [
-            'lib/roles/ws/client-ws.c',
-            'lib/roles/ws/client-parser-ws.c']
+        lws_sources += ['lib/roles/ws/client-ws.c', 'lib/roles/ws/client-parser-ws.c']
     endif
     if not lws_without_server
         lws_sources += ['lib/roles/ws/server-ws.c']
@@ -1043,9 +1053,7 @@ if lws_role_raw_proxy
 endif
 
 if lws_role_cgi
-    lws_sources += [
-        'lib/roles/cgi/cgi-server.c',
-        'lib/roles/cgi/ops-cgi.c']
+    lws_sources += ['lib/roles/cgi/cgi-server.c', 'lib/roles/cgi/ops-cgi.c']
 endif
 
 if lws_role_dbus
@@ -1061,15 +1069,11 @@ if lws_with_peer_limits
 endif
 
 if lws_with_lwsac
-    lws_sources += [
-        'lib/misc/lwsac/lwsac.c',
-        'lib/misc/lwsac/cached-file.c']
+    lws_sources += ['lib/misc/lwsac/lwsac.c', 'lib/misc/lwsac/cached-file.c']
 endif
 
 if lws_with_fts
-    lws_sources += [
-        'lib/misc/fts/trie.c',
-		'lib/misc/fts/trie-fd.c']
+    lws_sources += ['lib/misc/fts/trie.c', 'lib/misc/fts/trie-fd.c']
 endif
 
 if lws_with_diskcache
@@ -1085,11 +1089,7 @@ if lws_with_struct_sqlite3
 endif
 
 if not lws_without_client
-    lws_sources += [
-        'lib/core-net/connect.c',
-		'lib/core-net/client.c',
-		'lib/roles/http/client/client-http.c',
-		'lib/roles/http/client/client-handshake.c']
+    lws_sources += ['lib/core-net/connect.c', 'lib/core-net/client.c', 'lib/roles/http/client/client-http.c', 'lib/roles/http/client/client-handshake.c']
 endif
 
 if not lws_without_server
@@ -1105,20 +1105,20 @@ if lws_with_mbedtls
         'lib/tls/mbedtls/wrapper/include',
         'lib/tls/mbedtls/wrapper/include/platform',
         'lib/tls/mbedtls/wrapper/include/internal',
-        'lib/tls/mbedtls/wrapper/include/openssl']
-    
+        'lib/tls/mbedtls/wrapper/include/openssl',
+    ]
+
     if lws_with_network
         lws_sources += [
             'lib/tls/mbedtls/wrapper/library/ssl_cert.c',
-			'lib/tls/mbedtls/wrapper/library/ssl_lib.c',
-			'lib/tls/mbedtls/wrapper/library/ssl_methods.c',
-			'lib/tls/mbedtls/wrapper/library/ssl_pkey.c',
-			'lib/tls/mbedtls/wrapper/library/ssl_stack.c',
-			'lib/tls/mbedtls/wrapper/library/ssl_x509.c']
+            'lib/tls/mbedtls/wrapper/library/ssl_lib.c',
+            'lib/tls/mbedtls/wrapper/library/ssl_methods.c',
+            'lib/tls/mbedtls/wrapper/library/ssl_pkey.c',
+            'lib/tls/mbedtls/wrapper/library/ssl_stack.c',
+            'lib/tls/mbedtls/wrapper/library/ssl_x509.c',
+        ]
 
-        lws_sources += [
-            'lib/tls/mbedtls/wrapper/platform/ssl_pm.c',
-			'lib/tls/mbedtls/wrapper/platform/ssl_port.c']
+        lws_sources += ['lib/tls/mbedtls/wrapper/platform/ssl_pm.c', 'lib/tls/mbedtls/wrapper/platform/ssl_port.c']
     endif
 endif
 
@@ -1130,10 +1130,8 @@ if lws_with_ssl
     endif
 
     if lws_with_mbedtls
-        lws_sources += [
-            'lib/tls/mbedtls/mbedtls-tls.c',
-			'lib/tls/mbedtls/mbedtls-x509.c']
-        
+        lws_sources += ['lib/tls/mbedtls/mbedtls-tls.c', 'lib/tls/mbedtls/mbedtls-x509.c']
+
         if lws_with_network
             lws_sources += ['lib/tls/mbedtls/mbedtls-ssl.c']
         endif
@@ -1141,17 +1139,16 @@ if lws_with_ssl
         if lws_with_gencrypto
             lws_sources += [
                 'lib/tls/mbedtls/lws-genhash.c',
-				'lib/tls/mbedtls/lws-genrsa.c',
-				'lib/tls/mbedtls/lws-genaes.c',
-				'lib/tls/lws-genec-common.c',
-				'lib/tls/mbedtls/lws-genec.c',
-				'lib/tls/mbedtls/lws-gencrypto.c']
+                'lib/tls/mbedtls/lws-genrsa.c',
+                'lib/tls/mbedtls/lws-genaes.c',
+                'lib/tls/lws-genec-common.c',
+                'lib/tls/mbedtls/lws-genec.c',
+                'lib/tls/mbedtls/lws-gencrypto.c',
+            ]
         endif
     else
-        lws_sources += [
-            'lib/tls/openssl/openssl-tls.c',
-			'lib/tls/openssl/openssl-x509.c']
-        
+        lws_sources += ['lib/tls/openssl/openssl-tls.c', 'lib/tls/openssl/openssl-x509.c']
+
         if lws_with_network
             lws_sources += ['lib/tls/openssl/openssl-ssl.c']
         endif
@@ -1159,11 +1156,12 @@ if lws_with_ssl
         if lws_with_gencrypto
             lws_sources += [
                 'lib/tls/openssl/lws-genhash.c',
-				'lib/tls/openssl/lws-genrsa.c',
-				'lib/tls/openssl/lws-genaes.c',
-				'lib/tls/lws-genec-common.c',
-				'lib/tls/openssl/lws-genec.c',
-				'lib/tls/openssl/lws-gencrypto.c']
+                'lib/tls/openssl/lws-genrsa.c',
+                'lib/tls/openssl/lws-genaes.c',
+                'lib/tls/lws-genec-common.c',
+                'lib/tls/openssl/lws-genec.c',
+                'lib/tls/openssl/lws-gencrypto.c',
+            ]
         endif
     endif
 
@@ -1193,10 +1191,7 @@ if not lws_without_builtin_sha1
 endif
 
 if lws_with_http2 and not lws_without_server
-    lws_sources += [
-        'lib/roles/h2/http2.c',
-		'lib/roles/h2/hpack.c',
-		'lib/roles/h2/ops-h2.c']
+    lws_sources += ['lib/roles/h2/http2.c', 'lib/roles/h2/hpack.c', 'lib/roles/h2/ops-h2.c']
 endif
 
 # select the active platform files
@@ -1204,13 +1199,14 @@ endif
 if win32
     lws_sources += [
         'lib/plat/windows/windows-fds.c',
-		'lib/plat/windows/windows-file.c',
-		'lib/plat/windows/windows-init.c',
-		'lib/plat/windows/windows-misc.c',
-		'lib/plat/windows/windows-pipe.c',
-		'lib/plat/windows/windows-plugins.c',
-		'lib/plat/windows/windows-service.c',
-		'lib/plat/windows/windows-sockets.c']
+        'lib/plat/windows/windows-file.c',
+        'lib/plat/windows/windows-init.c',
+        'lib/plat/windows/windows-misc.c',
+        'lib/plat/windows/windows-pipe.c',
+        'lib/plat/windows/windows-plugins.c',
+        'lib/plat/windows/windows-service.c',
+        'lib/plat/windows/windows-sockets.c',
+    ]
 
     if lws_with_sys_async_dns
         lws_sources += ['lib/plat/windows/windows-resolv.c']
@@ -1226,12 +1222,13 @@ elif lws_plat_optee
 elif lws_plat_freertos
     lws_sources += [
         'lib/plat/freertos/freertos-fds.c',
-		'lib/plat/freertos/freertos-init.c',
-		'lib/plat/freertos/freertos-misc.c',
-		'lib/plat/freertos/freertos-pipe.c',
-		'lib/plat/freertos/freertos-service.c',
-		'lib/plat/freertos/freertos-sockets.c',
-		'lib/misc/romfs.c']
+        'lib/plat/freertos/freertos-init.c',
+        'lib/plat/freertos/freertos-misc.c',
+        'lib/plat/freertos/freertos-pipe.c',
+        'lib/plat/freertos/freertos-service.c',
+        'lib/plat/freertos/freertos-sockets.c',
+        'lib/misc/romfs.c',
+    ]
 
     if lws_with_esp32_helper
         lws_sources += ['lib/plat/freertos/esp32/esp32-helpers.c']
@@ -1247,21 +1244,14 @@ elif lws_plat_freertos
 
 else
     lws_plat_unix = true
-    lws_sources += [
-        'lib/plat/unix/unix-caps.c',
-		'lib/plat/unix/unix-misc.c',
-		'lib/plat/unix/unix-init.c']
+    lws_sources += ['lib/plat/unix/unix-caps.c', 'lib/plat/unix/unix-misc.c', 'lib/plat/unix/unix-init.c']
 
     if lws_with_file_ops
         lws_sources += ['lib/plat/unix/unix-file.c']
     endif
 
     if lws_with_network
-        lws_sources += [
-            'lib/plat/unix/unix-pipe.c',
-			'lib/plat/unix/unix-service.c',
-			'lib/plat/unix/unix-sockets.c',
-			'lib/plat/unix/unix-fds.c']
+        lws_sources += ['lib/plat/unix/unix-pipe.c', 'lib/plat/unix/unix-service.c', 'lib/plat/unix/unix-sockets.c', 'lib/plat/unix/unix-fds.c']
 
         if lws_with_sys_async_dns
             if lws_plat_android
@@ -1282,15 +1272,11 @@ if lws_with_socks5 and not lws_without_client
 endif
 
 if (lws_role_h1 or lws_role_h2) and not lws_without_server
-    lws_sources += [
-        'lib/roles/http/server/server.c',
-		'lib/roles/http/server/lws-spa.c']
+    lws_sources += ['lib/roles/http/server/server.c', 'lib/roles/http/server/lws-spa.c']
 endif
 
 if lws_role_ws and not lws_without_extensions
-    lws_sources += [
-        'lib/roles/ws/ext/extension.c',
-        'lib/roles/ws/ext/extension-permessage-deflate.c']
+    lws_sources += ['lib/roles/ws/ext/extension.c', 'lib/roles/ws/ext/extension-permessage-deflate.c']
 endif
 
 if lws_with_http_proxy
@@ -1315,9 +1301,9 @@ endif
 
 if lws_with_libev and lws_with_network
     lws_sources += ['lib/event-libs/libev/libev.c']
-	# libev generates a big mess of warnings with gcc, maintainer claims gcc to blame
+    # libev generates a big mess of warnings with gcc, maintainer claims gcc to blame
     # ToDo: How to express this in meson?
-	# set_source_files_properties( lib/event-libs/libev/libev.c PROPERTIES COMPILE_FLAGS "-Wno-error" )
+    # set_source_files_properties( lib/event-libs/libev/libev.c PROPERTIES COMPILE_FLAGS "-Wno-error" )
 endif
 
 if lws_with_lejp
@@ -1353,15 +1339,16 @@ endif
 if lws_with_jose
     lws_sources += [
         'lib/jose/jwk/jwk.c',
-		'lib/jose/jws/jose.c',
-		'lib/jose/jws/jws.c',
-		'lib/jose/jwe/jwe.c',
-		'lib/jose/jwe/enc/aescbc.c',
-		'lib/jose/jwe/enc/aesgcm.c',
-		'lib/jose/jwe/enc/aeskw.c',
-		'lib/jose/jwe/jwe-rsa-aescbc.c',
-		'lib/jose/jwe/jwe-rsa-aesgcm.c',
-		'lib/jose/jwe/jwe-ecdh-es-aeskw.c']
+        'lib/jose/jws/jose.c',
+        'lib/jose/jws/jws.c',
+        'lib/jose/jwe/jwe.c',
+        'lib/jose/jwe/enc/aescbc.c',
+        'lib/jose/jwe/enc/aesgcm.c',
+        'lib/jose/jwe/enc/aeskw.c',
+        'lib/jose/jwe/jwe-rsa-aescbc.c',
+        'lib/jose/jwe/jwe-rsa-aesgcm.c',
+        'lib/jose/jwe/jwe-ecdh-es-aeskw.c',
+    ]
 endif
 
 if lws_with_tls and (lws_with_jose or lws_with_gencrypto)
@@ -1421,10 +1408,12 @@ lws_config_private_data.set('LWS_HAVE_EXECVPE', lws_have_execvpe)
 lws_config_private_data.set('LWS_HAVE_ZLIB_H', lws_have_zlib_h)
 lws_config_private_data.set('LWS_WITH_ZLIB', lws_with_zlib)
 lws_config_private_data.set('LWS_HAS_PTHREAD_SETNAME_NP', lws_has_pthread_setname_np)
-lws_config_private_h = configure_file(input: 'cmake/lws_config_private.h.in',
+lws_config_private_h = configure_file(
+    input: 'cmake/lws_config_private.h.in',
     output: 'lws_config_private.h',
     configuration: lws_config_private_data,
-    format: 'cmake')
+    format: 'cmake',
+)
 lws_sources += [lws_config_private_h]
 
 lws_config_data = configuration_data()
@@ -1434,177 +1423,173 @@ lws_config_data.set('LWS_LIBRARY_VERSION_MINOR', lws_library_version_minor)
 lws_config_data.set('LWS_LIBRARY_VERSION_PATCH', lws_library_version_patch)
 lws_config_data.set('LWS_MAX_SMP', lws_max_smp)
 #lws_config_data.set('LWS_LIBRARY_VERSION_NUMBER',lws_library_version_number)
-lws_config_data.set('LWS_AVOID_SIGPIPE_IGN',lws_avoid_sigpipe_ign)
-lws_config_data.set('LWS_BUILD_HASH',lws_build_hash)
-lws_config_data.set('LWS_BUILTIN_GETIFADDRS',lws_builtin_getifaddrs)
-lws_config_data.set('LWS_CLIENT_HTTP_PROXYING',lws_client_http_proxying)
-lws_config_data.set('LWS_DETECTED_PLAT_IOS',lws_detected_plat_ios)
-lws_config_data.set('LWS_FALLBACK_GETHOSTBYNAME',lws_fallback_gethostbyname)
-lws_config_data.set('LWS_HAS_INTPTR_T',lws_has_intptr_t)
-lws_config_data.set('LWS_HAS_GETOPT_LONG',lws_has_getopt_long)
-lws_config_data.set('LWS_HAVE__ATOI64',lws_have__atoi64)
-lws_config_data.set('LWS_HAVE_ATOLL',lws_have_atoll)
-lws_config_data.set('LWS_HAVE_BN_bn2binpad',lws_have_bn_bn2binpad)
-lws_config_data.set('LWS_HAVE_CLOCK_GETTIME',lws_have_clock_gettime)
-lws_config_data.set('LWS_HAVE_EC_POINT_get_affine_coordinates',lws_have_ec_point_get_affine_coordinates)
-lws_config_data.set('LWS_HAVE_ECDSA_SIG_set0',lws_have_ecdsa_sig_set0)
-lws_config_data.set('LWS_HAVE_EVP_MD_CTX_free',lws_have_evp_md_ctx_free)
-lws_config_data.set('LWS_HAVE_EVP_aes_128_wrap',lws_have_evp_aes_128_wrap)
-lws_config_data.set('LWS_HAVE_EVP_aes_128_cfb8',lws_have_evp_aes_128_cfb8)
-lws_config_data.set('LWS_HAVE_EVP_aes_128_cfb128',lws_have_evp_aes_128_cfb128)
-lws_config_data.set('LWS_HAVE_EVP_aes_192_cfb8',lws_have_evp_aes_192_cfb8)
-lws_config_data.set('LWS_HAVE_EVP_aes_192_cfb128',lws_have_evp_aes_192_cfb128)
-lws_config_data.set('LWS_HAVE_EVP_aes_256_cfb8',lws_have_evp_aes_256_cfb8)
-lws_config_data.set('LWS_HAVE_EVP_aes_256_cfb128',lws_have_evp_aes_256_cfb128)
-lws_config_data.set('LWS_HAVE_EVP_aes_128_xts',lws_have_evp_aes_128_xts)
-lws_config_data.set('LWS_HAVE_EXECVPE',lws_have_execvpe)
-lws_config_data.set('LWS_HAVE_LIBCAP',lws_have_libcap)
-lws_config_data.set('LWS_HAVE_HMAC_CTX_new',lws_have_hmac_ctx_new)
-lws_config_data.set('LWS_HAVE_MALLOC_H',lws_have_malloc_h)
-lws_config_data.set('LWS_HAVE_MALLOC_TRIM',lws_have_malloc_trim)
-lws_config_data.set('LWS_HAVE_MALLOC_USABLE_SIZE',lws_have_malloc_usable_size)
-lws_config_data.set('LWS_HAVE_mbedtls_net_init',lws_have_mbedtls_net_init)
-lws_config_data.set('LWS_HAVE_mbedtls_ssl_conf_alpn_protocols',lws_have_mbedtls_ssl_conf_alpn_protocols)
-lws_config_data.set('LWS_HAVE_mbedtls_ssl_get_alpn_protocol',lws_have_mbedtls_ssl_get_alpn_protocol)
-lws_config_data.set('LWS_HAVE_mbedtls_ssl_conf_sni',lws_have_mbedtls_ssl_conf_sni)
-lws_config_data.set('LWS_HAVE_mbedtls_ssl_set_hs_ca_chain',lws_have_mbedtls_ssl_set_hs_ca_chain)
-lws_config_data.set('LWS_HAVE_mbedtls_ssl_set_hs_own_cert',lws_have_mbedtls_ssl_set_hs_own_cert)
-lws_config_data.set('LWS_HAVE_mbedtls_ssl_set_hs_authmode',lws_have_mbedtls_ssl_set_hs_authmode)
-lws_config_data.set('LWS_HAVE_MBEDTLS_NET_SOCKETS',lws_have_mbedtls_net_sockets)
-lws_config_data.set('LWS_HAVE_NEW_UV_VERSION_H',lws_have_new_uv_version_h)
-lws_config_data.set('LWS_HAVE_OPENSSL_ECDH_H',lws_have_openssl_ecdh_h)
-lws_config_data.set('LWS_HAVE_PIPE2',lws_have_pipe2)
-lws_config_data.set('LWS_HAVE_EVENTFD',lws_have_eventfd)
-lws_config_data.set('LWS_HAVE_PTHREAD_H',lws_have_pthread_h)
-lws_config_data.set('LWS_HAVE_RSA_SET0_KEY',lws_have_rsa_set0_key)
-lws_config_data.set('LWS_HAVE_RSA_verify_pss_mgf1',lws_have_rsa_verify_pss_mgf1)
-lws_config_data.set('LWS_HAVE_SSL_CTX_get0_certificate',lws_have_ssl_ctx_get0_certificate)
-lws_config_data.set('LWS_HAVE_SSL_CTX_set1_param',lws_have_ssl_ctx_set1_param)
-lws_config_data.set('LWS_HAVE_SSL_CTX_set_ciphersuites',lws_have_ssl_ctx_set_ciphersuites)
-lws_config_data.set('LWS_HAVE_SSL_EXTRA_CHAIN_CERTS',lws_have_ssl_extra_chain_certs)
-lws_config_data.set('LWS_HAVE_SSL_get0_alpn_selected',lws_have_ssl_get0_alpn_selected)
-lws_config_data.set('LWS_HAVE_SSL_CTX_EVP_PKEY_new_raw_private_key',lws_have_ssl_ctx_evp_pkey_new_raw_private_key)
-lws_config_data.set('LWS_HAVE_SSL_set_alpn_protos',lws_have_ssl_set_alpn_protos)
-lws_config_data.set('LWS_HAVE_SSL_SET_INFO_CALLBACK',lws_have_ssl_set_info_callback)
-lws_config_data.set('LWS_HAVE__STAT32I64',lws_have__stat32i64)
-lws_config_data.set('LWS_HAVE_STDINT_H',lws_have_stdint_h)
-lws_config_data.set('LWS_HAVE_SYS_CAPABILITY_H',lws_have_sys_capability_h)
-lws_config_data.set('LWS_HAVE_TLS_CLIENT_METHOD',lws_have_tls_client_method)
-lws_config_data.set('LWS_HAVE_TLSV1_2_CLIENT_METHOD',lws_have_tlsv1_2_client_method)
-lws_config_data.set('LWS_HAVE_UV_VERSION_H',lws_have_uv_version_h)
-lws_config_data.set('LWS_HAVE_VFORK',lws_have_vfork)
-lws_config_data.set('LWS_HAVE_X509_get_key_usage',lws_have_x509_get_key_usage)
-lws_config_data.set('LWS_HAVE_X509_VERIFY_PARAM_set1_host',lws_have_x509_verify_param_set1_host)
-lws_config_data.set('LWS_LIBRARY_VERSION',lws_library_version)
-lws_config_data.set('LWS_LOGGING_BITFIELD_CLEAR',lws_logging_bitfield_clear)
+lws_config_data.set('LWS_AVOID_SIGPIPE_IGN', lws_avoid_sigpipe_ign)
+lws_config_data.set('LWS_BUILD_HASH', lws_build_hash)
+lws_config_data.set('LWS_BUILTIN_GETIFADDRS', lws_builtin_getifaddrs)
+lws_config_data.set('LWS_CLIENT_HTTP_PROXYING', lws_client_http_proxying)
+lws_config_data.set('LWS_DETECTED_PLAT_IOS', lws_detected_plat_ios)
+lws_config_data.set('LWS_FALLBACK_GETHOSTBYNAME', lws_fallback_gethostbyname)
+lws_config_data.set('LWS_HAS_INTPTR_T', lws_has_intptr_t)
+lws_config_data.set('LWS_HAS_GETOPT_LONG', lws_has_getopt_long)
+lws_config_data.set('LWS_HAVE__ATOI64', lws_have__atoi64)
+lws_config_data.set('LWS_HAVE_ATOLL', lws_have_atoll)
+lws_config_data.set('LWS_HAVE_BN_bn2binpad', lws_have_bn_bn2binpad)
+lws_config_data.set('LWS_HAVE_CLOCK_GETTIME', lws_have_clock_gettime)
+lws_config_data.set('LWS_HAVE_EC_POINT_get_affine_coordinates', lws_have_ec_point_get_affine_coordinates)
+lws_config_data.set('LWS_HAVE_ECDSA_SIG_set0', lws_have_ecdsa_sig_set0)
+lws_config_data.set('LWS_HAVE_EVP_MD_CTX_free', lws_have_evp_md_ctx_free)
+lws_config_data.set('LWS_HAVE_EVP_aes_128_wrap', lws_have_evp_aes_128_wrap)
+lws_config_data.set('LWS_HAVE_EVP_aes_128_cfb8', lws_have_evp_aes_128_cfb8)
+lws_config_data.set('LWS_HAVE_EVP_aes_128_cfb128', lws_have_evp_aes_128_cfb128)
+lws_config_data.set('LWS_HAVE_EVP_aes_192_cfb8', lws_have_evp_aes_192_cfb8)
+lws_config_data.set('LWS_HAVE_EVP_aes_192_cfb128', lws_have_evp_aes_192_cfb128)
+lws_config_data.set('LWS_HAVE_EVP_aes_256_cfb8', lws_have_evp_aes_256_cfb8)
+lws_config_data.set('LWS_HAVE_EVP_aes_256_cfb128', lws_have_evp_aes_256_cfb128)
+lws_config_data.set('LWS_HAVE_EVP_aes_128_xts', lws_have_evp_aes_128_xts)
+lws_config_data.set('LWS_HAVE_EXECVPE', lws_have_execvpe)
+lws_config_data.set('LWS_HAVE_LIBCAP', lws_have_libcap)
+lws_config_data.set('LWS_HAVE_HMAC_CTX_new', lws_have_hmac_ctx_new)
+lws_config_data.set('LWS_HAVE_MALLOC_H', lws_have_malloc_h)
+lws_config_data.set('LWS_HAVE_MALLOC_TRIM', lws_have_malloc_trim)
+lws_config_data.set('LWS_HAVE_MALLOC_USABLE_SIZE', lws_have_malloc_usable_size)
+lws_config_data.set('LWS_HAVE_mbedtls_net_init', lws_have_mbedtls_net_init)
+lws_config_data.set('LWS_HAVE_mbedtls_ssl_conf_alpn_protocols', lws_have_mbedtls_ssl_conf_alpn_protocols)
+lws_config_data.set('LWS_HAVE_mbedtls_ssl_get_alpn_protocol', lws_have_mbedtls_ssl_get_alpn_protocol)
+lws_config_data.set('LWS_HAVE_mbedtls_ssl_conf_sni', lws_have_mbedtls_ssl_conf_sni)
+lws_config_data.set('LWS_HAVE_mbedtls_ssl_set_hs_ca_chain', lws_have_mbedtls_ssl_set_hs_ca_chain)
+lws_config_data.set('LWS_HAVE_mbedtls_ssl_set_hs_own_cert', lws_have_mbedtls_ssl_set_hs_own_cert)
+lws_config_data.set('LWS_HAVE_mbedtls_ssl_set_hs_authmode', lws_have_mbedtls_ssl_set_hs_authmode)
+lws_config_data.set('LWS_HAVE_MBEDTLS_NET_SOCKETS', lws_have_mbedtls_net_sockets)
+lws_config_data.set('LWS_HAVE_NEW_UV_VERSION_H', lws_have_new_uv_version_h)
+lws_config_data.set('LWS_HAVE_OPENSSL_ECDH_H', lws_have_openssl_ecdh_h)
+lws_config_data.set('LWS_HAVE_PIPE2', lws_have_pipe2)
+lws_config_data.set('LWS_HAVE_EVENTFD', lws_have_eventfd)
+lws_config_data.set('LWS_HAVE_PTHREAD_H', lws_have_pthread_h)
+lws_config_data.set('LWS_HAVE_RSA_SET0_KEY', lws_have_rsa_set0_key)
+lws_config_data.set('LWS_HAVE_RSA_verify_pss_mgf1', lws_have_rsa_verify_pss_mgf1)
+lws_config_data.set('LWS_HAVE_SSL_CTX_get0_certificate', lws_have_ssl_ctx_get0_certificate)
+lws_config_data.set('LWS_HAVE_SSL_CTX_set1_param', lws_have_ssl_ctx_set1_param)
+lws_config_data.set('LWS_HAVE_SSL_CTX_set_ciphersuites', lws_have_ssl_ctx_set_ciphersuites)
+lws_config_data.set('LWS_HAVE_SSL_EXTRA_CHAIN_CERTS', lws_have_ssl_extra_chain_certs)
+lws_config_data.set('LWS_HAVE_SSL_get0_alpn_selected', lws_have_ssl_get0_alpn_selected)
+lws_config_data.set('LWS_HAVE_SSL_CTX_EVP_PKEY_new_raw_private_key', lws_have_ssl_ctx_evp_pkey_new_raw_private_key)
+lws_config_data.set('LWS_HAVE_SSL_set_alpn_protos', lws_have_ssl_set_alpn_protos)
+lws_config_data.set('LWS_HAVE_SSL_SET_INFO_CALLBACK', lws_have_ssl_set_info_callback)
+lws_config_data.set('LWS_HAVE__STAT32I64', lws_have__stat32i64)
+lws_config_data.set('LWS_HAVE_STDINT_H', lws_have_stdint_h)
+lws_config_data.set('LWS_HAVE_SYS_CAPABILITY_H', lws_have_sys_capability_h)
+lws_config_data.set('LWS_HAVE_TLS_CLIENT_METHOD', lws_have_tls_client_method)
+lws_config_data.set('LWS_HAVE_TLSV1_2_CLIENT_METHOD', lws_have_tlsv1_2_client_method)
+lws_config_data.set('LWS_HAVE_UV_VERSION_H', lws_have_uv_version_h)
+lws_config_data.set('LWS_HAVE_VFORK', lws_have_vfork)
+lws_config_data.set('LWS_HAVE_X509_get_key_usage', lws_have_x509_get_key_usage)
+lws_config_data.set('LWS_HAVE_X509_VERIFY_PARAM_set1_host', lws_have_x509_verify_param_set1_host)
+lws_config_data.set('LWS_LIBRARY_VERSION', lws_library_version)
+lws_config_data.set('LWS_LOGGING_BITFIELD_CLEAR', lws_logging_bitfield_clear)
 lws_config_data.set('LWS_LOGGING_BITFIELD_SET', lws_logging_bitfield_set)
-lws_config_data.set('LWS_MINGW_SUPPORT',lws_mingw_support)
-lws_config_data.set('LWS_NO_CLIENT',lws_no_client)
-lws_config_data.set('LWS_NO_DAEMONIZE',lws_no_daemonize)
-lws_config_data.set('LWS_OPENSSL_CLIENT_CERTS',lws_openssl_client_certs)
-lws_config_data.set('LWS_OPENSSL_SUPPORT',lws_openssl_support)
-lws_config_data.set('LWS_PLAT_OPTEE',lws_plat_optee)
-lws_config_data.set('LWS_PLAT_UNIX',lws_plat_unix)
-lws_config_data.set('LWS_PLAT_FREERTOS',lws_plat_freertos)
-lws_config_data.set('LWS_ROLE_CGI',lws_role_cgi)
-lws_config_data.set('LWS_ROLE_DBUS',lws_role_dbus)
-lws_config_data.set('LWS_ROLE_H1',lws_role_h1)
-lws_config_data.set('LWS_ROLE_H2',lws_role_h2)
-lws_config_data.set('LWS_ROLE_RAW',lws_role_raw)
-lws_config_data.set('LWS_ROLE_RAW_FILE',lws_role_raw_file)
-lws_config_data.set('LWS_ROLE_RAW_PROXY',lws_role_raw_proxy)
-lws_config_data.set('LWS_ROLE_WS',lws_role_ws)
-lws_config_data.set('LWS_ROLE_MQTT',lws_role_mqtt)
-lws_config_data.set('LWS_SHA1_USE_OPENSSL_NAME',lws_sha1_use_openssl_name)
-lws_config_data.set('LWS_SSL_CLIENT_USE_OS_CA_CERTS',lws_ssl_client_use_os_ca_certs)
-lws_config_data.set('LWS_SSL_SERVER_WITH_ECDH_CERT',lws_ssl_server_with_ecdh_cert)
-lws_config_data.set('LWS_WITH_ABSTRACT',lws_with_abstract)
-lws_config_data.set('LWS_WITH_ACCESS_LOG',lws_with_access_log)
-lws_config_data.set('LWS_WITH_ACME',lws_with_acme)
-lws_config_data.set('LWS_WITH_ALSA',lws_with_alsa)
-lws_config_data.set('LWS_WITH_SYS_ASYNC_DNS',lws_with_sys_async_dns)
-lws_config_data.set('LWS_WITH_BORINGSSL',lws_with_boringssl)
-lws_config_data.set('LWS_WITH_CGI',lws_with_cgi)
-lws_config_data.set('LWS_WITH_CUSTOM_HEADERS',lws_with_custom_headers)
-lws_config_data.set('LWS_WITH_DEPRECATED_LWS_DLL',lws_with_deprecated_lws_dll)
-lws_config_data.set('LWS_WITH_DETAILED_LATENCY',lws_with_detailed_latency)
-lws_config_data.set('LWS_WITH_DIR',lws_with_dir)
-lws_config_data.set('LWS_WITH_ESP32',lws_with_esp32)
-lws_config_data.set('LWS_HAVE_EVBACKEND_LINUXAIO',lws_have_evbackend_linuxaio)
-lws_config_data.set('LWS_HAVE_EVBACKEND_IOURING',lws_have_evbackend_iouring)
-lws_config_data.set('LWS_WITH_EXTERNAL_POLL',lws_with_external_poll)
-lws_config_data.set('LWS_WITH_FILE_OPS',lws_with_file_ops)
-lws_config_data.set('LWS_WITH_FSMOUNT',lws_with_fsmount)
-lws_config_data.set('LWS_WITH_FTS',lws_with_fts)
-lws_config_data.set('LWS_WITH_GENCRYPTO',lws_with_gencrypto)
-lws_config_data.set('LWS_WITH_GENERIC_SESSIONS',lws_with_generic_sessions)
-lws_config_data.set('LWS_WITH_GLIB',lws_with_glib)
-lws_config_data.set('LWS_WITH_GTK',lws_with_gtk)
-lws_config_data.set('LWS_WITH_HTTP2',lws_with_http_basic_auth)
-lws_config_data.set('LWS_WITH_HTTP_BASIC_AUTH',lws_with_http_basic_auth)
-lws_config_data.set('LWS_WITH_HTTP_BROTLI',lws_with_http_brotli)
-lws_config_data.set('LWS_WITH_HTTP_PROXY',lws_with_http_proxy)
-lws_config_data.set('LWS_WITH_HTTP_STREAM_COMPRESSION',lws_with_http_stream_compression)
-lws_config_data.set('LWS_WITH_HTTP_UNCOMMON_HEADERS',lws_with_http_uncommon_headers)
-lws_config_data.set('LWS_WITH_IPV6',lws_with_ipv6)
-lws_config_data.set('LWS_WITH_JOSE',lws_with_jose)
-lws_config_data.set('LWS_WITH_LEJP',lws_with_lejp)
-lws_config_data.set('LWS_WITH_LIBEV',lws_with_libev)
-lws_config_data.set('LWS_WITH_LIBEVENT',lws_with_libevent)
-lws_config_data.set('LWS_WITH_LIBUV',lws_with_libuv)
-lws_config_data.set('LWS_WITH_LWSAC',lws_with_lwsac)
-lws_config_data.set('LWS_LOGS_TIMESTAMP',lws_logs_timestamp)
-lws_config_data.set('LWS_WITH_MBEDTLS',lws_with_mbedtls)
-lws_config_data.set('LWS_WITH_MINIZ',lws_with_miniz)
-lws_config_data.set('LWS_WITH_NETWORK',lws_with_network)
-lws_config_data.set('LWS_WITH_NO_LOGS',lws_with_no_logs)
-lws_config_data.set('LWS_WITH_CLIENT',lws_with_client)
-lws_config_data.set('LWS_WITHOUT_EXTENSIONS',lws_without_extensions)
-lws_config_data.set('LWS_WITH_SERVER',lws_with_server)
-lws_config_data.set('LWS_WITH_SPAWN',lws_with_spawn)
-lws_config_data.set('LWS_WITH_PEER_LIMITS',lws_with_peer_limits)
-lws_config_data.set('LWS_WITH_PLUGINS',lws_with_plugins)
-lws_config_data.set('LWS_WITH_POLARSSL',lws_with_polarssl)
-lws_config_data.set('LWS_WITH_POLL',lws_with_poll)
-lws_config_data.set('LWS_WITH_RANGES',lws_with_ranges)
-lws_config_data.set('LWS_WITH_SECURE_STREAMS',lws_with_secure_streams)
-lws_config_data.set('LWS_WITH_SECURE_STREAMS_SYS_AUTH_API_AMAZON_COM',lws_with_secure_streams_sys_auth_api_amazon_com)
-lws_config_data.set('LWS_WITH_SECURE_STREAMS_PROXY_API',lws_with_secure_streams_proxy_api)
-lws_config_data.set('LWS_WITH_SELFTESTS',lws_with_selftests)
-lws_config_data.set('LWS_WITH_SEQUENCER',lws_with_sequencer)
-lws_config_data.set('LWS_WITH_SERVER_STATUS',lws_with_server_status)
-lws_config_data.set('LWS_WITH_SMTP',lws_with_smtp)
-lws_config_data.set('LWS_WITH_SOCKS5',lws_with_socks5)
-lws_config_data.set('LWS_WITH_STATEFUL_URLDECODE',lws_with_stateful_urldecode)
-lws_config_data.set('LWS_WITH_STATS',lws_with_stats)
-lws_config_data.set('LWS_WITH_STRUCT_SQLITE3',lws_with_struct_sqlite3)
-lws_config_data.set('LWS_WITH_STRUCT_JSON',lws_with_struct_json)
-lws_config_data.set('LWS_WITH_SQLITE3',lws_with_sqlite3)
-lws_config_data.set('LWS_WITH_SYS_NTPCLIENT',lws_with_sys_ntpclient)
-lws_config_data.set('LWS_WITH_SYS_DHCP_CLIENT',lws_with_sys_dhcp_client)
-lws_config_data.set('LWS_WITH_THREADPOOL',lws_with_threadpool)
-lws_config_data.set('LWS_WITH_TLS',lws_with_tls)
-lws_config_data.set('LWS_WITH_UDP',lws_with_udp)
-lws_config_data.set('LWS_WITH_UNIX_SOCK',lws_with_unix_sock)
-lws_config_data.set('LWS_WITH_ZIP_FOPS',lws_with_zip_fops)
-lws_config_data.set('USE_OLD_CYASSL',use_old_cyassl)
-lws_config_data.set('USE_WOLFSSL',use_wolfssl)
+lws_config_data.set('LWS_MINGW_SUPPORT', lws_mingw_support)
+lws_config_data.set('LWS_NO_CLIENT', lws_no_client)
+lws_config_data.set('LWS_NO_DAEMONIZE', lws_no_daemonize)
+lws_config_data.set('LWS_OPENSSL_CLIENT_CERTS', lws_openssl_client_certs)
+lws_config_data.set('LWS_OPENSSL_SUPPORT', lws_openssl_support)
+lws_config_data.set('LWS_PLAT_OPTEE', lws_plat_optee)
+lws_config_data.set('LWS_PLAT_UNIX', lws_plat_unix)
+lws_config_data.set('LWS_PLAT_FREERTOS', lws_plat_freertos)
+lws_config_data.set('LWS_ROLE_CGI', lws_role_cgi)
+lws_config_data.set('LWS_ROLE_DBUS', lws_role_dbus)
+lws_config_data.set('LWS_ROLE_H1', lws_role_h1)
+lws_config_data.set('LWS_ROLE_H2', lws_role_h2)
+lws_config_data.set('LWS_ROLE_RAW', lws_role_raw)
+lws_config_data.set('LWS_ROLE_RAW_FILE', lws_role_raw_file)
+lws_config_data.set('LWS_ROLE_RAW_PROXY', lws_role_raw_proxy)
+lws_config_data.set('LWS_ROLE_WS', lws_role_ws)
+lws_config_data.set('LWS_ROLE_MQTT', lws_role_mqtt)
+lws_config_data.set('LWS_SHA1_USE_OPENSSL_NAME', lws_sha1_use_openssl_name)
+lws_config_data.set('LWS_SSL_CLIENT_USE_OS_CA_CERTS', lws_ssl_client_use_os_ca_certs)
+lws_config_data.set('LWS_SSL_SERVER_WITH_ECDH_CERT', lws_ssl_server_with_ecdh_cert)
+lws_config_data.set('LWS_WITH_ABSTRACT', lws_with_abstract)
+lws_config_data.set('LWS_WITH_ACCESS_LOG', lws_with_access_log)
+lws_config_data.set('LWS_WITH_ACME', lws_with_acme)
+lws_config_data.set('LWS_WITH_ALSA', lws_with_alsa)
+lws_config_data.set('LWS_WITH_SYS_ASYNC_DNS', lws_with_sys_async_dns)
+lws_config_data.set('LWS_WITH_BORINGSSL', lws_with_boringssl)
+lws_config_data.set('LWS_WITH_CGI', lws_with_cgi)
+lws_config_data.set('LWS_WITH_CUSTOM_HEADERS', lws_with_custom_headers)
+lws_config_data.set('LWS_WITH_DEPRECATED_LWS_DLL', lws_with_deprecated_lws_dll)
+lws_config_data.set('LWS_WITH_DETAILED_LATENCY', lws_with_detailed_latency)
+lws_config_data.set('LWS_WITH_DIR', lws_with_dir)
+lws_config_data.set('LWS_WITH_ESP32', lws_with_esp32)
+lws_config_data.set('LWS_HAVE_EVBACKEND_LINUXAIO', lws_have_evbackend_linuxaio)
+lws_config_data.set('LWS_HAVE_EVBACKEND_IOURING', lws_have_evbackend_iouring)
+lws_config_data.set('LWS_WITH_EXTERNAL_POLL', lws_with_external_poll)
+lws_config_data.set('LWS_WITH_FILE_OPS', lws_with_file_ops)
+lws_config_data.set('LWS_WITH_FSMOUNT', lws_with_fsmount)
+lws_config_data.set('LWS_WITH_FTS', lws_with_fts)
+lws_config_data.set('LWS_WITH_GENCRYPTO', lws_with_gencrypto)
+lws_config_data.set('LWS_WITH_GENERIC_SESSIONS', lws_with_generic_sessions)
+lws_config_data.set('LWS_WITH_GLIB', lws_with_glib)
+lws_config_data.set('LWS_WITH_GTK', lws_with_gtk)
+lws_config_data.set('LWS_WITH_HTTP2', lws_with_http_basic_auth)
+lws_config_data.set('LWS_WITH_HTTP_BASIC_AUTH', lws_with_http_basic_auth)
+lws_config_data.set('LWS_WITH_HTTP_BROTLI', lws_with_http_brotli)
+lws_config_data.set('LWS_WITH_HTTP_PROXY', lws_with_http_proxy)
+lws_config_data.set('LWS_WITH_HTTP_STREAM_COMPRESSION', lws_with_http_stream_compression)
+lws_config_data.set('LWS_WITH_HTTP_UNCOMMON_HEADERS', lws_with_http_uncommon_headers)
+lws_config_data.set('LWS_WITH_IPV6', lws_with_ipv6)
+lws_config_data.set('LWS_WITH_JOSE', lws_with_jose)
+lws_config_data.set('LWS_WITH_LEJP', lws_with_lejp)
+lws_config_data.set('LWS_WITH_LIBEV', lws_with_libev)
+lws_config_data.set('LWS_WITH_LIBEVENT', lws_with_libevent)
+lws_config_data.set('LWS_WITH_LIBUV', lws_with_libuv)
+lws_config_data.set('LWS_WITH_LWSAC', lws_with_lwsac)
+lws_config_data.set('LWS_LOGS_TIMESTAMP', lws_logs_timestamp)
+lws_config_data.set('LWS_WITH_MBEDTLS', lws_with_mbedtls)
+lws_config_data.set('LWS_WITH_MINIZ', lws_with_miniz)
+lws_config_data.set('LWS_WITH_NETWORK', lws_with_network)
+lws_config_data.set('LWS_WITH_NO_LOGS', lws_with_no_logs)
+lws_config_data.set('LWS_WITH_CLIENT', lws_with_client)
+lws_config_data.set('LWS_WITHOUT_EXTENSIONS', lws_without_extensions)
+lws_config_data.set('LWS_WITH_SERVER', lws_with_server)
+lws_config_data.set('LWS_WITH_SPAWN', lws_with_spawn)
+lws_config_data.set('LWS_WITH_PEER_LIMITS', lws_with_peer_limits)
+lws_config_data.set('LWS_WITH_PLUGINS', lws_with_plugins)
+lws_config_data.set('LWS_WITH_POLARSSL', lws_with_polarssl)
+lws_config_data.set('LWS_WITH_POLL', lws_with_poll)
+lws_config_data.set('LWS_WITH_RANGES', lws_with_ranges)
+lws_config_data.set('LWS_WITH_SECURE_STREAMS', lws_with_secure_streams)
+lws_config_data.set('LWS_WITH_SECURE_STREAMS_SYS_AUTH_API_AMAZON_COM', lws_with_secure_streams_sys_auth_api_amazon_com)
+lws_config_data.set('LWS_WITH_SECURE_STREAMS_PROXY_API', lws_with_secure_streams_proxy_api)
+lws_config_data.set('LWS_WITH_SELFTESTS', lws_with_selftests)
+lws_config_data.set('LWS_WITH_SEQUENCER', lws_with_sequencer)
+lws_config_data.set('LWS_WITH_SERVER_STATUS', lws_with_server_status)
+lws_config_data.set('LWS_WITH_SMTP', lws_with_smtp)
+lws_config_data.set('LWS_WITH_SOCKS5', lws_with_socks5)
+lws_config_data.set('LWS_WITH_STATEFUL_URLDECODE', lws_with_stateful_urldecode)
+lws_config_data.set('LWS_WITH_STATS', lws_with_stats)
+lws_config_data.set('LWS_WITH_STRUCT_SQLITE3', lws_with_struct_sqlite3)
+lws_config_data.set('LWS_WITH_STRUCT_JSON', lws_with_struct_json)
+lws_config_data.set('LWS_WITH_SQLITE3', lws_with_sqlite3)
+lws_config_data.set('LWS_WITH_SYS_NTPCLIENT', lws_with_sys_ntpclient)
+lws_config_data.set('LWS_WITH_SYS_DHCP_CLIENT', lws_with_sys_dhcp_client)
+lws_config_data.set('LWS_WITH_THREADPOOL', lws_with_threadpool)
+lws_config_data.set('LWS_WITH_TLS', lws_with_tls)
+lws_config_data.set('LWS_WITH_UDP', lws_with_udp)
+lws_config_data.set('LWS_WITH_UNIX_SOCK', lws_with_unix_sock)
+lws_config_data.set('LWS_WITH_ZIP_FOPS', lws_with_zip_fops)
+lws_config_data.set('USE_OLD_CYASSL', use_old_cyassl)
+lws_config_data.set('USE_WOLFSSL', use_wolfssl)
 lws_config_data.set('LWS_SIZEOFPTR_CODE', '')
-lws_config_h = configure_file(input: 'cmake/lws_config.h.in',
-    output: 'lws_config.h',
-    configuration: lws_config_data,
-    format: 'cmake')
+lws_config_h = configure_file(input: 'cmake/lws_config.h.in', output: 'lws_config.h', configuration: lws_config_data, format: 'cmake')
 lws_sources += [lws_config_h]
 
-libwebsockets = library('websockets',
+libwebsockets = library(
+    'websockets',
     lws_sources,
     version: meson.project_version(),
     soversion: lws_library_version_number,
     include_directories: lws_includes,
     c_args: lws_c_args,
-    dependencies: lws_dependencies)
+    dependencies: lws_dependencies,
+)
 
-libwebsockets_dep = declare_dependency(
-    include_directories: lws_includes,
-    link_with: libwebsockets,
-    dependencies: lws_dependencies)
+libwebsockets_dep = declare_dependency(include_directories: lws_includes, link_with: libwebsockets, dependencies: lws_dependencies)

--- a/subprojects/packagefiles/libwebsockets/meson.build
+++ b/subprojects/packagefiles/libwebsockets/meson.build
@@ -1,26 +1,25 @@
-project('libwebsockets', 'c', version: '4.0.13', license: 'MIT')
+project('libwebsockets', 'c', version: '4.0.21', license: 'MIT')
 
 lws_library_version = meson.project_version()
 lws_library_version_major = '4'
 lws_library_version_minor = '0'
-lws_library_version_patch = '13'
+lws_library_version_patch = '21'
 lws_library_version_number = 16
 
 lws_incdirs = []
 lws_dependencies = []
 lws_c_args = []
 
-
 # ToDo: detect platform properly
 esp_platform = false
 ios = false
 apple = false
 mingw = false
-win32 = build_machine.system() == 'win32'
+win32 = build_machine.system() == 'windows'
 unix = build_machine.system() == 'linux'
 
 # Initialize
-lws_max_smp = ''
+lws_max_smp = 0
 lws_with_abstract = false
 lws_build_hash = ''
 lws_builtin_getifaddrs = false
@@ -320,7 +319,12 @@ if win32
     win32_version_data.set('LWS_LIBRARY_VERSION_MINOR', lws_library_version_minor)
     win32_version_data.set('LWS_LIBRARY_VERSION_PATCH', lws_library_version_patch)
     win32_version_data.set('LWS_LIBRARY_PACKAGE', 'libwebsockets')
-    configure_file(input: 'win32port/version.rc.in', output: 'win32port/version.rc', configuration: conf_data, format: 'cmake')
+    configure_file(
+        input: 'win32port/version.rc.in',
+        output: 'version.rc',
+        configuration: win32_version_data,
+        format: 'cmake',
+    )
 endif
 
 # translate old functionality enables to set up ROLE enables so nothing changes
@@ -330,11 +334,7 @@ if lws_with_http2 and lws_without_server
 endif
 
 lws_role_h2 = lws_with_http2
-
-lws_role_cgi = false
-if lws_with_cgi
-    lws_role_cgi = true
-endif
+lws_role_cgi = lws_with_cgi
 
 if not lws_role_ws
     lws_without_extensions = true
@@ -457,7 +457,7 @@ endif
 
 if win32
     lws_max_smp = 1
-    lws_with_threadpool = true
+    lws_with_threadpool = false
 endif
 
 if lws_without_server
@@ -539,6 +539,10 @@ endif
 
 # if you gave LWS_WITH_MINIZ, point to MINIZ here if not found
 # automatically
+
+c_compiler = meson.get_compiler('c')
+
+lws_dependencies += c_compiler.find_library('ws2_32', required: build_machine.system() == 'windows')
 
 zlib_dep = dependency('zlib', required: false)
 lws_dependencies += [zlib_dep]
@@ -626,19 +630,15 @@ else
 endif
 
 # LWS_OPENSSL_SUPPORT deprecated... use LWS_WITH_TLS
-if lws_with_ssl or lws_with_mbedtls
-    lws_openssl_support = true
-    lws_with_tls = true
-endif
+lws_openssl_support = lws_with_ssl or lws_with_mbedtls
+lws_with_tls = lws_with_ssl or lws_with_mbedtls
 
-if lws_without_daemonize or win32
-    lws_no_daemonize = true
-endif
+lws_no_daemonize = lws_without_daemonize or win32
 
 lws_with_ipv6 = lws_ipv6
 lws_with_unix_sock = lws_unix_sock
 
-if '' == lws_max_smp
+if lws_max_smp == 0
     lws_max_smp = 1
 endif
 
@@ -652,38 +652,24 @@ lws_sha1_use_openssl_name = lws_without_builtin_sha1
 
 # checking compiler features
 
-c_compiler = meson.get_compiler('c')
-
-lws_have_malloc_trim = c_compiler.compiles(
-    '''
-    #include <malloc.h>
-    int main(int argc, char **argv) { return malloc_trim(0); }
-    ''',
-)
-
-lws_have_malloc_usable_size = c_compiler.compiles(
-    '''
-    #include <malloc.h>
-    int main(int argc, char **argv) { return (int)malloc_usable_size((void *)0); }
-    ''',
-)
-
+lws_have_malloc_trim = c_compiler.has_function('malloc_trim')
+lws_have_malloc_usable_size = c_compiler.has_function('malloc_usable_size')
 
 lws_have_fork = c_compiler.has_function('fork')
 lws_have_getenv = c_compiler.has_function('getenv')
 lws_have_malloc = c_compiler.has_function('malloc')
 lws_have_memset = c_compiler.has_function('memset')
 lws_have_realloc = c_compiler.has_function('realloc')
-lws_have_socket = c_compiler.has_function('(socket')
+lws_have_socket = c_compiler.has_function('socket')
 lws_have_strerror = c_compiler.has_function('strerror')
 lws_have_vfork = c_compiler.has_function('vfork')
-lws_have_execvpe = c_compiler.has_function('(execvpe')
+lws_have_execvpe = c_compiler.has_function('execvpe')
 lws_have_getifaddrs = c_compiler.has_function('getifaddrs')
 lws_have_snprintf = c_compiler.has_function('snprintf')
 lws_have__snprintf = c_compiler.has_function('_snprintf')
 lws_have__vsnprintf = c_compiler.has_function('_vsnprintf')
-lws_have_getloadavg = c_compiler.has_function('(getloadavg')
-lws_have_atoll = c_compiler.has_function('(atoll')
+lws_have_getloadavg = c_compiler.has_function('getloadavg')
+lws_have_atoll = c_compiler.has_function('atoll')
 lws_have__atoi64 = c_compiler.has_function('_atoi64')
 lws_have__stat32i64 = c_compiler.has_function('_stat32i64')
 lws_have_clock_gettime = c_compiler.has_function('clock_gettime')
@@ -735,21 +721,8 @@ endif
 lws_have_evbackend_linuxaio = false
 lws_have_evbackend_iouring = false
 if lws_with_libev
-    lws_have_evbackend_linuxaio = c_compiler.compiles(
-        '''
-        #include <ev.h>
-        int main(int argc, char **argv) { return EVBACKEND_LINUXAIO; }
-        ''',
-        dependencies: [libev_dep],
-    )
-
-    lws_have_evbackend_iouring = c_compiler.compiles(
-        '''(
-        #include <ev.h>
-        int main(int argc, char **argv) { return EVBACKEND_IOURING; }
-        ''',
-        dependencies: [libev_dep],
-    )
+    lws_have_evbackend_linuxaio = c_compiler.has_header_symbol('ev.h', 'EVBACKEND_LINUXAIO')
+    lws_have_evbackend_iouring = c_compiler.has_header_symbol('ev.h', 'EVBACKEND_IOURING')
 endif
 
 if lws_with_zlib and not lws_with_bundled_zlib
@@ -758,45 +731,22 @@ if lws_with_zlib and not lws_with_bundled_zlib
     else
         lws_have_zlib_h = c_compiler.has_header('zlib.h')
     endif
+else
+    lws_have_zlib_h = false
 endif
 
 # TODO: These can also be tested to see whether they actually work...
 lws_have_working_fork = lws_have_fork
 lws_have_working_vfork = lws_have_vfork
 
-lws_has_intptr_t = c_compiler.compiles(
-    '''
-    #include <stdint.h>
-    int main(void) {
-        intptr_t test = 1;
-        return 0;
-    }''',
-)
+lws_has_intptr_t = c_compiler.has_header_symbol('stdint.h', 'intptr_t')
 
 lws_has_pthread_setname_np = false
 if lws_have_pthread_h
-    lws_has_pthread_setname_np = c_compiler.compiles(
-        '''
-        #define _GNU_SOURCE
-        #include <pthread.h>
-        int main(void) {
-            pthread_t th = 0;
-            pthread_setname_np(th, NULL);
-            return 0;
-        }''',
-    )
+    lws_has_pthread_setname_np = c_compiler.has_header_symbol('pthread.h', 'pthread_setname_np', prefix: '#define _GNU_SOURCE')
 endif
 
-lws_has_getopt_long = c_compiler.compiles(
-    '''
-    #include <stddef.h>
-    #include <getopt.h>
-    int main(void) {
-        void *p = (void *)getopt_long;
-        return p != NULL;
-    }''',
-)
-
+lws_has_getopt_long = c_compiler.has_function('getopt_long')
 varia = ''
 
 lws_have_openssl_ecdh_h = c_compiler.has_header('openssl/ecdh.h', dependencies: [openssl_dep])
@@ -822,18 +772,19 @@ lws_have_rsa_verify_pss_mgf1 = c_compiler.has_function(varia + 'RSA_verify_pss_m
 lws_have_hmac_ctx_new = c_compiler.has_function(varia + 'HMAC_CTX_new', dependencies: [openssl_dep])
 lws_have_ssl_ctx_set_ciphersuites = c_compiler.has_function(varia + 'SSL_CTX_set_ciphersuites', dependencies: [openssl_dep])
 if (lws_with_ssl and not lws_with_mbedtls)
-    lws_have_ssl_extra_chain_certs = c_compiler.compiles(
-        '#include <openssl/ssl.h>\nint main(void) { STACK_OF(X509) *c = NULL; SSL_CTX *ctx = NULL; return (int)SSL_CTX_get_extra_chain_certs_only(ctx, &c); }\n',
-        dependencies: [openssl_dep],
-    )
-    lws_have_evp_md_ctx_free = c_compiler.compiles(
-        '#include <openssl/ssl.h>\nint main(void) { EVP_MD_CTX *md_ctx = NULL; EVP_MD_CTX_free(md_ctx); return 0; }\n',
-        dependencies: [openssl_dep],
-    )
+    lws_have_ssl_extra_chain_certs = c_compiler.has_header_symbol('openssl/ssl.h', 'SSL_CTX_get_extra_chain_certs_only')
+    lws_have_evp_md_ctx_free = c_compiler.has_function(varia + 'EVP_MD_CTX_free', dependencies: [openssl_dep])
     lws_have_ecdsa_sig_set0 = c_compiler.has_function(varia + 'ECDSA_SIG_set0', dependencies: [openssl_dep])
     lws_have_bn_bn2binpad = c_compiler.has_function(varia + 'BN_bn2binpad', dependencies: [openssl_dep])
     lws_have_evp_aes_128_wrap = c_compiler.has_function(varia + 'EVP_aes_128_wrap', dependencies: [openssl_dep])
     lws_have_ec_point_get_affine_coordinates = c_compiler.has_function(varia + 'EC_POINT_get_affine_coordinates', dependencies: [openssl_dep])
+else
+    lws_have_ssl_extra_chain_certs = false
+    lws_have_evp_md_ctx_free = false
+    lws_have_ecdsa_sig_set0 = false
+    lws_have_bn_bn2binpad = false
+    lws_have_evp_aes_128_wrap = false
+    lws_have_ec_point_get_affine_coordinates = false
 endif
 if lws_with_mbedtls
     lws_have_tls_client_method = true
@@ -859,26 +810,22 @@ else
     lws_have_mbedtls_ssl_set_hs_authmode = false
     lws_have_mbedtls_net_init = false
 
-    lws_have_tls_client_method = c_compiler.has_function(varia + 'TLS_client_method')
-    lws_have_tlsv1_2_client_method = c_compiler.has_function(varia + 'TLSv1_2_client_method')
+    lws_have_tls_client_method = c_compiler.has_function(varia + 'TLS_client_method', dependencies: [openssl_dep])
+    lws_have_tlsv1_2_client_method = c_compiler.has_function(varia + 'TLSv1_2_client_method', dependencies: [openssl_dep])
 endif
 
 # ideally we want to use pipe2()
 
-lws_have_pipe2 = c_compiler.compiles('#define _GNU_SOURCE\n#include <unistd.h>\nint main(void) {int fd[2];\n return pipe2(fd, 0);\n}\n')
+lws_have_pipe2 = c_compiler.has_function('pipe2')
 
 # old mbedtls has everything in mbedtls/net.h
 
-lws_have_mbedtls_net_sockets = c_compiler.compiles('#include <mbedtls/net_sockets.h>\nint main(void) { return 0;}\n')
+lws_have_mbedtls_net_sockets = c_compiler.has_header('mbedtls/net_sockets.h')
 
 # tcp keepalive needs this on linux to work practically... but it only exists
 # after kernel 2.6.37
 
-lws_have_tcp_user_timeout = c_compiler.compiles('#include <netinet/tcp.h>\nint main(void) { return TCP_USER_TIMEOUT; }\n')
-
-
-
-lws_includes = include_directories(lws_incdirs)
+lws_have_tcp_user_timeout = c_compiler.has_header_symbol('netinet/tcp.h', 'TCP_USER_TIMEOUT')
 
 lws_sources = [
     'lib/core/alloc.c',
@@ -959,7 +906,11 @@ if lws_with_network
     endif
 
     if lws_with_secure_streams
-        lws_sources += ['lib/secure-streams/secure-streams.c', 'lib/secure-streams/policy.c', 'lib/secure-streams/system/fetch-policy/fetch-policy.c']
+        lws_sources += [
+            'lib/secure-streams/secure-streams.c',
+            'lib/secure-streams/policy.c',
+            'lib/secure-streams/system/fetch-policy/fetch-policy.c',
+        ]
 
         if lws_role_h1
             lws_sources += ['lib/secure-streams/protocols/ss-h1.c']
@@ -978,7 +929,10 @@ if lws_with_network
         endif
 
         if lws_with_secure_streams_proxy_api
-            lws_sources += ['lib/secure-streams/secure-streams-serialize.c', 'lib/secure-streams/secure-streams-client.c']
+            lws_sources += [
+                'lib/secure-streams/secure-streams-serialize.c',
+                'lib/secure-streams/secure-streams-client.c',
+            ]
         endif
 
         if lws_with_secure_streams_proxy_api
@@ -1089,7 +1043,12 @@ if lws_with_struct_sqlite3
 endif
 
 if not lws_without_client
-    lws_sources += ['lib/core-net/connect.c', 'lib/core-net/client.c', 'lib/roles/http/client/client-http.c', 'lib/roles/http/client/client-handshake.c']
+    lws_sources += [
+        'lib/core-net/connect.c',
+        'lib/core-net/client.c',
+        'lib/roles/http/client/client-http.c',
+        'lib/roles/http/client/client-handshake.c',
+    ]
 endif
 
 if not lws_without_server
@@ -1251,7 +1210,12 @@ else
     endif
 
     if lws_with_network
-        lws_sources += ['lib/plat/unix/unix-pipe.c', 'lib/plat/unix/unix-service.c', 'lib/plat/unix/unix-sockets.c', 'lib/plat/unix/unix-fds.c']
+        lws_sources += [
+            'lib/plat/unix/unix-pipe.c',
+            'lib/plat/unix/unix-service.c',
+            'lib/plat/unix/unix-sockets.c',
+            'lib/plat/unix/unix-fds.c',
+        ]
 
         if lws_with_sys_async_dns
             if lws_plat_android
@@ -1377,6 +1341,8 @@ lws_have_visibility = c_compiler.has_argument('-fvisibility=hidden')
 if lws_have_visibility
     lws_c_args += ['-fvisibility=hidden']
 endif
+
+lws_includes = include_directories(lws_incdirs)
 
 lws_config_private_data = configuration_data()
 lws_config_private_data.set('LWS_HAVE_DLFCN_H', lws_have_dlfcn_h)
@@ -1579,7 +1545,12 @@ lws_config_data.set('LWS_WITH_ZIP_FOPS', lws_with_zip_fops)
 lws_config_data.set('USE_OLD_CYASSL', use_old_cyassl)
 lws_config_data.set('USE_WOLFSSL', use_wolfssl)
 lws_config_data.set('LWS_SIZEOFPTR_CODE', '')
-lws_config_h = configure_file(input: 'cmake/lws_config.h.in', output: 'lws_config.h', configuration: lws_config_data, format: 'cmake')
+lws_config_h = configure_file(
+    input: 'cmake/lws_config.h.in',
+    output: 'lws_config.h',
+    configuration: lws_config_data,
+    format: 'cmake',
+)
 lws_sources += [lws_config_h]
 
 libwebsockets = library(
@@ -1592,4 +1563,8 @@ libwebsockets = library(
     dependencies: lws_dependencies,
 )
 
-libwebsockets_dep = declare_dependency(include_directories: lws_includes, link_with: libwebsockets, dependencies: lws_dependencies)
+libwebsockets_dep = declare_dependency(
+    include_directories: lws_includes,
+    link_with: libwebsockets,
+    dependencies: lws_dependencies,
+)


### PR DESCRIPTION
Ran meson.build file through muon's fmt_unstable to get rid of
problematic tab usage in meson.build.

Signed-off-by: Rosen Penev <rosenp@gmail.com>