### PR TITLE
ci: Run meson compile with the -v option

### DIFF
--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -262,7 +262,7 @@ class TestReleases(unittest.TestCase):
             print(log_file.read_text(encoding='utf-8'))
             print('::endgroup::')
             raise
-        subprocess.check_call(['meson', 'compile', '-C', builddir])
+        subprocess.check_call(['meson', 'compile', '-C', builddir, '-v'])
         try:
             subprocess.check_call(['meson', 'test', '-C', builddir, '--suite', name, '--print-errorlogs'])
         except subprocess.CalledProcessError:


### PR DESCRIPTION
Having the executed commands reported in the CI logs allows to more easily inspect the actual compiler flags used. This is especially useful when a local build environment is not available.