### PR TITLE
libglvnd: add

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -216,6 +216,17 @@
       "windows": false
     }
   },
+  "libglvnd": {
+    "_comment": "Upstream explicitly only supports Unix-like OSes excluding macOS",
+    "build_on": {
+      "darwin": false,
+      "windows": false
+    },
+    "_comment": "GLX tests require an X server, which CI does not provide.",
+    "build_options": [
+      "libglvnd:glx=disabled"
+    ]
+  },
   "libjpeg-turbo": {
     "brew_packages": [
       "nasm"

--- a/releases.json
+++ b/releases.json
@@ -1048,6 +1048,17 @@
       "2.2.2-1"
     ]
   },
+  "libglvnd": {
+    "dependency_names": [
+      "egl",
+      "opengl",
+      "glesv1",
+      "glesv2"
+    ],
+    "versions": [
+      "1.6.0-1"
+    ]
+  },
   "libgpiod": {
     "versions": [
       "1.6.3-1"

--- a/subprojects/libglvnd.wrap
+++ b/subprojects/libglvnd.wrap
@@ -1,0 +1,11 @@
+[wrap-file]
+directory = libglvnd-v1.6.0
+source_url = https://gitlab.freedesktop.org/glvnd/libglvnd/-/archive/v1.6.0/libglvnd-v1.6.0.tar.bz2
+source_filename = libglvnd-1.6.0.tar.bz2
+source_hash = 2b22a72f9f35fe9ba630c2971f6cee6eefc0c8317e0eecc3c76134ed5f00bd8a
+
+[provide]
+egl = dep_egl
+opengl = dep_opengl
+glesv1 = dep_glesv1
+glesv2 = dep_glesv2


### PR DESCRIPTION
Upstream has a meson build. No need to write one.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

tests require an X11 server. Can't figure out how to disable them. Hmmm...