### PR TITLE
Add concurrentqueue 1.0.3 support

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -164,6 +164,14 @@
       "1.1.2-1"
     ]
   },
+  "concurrentqueue": {
+    "dependency_names": [
+      "concurrentqueue"
+    ],
+    "versions": [
+      "1.0.3-1"
+    ]
+  },
   "cpp-httplib": {
     "dependency_names": [
       "cpp-httplib"

--- a/subprojects/concurrentqueue.wrap
+++ b/subprojects/concurrentqueue.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = concurrentqueue-1.0.3
+source_url = https://github.com/cameron314/concurrentqueue/archive/refs/tags/v1.0.3.tar.gz
+source_filename = concurrentqueue-1.0.3.tar.xz
+source_hash = eb37336bf9ae59aca7b954db3350d9b30d1cab24b96c7676f36040aa76e915e8
+patch_directory = concurrentqueue
+
+[provide]
+
+concurrentqueue = concurrentqueue_dep

--- a/subprojects/concurrentqueue.wrap
+++ b/subprojects/concurrentqueue.wrap
@@ -6,5 +6,4 @@ source_hash = eb37336bf9ae59aca7b954db3350d9b30d1cab24b96c7676f36040aa76e915e8
 patch_directory = concurrentqueue
 
 [provide]
-
 concurrentqueue = concurrentqueue_dep

--- a/subprojects/packagefiles/concurrentqueue/meson.build
+++ b/subprojects/packagefiles/concurrentqueue/meson.build
@@ -1,0 +1,15 @@
+project(
+    # moodycamel::ConcurrentQueue
+    'concurrentqueue',
+    ['cpp'],
+    # Dual licensing
+    license: ['symplified-BSD', 'Boost 1.0'],
+    version: '1.0.3',
+)
+
+concurrentqueue_dep = declare_dependency(
+
+    # it should be better if it was in a subdirectory
+    # like moodycamel/ConcurrentQueue
+    include_directories: [include_directories('.')],
+)


### PR DESCRIPTION
adds support for `concurrent queue 1.0.3` (#232 )
this library is itself a header only library