### PR TITLE
sanity_checks: Pass meson_env to compile command too

### DIFF
--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -337,7 +337,7 @@ class TestReleases(unittest.TestCase):
                         print('cannot verify in wrapdb due to missing dependency')
                         return
             raise Exception(f'Wrap {name} failed to configure due to bugs in the wrap, rather than due to being unsupported')
-        subprocess.check_call(['meson', 'compile', '-C', builddir])
+        subprocess.check_call(['meson', 'compile', '-C', builddir], env=meson_env)
         try:
             subprocess.check_call(['meson', 'test', '-C', builddir, '--suite', name, '--print-errorlogs'])
         except subprocess.CalledProcessError:


### PR DESCRIPTION
Otherwise ninja won't find nasm.