### PR TITLE
cmark-gfm: add

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -168,6 +168,14 @@
       "1.9.1-1"
     ]
   },
+  "cmark-gfm": {
+    "dependency_names": [
+      "libcmark-gfm"
+    ],
+    "versions": [
+      "0.29.0.gfm.6-1"
+    ]
+  },
   "cmock": {
     "dependency_names": [
       "cmock"

--- a/subprojects/cmark-gfm.wrap
+++ b/subprojects/cmark-gfm.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = cmark-gfm-0.29.0.gfm.6
+source_url = https://github.com/github/cmark-gfm/archive/refs/tags/0.29.0.gfm.6.tar.gz
+source_filename = cmark-gfm-0.29.0.gfm.6.tar.gz
+source_hash = b17d86164c0822b5db3818780b44cb130ff30e9c6ec6a64f199b6d142684dba0
+patch_directory = cmark-gfm
+
+[provide]
+libcmark-gfm = cmark_gfm_dep

--- a/subprojects/packagefiles/cmark-gfm/cmark-gfm-extensions_export.h.meson
+++ b/subprojects/packagefiles/cmark-gfm/cmark-gfm-extensions_export.h.meson
@@ -1,0 +1,38 @@
+#ifndef CMARK_GFM_EXTENSIONS_EXPORT_H
+#define CMARK_GFM_EXTENSIONS_EXPORT_H
+
+/* Is this an exclusively static build */
+#if @CMARK_GFM_STATIC_DEFINE@ && ! defined CMARK_GFM_STATIC_DEFINE
+#  define CMARK_GFM_STATIC_DEFINE
+#endif
+
+/*
+ * Here is the complicated part. Windows is special -- you cannot just define
+ * entry points unconditionally.
+ * */
+#if defined _WIN32 || defined __CYGWIN__
+   /* When building static libraries, avoid marking public ones */
+#  if defined CMARK_GFM_STATIC_DEFINE
+#    define CMARK_GFM_EXTENSIONS_EXPORT
+   /* We are building this library */
+#  elif defined libcmark_gfm_EXPORTS
+#    define CMARK_GFM_EXTENSIONS_EXPORT __declspec(dllexport)
+   /* We are using this library */
+#  else
+#    define CMARK_GFM_EXTENSIONS_EXPORT __declspec(dllimport)
+#  endif
+
+/* On to the easy part. GCC and lookalikes such as clang just work */
+#elif defined __GNUC__ && __GNUC__ >= 4
+#  define CMARK_GFM_EXTENSIONS_EXPORT __attribute__((visibility("default")))
+
+/* Older solaris support, why not */
+#elif defined __SUNPRO_C && __SUNPRO_C >= 0x550
+#  define CMARK_GFM_EXTENSIONS_EXPORT __global
+
+/* All else failed, and we don't know about this compiler. Be conservative. */
+#else
+#  define CMARK_GFM_EXTENSIONS_EXPORT
+#endif
+
+#endif /* CMARK_GFM_EXTENSIONS_EXPORT_H */

--- a/subprojects/packagefiles/cmark-gfm/cmark-gfm_export.h.meson
+++ b/subprojects/packagefiles/cmark-gfm/cmark-gfm_export.h.meson
@@ -1,0 +1,38 @@
+#ifndef CMARK_GFM_EXPORT_H
+#define CMARK_GFM_EXPORT_H
+
+/* Is this an exclusively static build */
+#if @CMARK_GFM_STATIC_DEFINE@ && ! defined CMARK_GFM_STATIC_DEFINE
+#  define CMARK_GFM_STATIC_DEFINE
+#endif
+
+/*
+ * Here is the complicated part. Windows is special -- you cannot just define
+ * entry points unconditionally.
+ * */
+#if defined _WIN32 || defined __CYGWIN__
+   /* When building static libraries, avoid marking public ones */
+#  if defined CMARK_GFM_STATIC_DEFINE
+#    define CMARK_GFM_EXPORT
+   /* We are building this library */
+#  elif defined libcmark_gfm_EXPORTS
+#    define CMARK_GFM_EXPORT __declspec(dllexport)
+   /* We are using this library */
+#  else
+#    define CMARK_GFM_EXPORT __declspec(dllimport)
+#  endif
+
+/* On to the easy part. GCC and lookalikes such as clang just work */
+#elif defined __GNUC__ && __GNUC__ >= 4
+#  define CMARK_GFM_EXPORT __attribute__((visibility("default")))
+
+/* Older solaris support, why not */
+#elif defined __SUNPRO_C && __SUNPRO_C >= 0x550
+#  define CMARK_GFM_EXPORT __global
+
+/* All else failed, and we don't know about this compiler. Be conservative. */
+#else
+#  define CMARK_GFM_EXPORT
+#endif
+
+#endif /* CMARK_GFM_EXPORT_H */

--- a/subprojects/packagefiles/cmark-gfm/meson.build
+++ b/subprojects/packagefiles/cmark-gfm/meson.build
@@ -1,0 +1,141 @@
+project(
+    'cmark-gfm',
+    'c',
+    version: '0.29.0.gfm.6',
+    default_options: ['warning_level=3'],
+    meson_version: '>=0.49.0',
+    license: 'BSD-2-Clause',
+)
+
+cc = meson.get_compiler('c')
+has_stdbool_header = cc.has_header('stdbool.h')
+has_builtin_expect_code = 'int main() { __builtin_expect(0,0); return 0; }'
+has_builtin_expect = cc.links(
+    has_builtin_expect_code,
+    name: 'has __builtin_expect',
+)
+has_attribute_code = '''
+  int f(void) __attribute__ (());
+  int main() { return 0; }
+'''
+has_attribute = cc.compiles(has_attribute_code, name: 'has __attribute__')
+
+cdata = configuration_data(
+    {
+        'HAVE_STDBOOL_H': has_stdbool_header,
+        'HAVE___BUILTIN_EXPECT': has_builtin_expect,
+        'HAVE___ATTRIBUTE__': has_attribute,
+    },
+)
+
+configure_file(
+    format: 'cmake@',
+    input: 'src/config.h.in',
+    output: 'config.h',
+    configuration: cdata,
+)
+
+varr = meson.project_version().split('.')
+vdata = configuration_data(
+    {
+        'PROJECT_VERSION_MAJOR': varr[0],
+        'PROJECT_VERSION_MINOR': varr[1],
+        'PROJECT_VERSION_PATCH': varr[2],
+        'PROJECT_VERSION_GFM': varr[4],
+    },
+)
+
+configure_file(
+    format: 'cmake@',
+    input: 'src/cmark-gfm_version.h.in',
+    output: 'cmark-gfm_version.h',
+    configuration: vdata,
+)
+
+edata = configuration_data(
+    {
+        'CMARK_GFM_STATIC_DEFINE': get_option('default_library') == 'static',
+    },
+)
+
+configure_file(
+    input: 'cmark-gfm_export.h.meson',
+    output: 'cmark-gfm_export.h',
+    configuration: edata,
+)
+
+configure_file(
+    input: 'cmark-gfm-extensions_export.h.meson',
+    output: 'cmark-gfm-extensions_export.h',
+    configuration: edata,
+)
+
+# Required to avoid linker warnings on Windows.
+add_project_arguments('-Dlibcmark_gfm_EXPORTS', language: 'c')
+
+cmark_gfm_src = files(
+    'src/arena.c',
+    'src/blocks.c',
+    'src/buffer.c',
+    'src/cmark.c',
+    'src/cmark_ctype.c',
+    'src/commonmark.c',
+    'src/footnotes.c',
+    'src/houdini_href_e.c',
+    'src/houdini_html_e.c',
+    'src/houdini_html_u.c',
+    'src/html.c',
+    'src/inlines.c',
+    'src/iterator.c',
+    'src/latex.c',
+    'src/linked_list.c',
+    'src/man.c',
+    'src/map.c',
+    'src/node.c',
+    'src/plaintext.c',
+    'src/plugin.c',
+    'src/references.c',
+    'src/registry.c',
+    'src/render.c',
+    'src/scanners.c',
+    'src/syntax_extension.c',
+    'src/utf8.c',
+    'src/xml.c',
+)
+
+cmark_gfm_extensions_src = files(
+    'extensions/autolink.c',
+    'extensions/core-extensions.c',
+    'extensions/ext_scanners.c',
+    'extensions/ext_scanners.h',
+    'extensions/strikethrough.c',
+    'extensions/table.c',
+    'extensions/tagfilter.c',
+    'extensions/tasklist.c',
+)
+
+# cmark-gfm has many unused parameter warnings, so we disable that warning
+# on compilers that support it.
+add_project_arguments(
+    cc.get_supported_arguments('-Wno-unused-parameter'),
+    language: 'c',
+)
+
+includes = include_directories('.', 'src', 'extensions')
+cmark_gfm_lib = library(
+    'cmark-gfm',
+    cmark_gfm_src,
+    include_directories: includes,
+)
+
+cmark_gfm_extensions_lib = library(
+    'cmark-gfm-extensions',
+    cmark_gfm_extensions_src,
+    include_directories: includes,
+    link_with: cmark_gfm_lib,
+)
+
+cmark_gfm_dep = declare_dependency(
+    link_with: [cmark_gfm_lib, cmark_gfm_extensions_lib],
+    include_directories: includes,
+)


### PR DESCRIPTION
Per @eli-schwartz's suggestion in https://github.com/hdoc/hdoc/pull/25, we'd like to contribute a Meson wrap for the [cmark-gfm](https://github.com/github/cmark-gfm) package.

This is a C library that implements parsing of Markdown files, and includes some extensions that GitHub (the company) has made. It's built using CMake, and this PR adds Meson support as a wrap.