### PR TITLE
sanity checks: extend pattern matching for not found dependencies

### DIFF
--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -332,7 +332,7 @@ class TestReleases(unittest.TestCase):
                 if 'unsupported' in error or 'not supported' in error or 'does not support' in error:
                     print('unsupported, as expected')
                     return
-                elif 'ERROR: Dependency ' in error or 'ERROR: Program ' in error:
+                elif any('ERROR: '+x in error for x in {'Dependency', 'Program', 'Pkg-config binary', 'CMake binary'}):
                     if 'not found' in error:
                         print('cannot verify in wrapdb due to missing dependency')
                         return


### PR DESCRIPTION
pkg-config and cmake don't error out with Dependency not found, they have custom messages about the tool lookup. Catch these too.

Fixes #678