### PR TITLE
Add nowide

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -333,6 +333,11 @@
       "mpdecimal:tests=true"
     ]
   },
+  "nowide": {
+    "build_options": [
+      "nowide:tests=true"
+    ]
+  },
   "openh264": {
     "brew_packages": [
       "nasm"

--- a/releases.json
+++ b/releases.json
@@ -1602,6 +1602,14 @@
       "1.3.0-1"
     ]
   },
+  "nowide": {
+    "dependency_names": [
+      "nowide"
+    ],
+    "versions": [
+      "11.2.0-1"
+    ]
+  },
   "ogg": {
     "dependency_names": [
       "ogg"

--- a/subprojects/nowide.wrap
+++ b/subprojects/nowide.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = nowide_standalone_v11.2.0
+source_url = https://github.com/boostorg/nowide/releases/download/v11.2.0/nowide_standalone_v11.2.0.tar.gz
+source_filename = nowide_standalone_v11.2.0.tar.gz
+source_hash = 1869d176a8af389e4f7416f42bdd15d6a5db3c6e4ae77269ecb071a232304e1d
+patch_directory = nowide
+
+[provide]
+nowide = nowide_dep

--- a/subprojects/packagefiles/nowide/meson.build
+++ b/subprojects/packagefiles/nowide/meson.build
@@ -20,10 +20,14 @@ subdir('src')  # fills in 'sources'
 
 includes = include_directories('include')
 
+install_subdir('include/nowide', install_dir: get_option('includedir'))
+
 nowide_lib = library(
     'nowide',
     sources,
     include_directories: includes,
+    version: meson.project_version(),
+    install: true
 )
 
 nowide_dep = declare_dependency(

--- a/subprojects/packagefiles/nowide/meson.build
+++ b/subprojects/packagefiles/nowide/meson.build
@@ -4,7 +4,7 @@ project(
     version: '11.2.0',
     license: 'BSL-1.0',
     default_options : ['cpp_std=c++14'],
-    meson_version : '>=0.37.0',
+    meson_version : '>=0.53.0',
 )
 
 compile_args = []
@@ -31,3 +31,7 @@ nowide_dep = declare_dependency(
     include_directories: includes,
     link_with: nowide_lib,
 )
+
+if get_option('tests')
+    subdir('test')
+endif

--- a/subprojects/packagefiles/nowide/meson.build
+++ b/subprojects/packagefiles/nowide/meson.build
@@ -1,0 +1,33 @@
+project(
+    'nowide',
+    'cpp',
+    version: '11.2.0',
+    license: 'BSL-1.0',
+    default_options : ['cpp_std=c++14'],
+    meson_version : '>=0.37.0',
+)
+
+compile_args = []
+
+if get_option('default_library') != 'static'
+    add_project_arguments('-DNOWIDE_DYN_LINK', language: 'cpp')
+    compile_args += ['-DNOWIDE_DYN_LINK']
+endif
+
+sources = []
+
+subdir('src')  # fills in 'sources'
+
+includes = include_directories('include')
+
+nowide_lib = library(
+    'nowide',
+    sources,
+    include_directories: includes,
+)
+
+nowide_dep = declare_dependency(
+    compile_args: compile_args,
+    include_directories: includes,
+    link_with: nowide_lib,
+)

--- a/subprojects/packagefiles/nowide/meson_options.txt
+++ b/subprojects/packagefiles/nowide/meson_options.txt
@@ -1,0 +1,1 @@
+option('tests', type : 'boolean', value : false)

--- a/subprojects/packagefiles/nowide/src/meson.build
+++ b/subprojects/packagefiles/nowide/src/meson.build
@@ -1,0 +1,8 @@
+sources += files(
+    'console_buffer.cpp',
+    'cstdio.cpp',
+    'cstdlib.cpp',
+    'filebuf.cpp',
+    'iostream.cpp',
+    'stat.cpp',
+)

--- a/subprojects/packagefiles/nowide/test/meson.build
+++ b/subprojects/packagefiles/nowide/test/meson.build
@@ -1,0 +1,90 @@
+file_test_helpers_lib = static_library(
+    'file_test_helpers',
+    'file_test_helpers.cpp',
+    dependencies: nowide_dep,
+    include_directories: includes,
+)
+
+tests_kwargs = {
+    'codecvt': {},
+    'convert': {},
+    'env': {},
+    'env windows': {
+        'sources': 'test_env.cpp',
+        'cpp_args': '-DNOWIDE_TEST_INCLUDE_WINDOWS',
+    },
+    # we skip test_fs.cpp which would have tested intergation with boost::filesystem
+    'filebuf': {'link_with': file_test_helpers_lib},
+    'fstream': {'link_with': file_test_helpers_lib},
+    'fstream_special': {'link_with': file_test_helpers_lib},
+    'ifstream': {'link_with': file_test_helpers_lib},
+    'iostream': {'link_with': file_test_helpers_lib},
+    'ofstream': {'link_with': file_test_helpers_lib},
+    'stackstring': {},
+    'stat': {},
+    'stdio': {},
+    'system_narrow': {
+        'sources': 'test_system.cpp',
+        'cpp_args': '-DNOWIDE_TEST_USE_NARROW=1',
+    },
+    'traits': {},
+}
+
+if host_machine.system() == 'windows'
+    tests_kwargs += {
+        'system_wide': {
+            'sources': 'test_system.cpp',
+            'cpp_args': '-DNOWIDE_TEST_USE_NARROW=0',
+        }
+    }
+else
+    foreach name : ['filebuf', 'ifstream', 'ofstream', 'fstream', 'fstream_special']
+        tests_kwargs += {
+            name + '_with_internal_filebuf_replacement': {
+                'sources': 'test_' + name + '.cpp',
+                'cpp_args': '-DNOWIDE_USE_FILEBUF_REPLACEMENT=1',
+                'link_with': file_test_helpers_lib,
+            }
+        }
+    endforeach
+endif
+
+foreach name, kwargs : tests_kwargs
+    if 'sources' not in kwargs
+        kwargs += {'sources': 'test_' + name + '.cpp'}
+    endif
+    test_executable = executable(
+        'test_' + name,
+        dependencies: nowide_dep,
+        include_directories: includes,
+        kwargs: kwargs,
+    )
+    test('test_' + name, test_executable)
+endforeach
+
+
+iostream_interactive = executable(
+    'iostream_interactive',
+    'test_iostream.cpp',
+    dependencies: nowide_dep,
+    include_directories: includes,
+    cpp_args: '-DNOWIDE_TEST_INTERACTIVE',
+    link_with: file_test_helpers_lib,
+)
+
+test(
+    'iostream_interactive',
+    find_program('python3'),
+    args: [
+        files('test_iostream_interactive.py'),
+        iostream_interactive
+    ],
+)
+
+fstream_benchmark = executable(
+    'fstream_benchmark',
+    'benchmark_fstream.cpp',
+    dependencies: nowide_dep,
+    include_directories: includes,
+    cpp_args: '-DNOWIDE_USE_FILEBUF_REPLACEMENT=1',
+)

--- a/subprojects/packagefiles/nowide/test/test_iostream_interactive.py
+++ b/subprojects/packagefiles/nowide/test/test_iostream_interactive.py
@@ -1,0 +1,29 @@
+import argparse
+import subprocess
+
+parser = argparse.ArgumentParser()
+parser.add_argument("test_binary")
+args = parser.parse_args()
+
+message = "Hello Nowide Nowide"
+test_binary = args.test_binary
+
+completed_process = subprocess.run(
+    [test_binary, "passthrough"],
+    input=message,
+    capture_output=True,
+    encoding='utf-8'
+)
+
+result = completed_process.returncode
+stdout_lines = set(completed_process.stdout.split("\n"))
+
+if completed_process.returncode != 0:
+    print(f"Command {test_binary} failed ({result}) with {stdout}")
+    exit(1)
+
+if message not in stdout_lines:
+    print(f"Command {test_binary} did not output {message!r} but {completed_process.stdout!r}")
+    exit(1)
+
+print("Test OK")

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -60,6 +60,9 @@ PER_PROJECT_PERMITTED_FILES = {
     'netstring-c': [
         'netstring-c.def',
     ],
+    'nowide': [
+        'test_iostream_interactive.py',
+    ],
     'openssl': [
         'bn_conf.h',
         'dso_conf.h',


### PR DESCRIPTION
Hi !

This is my very first time contributing a wrap, sorry if the PR is not as polished as it could be, I'm really not that knowledgeable in build systems in general.

I'm looking for feedback on some specific points : 

**wrap name**

[nowide](https://github.com/boostorg/nowide) is apparently part of boost by default, but this wrap downloads the non-boost "standalone" variant specifically. Should it be called `nowide-standalone` then ?

**required meson version**

I have it set to `>=0.60.3` which seems a bit restrictive since I don't even know if I'm using any recent features.

**override_dependency**

To be honest I don't even really understand what this does but I saw that some of the other wraps don't use it, should I remove it ?

Thanks in advance for you help.