### PR TITLE
Fix / General fallback on find_library() for static/shared mismatch

### DIFF
--- a/subprojects/packagefiles/openssl/meson.build
+++ b/subprojects/packagefiles/openssl/meson.build
@@ -306,19 +306,16 @@ else
 endif
 
 foreach library: openssl_libraries
-  # MSVC fails with "ERROR: C static library 'ws2_32' not found" when `static` is specified at all
-  if compiler.get_id() == 'msvc'
-    dependencies += [
-      compiler.find_library(library),
-    ]
-  else
-    dependencies += [
-      compiler.find_library(
+  single_dep = compiler.find_library(
         library,
         static: get_option('default_library') == 'static',
-      ),
-    ]
+        required : false,
+      )
+  if not single_dep.found()
+    # MSVC and mingw fail with "ERROR: C ... library 'ws2_32' not found" when `static` is specified at all
+    single_dep = compiler.find_library(library)
   endif
+  dependencies += [ single_dep ]
 endforeach
 
 # We may need to add some defines for static builds


### PR DESCRIPTION
# Description

Add a general fallback on `compiler.find_library()` when the wanted `static` preference is not found. 

The `"ERROR: C ... library 'ws2_32' not found"` does not only happen for MSVC compilers, but also when cross-compiling with MinGW.

The `compiler.get_id()` method does not work for MinGW, because it reports as generic 'gcc'. No other `compiler` property was found to make a clear distinction between Windows/Non-Windows. 

# Justification

Successfully cross-compile OpenSSL for Windows using MinGW.

# Caveats

The fallback now also happens on compilers other than MSVC. If strict static/shared preference enforcement is needed, another way must be found. I would need guidance to make it so. 
