### PR TITLE
Add CMock

### DIFF
--- a/subprojects/cmock.wrap
+++ b/subprojects/cmock.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = CMock-2.5.3
+source_url = https://github.com/ThrowTheSwitch/CMock/archive/refs/tags/v2.5.3.tar.gz
+source_filename = CMock-2.5.3.tar.gz
+source_hash = d30724405b527f2b1d2894b27a1600af3ccb4aad12e63e48ba4f0ea8ae88fe9c
+
+[provide]
+cmock = cmock_dep
+


### PR DESCRIPTION
[CMock](https://github.com/ThrowTheSwitch/CMock) is a complementary library to the [Unity](https://github.com/ThrowTheSwitch/Unity) unit test framework, which is already [included](https://github.com/mesonbuild/wrapdb/blob/master/subprojects/unity.wrap) in wrapdb. CMock has its own defined [meson.build](https://github.com/ThrowTheSwitch/CMock/blob/master/meson.build) file so it should be a simple addition.