### PR TITLE
meson: update minimum version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('wrapdb',
-  meson_version: '>=0.55.0',
+  meson_version: '>=0.58.0',
   default_options: ['cpp_std=c++17'],
 )
 


### PR DESCRIPTION
needed for global_build_root.

Signed-off-by: Rosen Penev <rosenp@gmail.com>