### PR TITLE
actions: update to 22.04

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   Ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
-latest is actually 20.04. 22.04 should be better as it has a newer GCC.

Signed-off-by: Rosen Penev <rosenp@gmail.com>