### PR TITLE
Add CException

### DIFF
--- a/subprojects/cexception.wrap
+++ b/subprojects/cexception.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = CException-1.3.3
+source_url = https://github.com/ThrowTheSwitch/CException/archive/refs/tags/v1.3.3.tar.gz
+source_filename = CException-1.3.3.tar.gz
+source_hash = 4c8330197e42f2ca4cbf45660e10b520ce5273ca15e8fc3a90af4cecc3b02b5c
+
+[provide]
+cexception = cexception_dep


### PR DESCRIPTION
[CException](https://github.com/ThrowTheSwitch/CException) is a complementary library to the [Unity](https://github.com/ThrowTheSwitch/Unity) unit test framework, which is already [included](https://github.com/mesonbuild/wrapdb/blob/master/subprojects/unity.wrap) in wrapdb. CException has its own defined [meson.build](https://github.com/ThrowTheSwitch/CException/blob/master/meson.build) file so it should be a simple addition.