### PR TITLE
libliftoff: add new wrap

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -228,6 +228,16 @@
       "windows": false
     }
   },
+  "libliftoff": {
+    "_comment": "- depends on libdrm",
+    "build_on": {
+      "darwin": false,
+      "windows": false
+    },
+    "debian_packages": [
+      "libpciaccess-dev"
+    ]
+  },
   "libnpupnp": {
     "brew_packages": [
       "libmicrohttpd"

--- a/releases.json
+++ b/releases.json
@@ -917,6 +917,14 @@
       "1.10-1"
     ]
   },
+  "libliftoff": {
+    "dependency_names": [
+      "libliftoff"
+    ],
+    "versions": [
+      "0.3.0-1"
+    ]
+  },
   "liblzma": {
     "dependency_names": [
       "liblzma"

--- a/subprojects/libliftoff.wrap
+++ b/subprojects/libliftoff.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = libliftoff-v0.3.0
+source_url = https://gitlab.freedesktop.org/emersion/libliftoff/-/archive/v0.3.0/libliftoff-v0.3.0.tar.gz
+source_filename = libliftoff-v0.3.0.tar.gz
+source_hash = ef531d4913903da3bdc5fe96324abd080aded89a0d4b7258c1d1095c1a4b7925
+
+[provide]
+libliftoff = liftoff


### PR DESCRIPTION
Depends only on libdrm, which is also available as wrap.