### PR TITLE
freetype: Provide both freetype and freetype2 names

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -421,9 +421,11 @@
   },
   "freetype2": {
     "dependency_names": [
-      "freetype2"
+      "freetype2",
+      "freetype"
     ],
     "versions": [
+      "2.12.1-2",
       "2.12.1-1",
       "2.12.0-1",
       "2.11.1-1",

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -6,3 +6,4 @@ source_hash = 4766f20157cc4cf0cd292f80bf917f92d1c439b243ac3018debf6b9140c41a7f
 
 [provide]
 freetype2 = freetype_dep
+freetype = freetype_dep


### PR DESCRIPTION
Harfbuzz lookup the freetype2 dependency like that:
```
freetype_dep = dependency(cpp.get_argument_syntax() == 'msvc' ?
'freetype' : 'freetype2', ...)
```
The reason is "freetype" is the CMake name. This causes meson to not lookup for freetype2 fallback when using MSVC.