### PR TITLE
miniz: update to 2.2.0

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1151,7 +1151,11 @@
     ]
   },
   "miniz": {
+    "dependency_names": [
+      "miniz"
+    ],
     "versions": [
+      "2.2.0-1",
       "2.1.0-2",
       "2.1.0-1"
     ]

--- a/subprojects/miniz.wrap
+++ b/subprojects/miniz.wrap
@@ -1,8 +1,10 @@
 [wrap-file]
-directory = miniz-2.1.0
+directory = miniz-2.2.0
 lead_directory_missing = true
-source_url = https://github.com/richgel999/miniz/releases/download/2.1.0/miniz-2.1.0.zip
-source_filename = miniz-2.1.0.zip
-source_hash = d133132721ad5efbcda2507699d44c54b0da5e31379e4ff049d78d6b1a571f0d
+source_url = https://github.com/richgel999/miniz/releases/download/2.2.0/miniz-2.2.0.zip
+source_filename = miniz-2.2.0.zip
+source_hash = e4aa5078999c7f7466fa6b8f9848e39ddfff9a4bafc50215764aebe1f13b3841
 patch_directory = miniz
 
+[provide]
+miniz = miniz_dep

--- a/subprojects/packagefiles/miniz/meson.build
+++ b/subprojects/packagefiles/miniz/meson.build
@@ -1,4 +1,4 @@
-project('miniz', 'c', license : 'mit', version : '2.1.0')
+project('miniz', 'c', license : 'mit', version : '2.2.0')
 
 miniz_inc = include_directories('.')
 


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Should probably be replaced with miniz-ng honestly.