### PR TITLE
Add proxy-libintl wrap

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1323,6 +1323,14 @@
       "1.3.0-1"
     ]
   },
+  "proxy-libintl": {
+    "versions": [
+      "0.4-1"
+    ],
+    "dependency_names": [
+      "intl"
+    ]
+  },
   "pugixml": {
     "dependency_names": [
       "pugixml"

--- a/subprojects/proxy-libintl.wrap
+++ b/subprojects/proxy-libintl.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory=proxy-libintl-0.4
+source_url=https://github.com/frida/proxy-libintl/archive/refs/tags/0.4.tar.gz
+source_filename=proxy-libintl-0.4.tar.gz
+source_hash=13ef3eea0a3bc0df55293be368dfbcff5a8dd5f4759280f28e030d1494a5dffb
+
+[provide]
+intl = intl_dep


### PR DESCRIPTION
This is a dependency of GLib and can be used as fallback for gettext on
all platforms.