### PR TITLE
SDL2: fixes

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -408,9 +408,7 @@
       "libxt-dev",
       "libxv-dev",
       "libxxf86vm-dev",
-      "libgles2-mesa-dev",
-      "pkg-config",
-      "wayland-protocols"
+      "libgles2-mesa-dev"
     ]
   },
   "sds": {

--- a/ci_config.json
+++ b/ci_config.json
@@ -40,8 +40,7 @@
     "sdl2_image",
     "tinyxml2",
     "unit-system",
-    "zstd",
-    "sdl2"
+    "zstd"
   ],
   "cexception": {
     "build_options": [
@@ -409,6 +408,14 @@
       "libxv-dev",
       "libxxf86vm-dev",
       "libgles2-mesa-dev"
+    ],
+    "brew_packages": [
+      "libx11",
+      "libxcursor",
+      "libext",
+      "libxi",
+      "libxkbcommon",
+      "libxrandr"
     ]
   },
   "sds": {

--- a/subprojects/packagefiles/sdl2/meson.build
+++ b/subprojects/packagefiles/sdl2/meson.build
@@ -153,6 +153,9 @@ gl_req_hack = opt_video_opengl.enabled() ? false : opt_video_opengl
 gles2_req_hack = opt_video_openglesv2.enabled() ? false : opt_video_openglesv2
 
 gl_dep = dependency('gl', required : opt_video_opengl)
+if not gl_dep.found()
+    gl_dep = dependency('opengl', required : opt_video_opengl)
+endif
 
 glesv2_dep = dependency('glesv2', required : gles2_req_hack)
 if not glesv2_dep.found() and not opt_video_openglesv2.disabled()
@@ -1033,12 +1036,14 @@ c_sources = []
 cxx_sources = []
 objc_sources = []
 main_sources = []
+test_c_sources = []
 
 subdir('include')
 subdir('src')
 subdir('wayland-protocols')
 
 all_sources = [c_sources]
+test_all_source = [test_c_sources]
 
 if platform_is_darwin
     add_languages('objc')
@@ -1051,17 +1056,6 @@ if platform_is_winrt or platform_is_haiku
 endif
 
 do_install = get_option('default_library') != 'static' or not meson.is_subproject()
-
-sdl2 = library('sdl2',
-    all_sources,
-    include_directories : core_inc,
-    c_args : core_args,
-    link_args : core_ldflags,
-    dependencies : [core_deps, extra_deps],
-    override_options : ['c_std=none'],
-    install : do_install,
-)
-
 
 main_link_with = []
 main_link_whole = []
@@ -1087,10 +1081,20 @@ sdl2main_dep = declare_dependency(
     compile_args : main_c_args,
 )
 
-deps = []
+deps = [core_deps, extra_deps]
 if cc.get_id() == 'msvc' and get_option('with_main')
     deps += sdl2main_dep
 endif
+
+sdl2 = library('sdl2',
+    all_sources,
+    include_directories : core_inc,
+    c_args : core_args,
+    link_args : core_ldflags,
+    dependencies : deps,
+    override_options : ['c_std=none'],
+    install : do_install,
+)
 
 sdl2_dep = declare_dependency(
     link_with : sdl2,
@@ -1105,6 +1109,6 @@ endif
 
 # MSVC does not correctly resolve the symbols when linking dynamically
 # works fine when linking statically or MinGW
-if get_option('test') and (cc.get_id() != 'msvc' or get_option('default_library') == 'static')
+if get_option('test')
     subdir('test')
 endif

--- a/subprojects/packagefiles/sdl2/meson.build
+++ b/subprojects/packagefiles/sdl2/meson.build
@@ -487,6 +487,11 @@ check_headers = [
     'sys/types.h',
     'wchar.h',
 
+    'usbhid.h',
+    'libusbhid.h',
+    'usb.h',
+    'libusb.h',
+
     'd3d.h',
     'd3d11.h',
     'd3d12.h',
@@ -730,6 +735,14 @@ if cdata.get('HAVE_FCITX', 0) == 1 or cdata.get('HAVE_IBUS_IBUS_H', 0) == 1
     cdata.set('SDL_USE_IME', 1)
 endif
 
+if platform_is_freebsd and cdata.get('HAVE_INOTIFY', 0) != 1
+    inotify_dep = dependency('libinotify', required : false)
+    if inotify_dep.found()
+        cdata.set('HAVE_INOTIFY', 1)
+        extra_deps += inotify_dep
+    endif
+endif
+
 sys_default_audio_driver = ['dummy']
 sys_default_filesystem = ['dummy']
 sys_default_haptic = ['dummy']
@@ -822,6 +835,11 @@ elif platform_is_linux
     sys_input = ['linuxev', 'linuxkd']
     sys_joystick = ['linux']
     sys_power = ['linux']
+elif platform_is_bsd
+    sys_joystick = ['bsd']
+    if platform_is_netbsd
+        sys_audio_driver = ['netbsd']
+    endif
 elif platform_is_windows
     sys_audio_driver = ['wasapi']  # XXX: winmm needed?
     sys_filesystem = ['windows']

--- a/subprojects/packagefiles/sdl2/src/test/meson.build
+++ b/subprojects/packagefiles/sdl2/src/test/meson.build
@@ -1,4 +1,4 @@
-c_sources += files(
+test_c_sources += files(
     'SDL_test_assert.c',
     'SDL_test_common.c',
     'SDL_test_compare.c',

--- a/subprojects/packagefiles/sdl2/test/meson.build
+++ b/subprojects/packagefiles/sdl2/test/meson.build
@@ -1,3 +1,26 @@
+test_deps = []
+
+if cdata.get('HAVE_LIBUNWIND_H', 0) == 1
+    test_deps += dependency('libunwind', required : false)
+    test_deps += dependency('libunwind-generic', required : false)
+endif
+
+sdl2_test = library('sdl2',
+    test_all_source,
+    include_directories : core_inc,
+    c_args : core_args,
+    link_args : core_ldflags,
+    dependencies : [deps, test_deps],
+    override_options : ['c_std=none'],
+    objects: sdl2.extract_all_objects(recursive: true),
+)
+
+sdl2_test_dep = declare_dependency(
+    link_with : sdl2_test,
+    dependencies : deps,
+    include_directories : core_inc,
+    compile_args : c_args,
+)
 
 tests = [
     { 'name': 'checkkeys',          'sources': ['checkkeys.c']},
@@ -74,7 +97,7 @@ tests = [
 ]
 
 foreach test_entry : tests
-    test_executable = executable(test_entry['name'], test_entry['sources'], dependencies: [sdl2_dep])
+    test_executable = executable(test_entry['name'], test_entry['sources'], dependencies: sdl2_test_dep)
     if get_option('run_test')
         test(test_entry['name'], test_executable, is_parallel: false)
     endif


### PR DESCRIPTION
- define a test library to be used when compiling the tests (talked about in #574)
- Fix dependencies not outwardly being defined (reported in #521)