### PR TITLE
WIP: gmp

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -586,6 +586,14 @@
       "0.9.9.8-1"
     ]
   },
+  "gmp": {
+    "dependency_names": [
+      "gmp"
+    ],
+    "versions": [
+      "6.2.1-1"
+    ]
+  },
   "google-benchmark": {
     "dependency_names": [
       "benchmark"

--- a/subprojects/gmp.wrap
+++ b/subprojects/gmp.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = gmp-6.2.1
+source_url = https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz
+source_filename = gmp-6.2.1.tar.xz
+source_hash = fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2
+patch_directory = gmp
+
+[provide]
+gmp = gmp_dep

--- a/subprojects/packagefiles/gmp/choose_arguments_for_cpu.py
+++ b/subprojects/packagefiles/gmp/choose_arguments_for_cpu.py
@@ -1,0 +1,56 @@
+import argparse
+from typing import NamedTuple, List, Optional
+
+CompilerOptions = NamedTuple(
+    "CompilerOptions",
+    [
+        ("c_flags", List[str]), # C flags for compiler
+        ("c_flags_maybe", List[str]), # C flags for compiler, if they work
+        ("cpp_flags"), # C++ flags for compiler
+        ("optional_flag_sets", Dict[str, List[str]]),
+        ("ld_flags", List[str]), # -Wc,-foo flags for libtool linking with compiler
+    ],
+)
+
+MPNOptions = NamedTuple(
+    "MPNOptions",
+    [
+        ("search_path", List[str]),
+        ("extra_functions", List[str]),
+    ],
+)
+
+ABIOptions = NamedTuple(
+    "ABIOptions",
+    [
+        ("compiler", Dict[str, CompilerOptions]),
+        ("ar_flags", List[str]), # extra flags for $AR
+        ("nm_flags", List[str]), # extra flags for $NM
+        ("limb", str), # limb size, can be "longlong"
+        ("mpn", MPNOptions),
+    ],
+)
+
+FatOptions = NamedTuple(
+    "FatOptions",
+    [
+        ("mpn_search_path", List[str]), # fat binary mpn search path [if fat binary desired]
+        ("function", List[str]),
+        ("thresholds", List[str]),
+    ],
+)
+
+Options = NamedTuple(
+    "Options",
+    [
+        ("abi", Dict[str, ABIOptions]),
+        ("fat", Optional[FatOptions]),
+    ],
+)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--cpu-family", type=str, required=True)
+parser.add_argument("--cpu", type=str, required=True)
+parser.add_argument("--assembly", type=str, required=True)
+args = parser.parse_args()
+

--- a/subprojects/packagefiles/gmp/config.h.meson
+++ b/subprojects/packagefiles/gmp/config.h.meson
@@ -1,0 +1,667 @@
+/* config.in.  Generated from configure.ac by autoheader.  */
+
+/*
+
+Copyright 1996-2020 Free Software Foundation, Inc.
+
+This file is part of the GNU MP Library.
+
+The GNU MP Library is free software; you can redistribute it and/or modify
+it under the terms of either:
+
+  * the GNU Lesser General Public License as published by the Free
+    Software Foundation; either version 3 of the License, or (at your
+    option) any later version.
+
+or
+
+  * the GNU General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any
+    later version.
+
+or both in parallel, as here.
+
+The GNU MP Library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received copies of the GNU General Public License and the
+GNU Lesser General Public License along with the GNU MP Library.  If not,
+see https://www.gnu.org/licenses/.
+*/
+
+/* Define if building universal (internal helper macro) */
+#mesondefine AC_APPLE_UNIVERSAL_BUILD
+
+/* The gmp-mparam.h file (a string) the tune program should suggest updating.
+   */
+#mesondefine GMP_MPARAM_H_SUGGEST
+
+/* Define to 1 if you have the `alarm' function. */
+#mesondefine HAVE_ALARM
+
+/* Define to 1 if alloca() works (via gmp-impl.h). */
+#mesondefine HAVE_ALLOCA
+
+/* Define to 1 if you have <alloca.h> and it should be used (not on Ultrix).
+   */
+#mesondefine HAVE_ALLOCA_H
+
+/* Define to 1 if the compiler accepts gcc style __attribute__ ((const)) */
+#mesondefine HAVE_ATTRIBUTE_CONST
+
+/* Define to 1 if the compiler accepts gcc style __attribute__ ((malloc)) */
+#mesondefine HAVE_ATTRIBUTE_MALLOC
+
+/* Define to 1 if the compiler accepts gcc style __attribute__ ((mode (XX)))
+   */
+#mesondefine HAVE_ATTRIBUTE_MODE
+
+/* Define to 1 if the compiler accepts gcc style __attribute__ ((noreturn)) */
+#mesondefine HAVE_ATTRIBUTE_NORETURN
+
+/* Define to 1 if you have the `attr_get' function. */
+#mesondefine HAVE_ATTR_GET
+
+/* Define to 1 if tests/libtests has calling conventions checking for the CPU
+   */
+#mesondefine HAVE_CALLING_CONVENTIONS
+
+/* Define to 1 if you have the `clock' function. */
+#mesondefine HAVE_CLOCK
+
+/* Define to 1 if you have the `clock_gettime' function */
+#mesondefine HAVE_CLOCK_GETTIME
+
+/* Define to 1 if you have the `cputime' function. */
+#mesondefine HAVE_CPUTIME
+
+/* Define to 1 if you have the declaration of `fgetc', and to 0 if you don't.
+   */
+#mesondefine HAVE_DECL_FGETC
+
+/* Define to 1 if you have the declaration of `fscanf', and to 0 if you don't.
+   */
+#mesondefine HAVE_DECL_FSCANF
+
+/* Define to 1 if you have the declaration of `optarg', and to 0 if you don't.
+   */
+#mesondefine HAVE_DECL_OPTARG
+
+/* Define to 1 if you have the declaration of `sys_errlist', and to 0 if you
+   don't. */
+#mesondefine HAVE_DECL_SYS_ERRLIST
+
+/* Define to 1 if you have the declaration of `sys_nerr', and to 0 if you
+   don't. */
+#mesondefine HAVE_DECL_SYS_NERR
+
+/* Define to 1 if you have the declaration of `ungetc', and to 0 if you don't.
+   */
+#mesondefine HAVE_DECL_UNGETC
+
+/* Define to 1 if you have the declaration of `vfprintf', and to 0 if you
+   don't. */
+#mesondefine HAVE_DECL_VFPRINTF
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#mesondefine HAVE_DLFCN_H
+
+/* Define one of the following to 1 for the format of a `double'.
+   If your format is not among these choices, or you don't know what it is,
+   then leave all undefined.
+   IEEE_LITTLE_SWAPPED means little endian, but with the two 4-byte halves
+   swapped, as used by ARM CPUs in little endian mode.  */
+#mesondefine HAVE_DOUBLE_IEEE_BIG_ENDIAN
+#mesondefine HAVE_DOUBLE_IEEE_LITTLE_ENDIAN
+#mesondefine HAVE_DOUBLE_IEEE_LITTLE_SWAPPED
+#mesondefine HAVE_DOUBLE_VAX_D
+#mesondefine HAVE_DOUBLE_VAX_G
+#mesondefine HAVE_DOUBLE_CRAY_CFP
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#mesondefine HAVE_FCNTL_H
+
+/* Define to 1 if you have the <float.h> header file. */
+#mesondefine HAVE_FLOAT_H
+
+/* Define to 1 if you have the `getpagesize' function. */
+#mesondefine HAVE_GETPAGESIZE
+
+/* Define to 1 if you have the `getrusage' function. */
+#mesondefine HAVE_GETRUSAGE
+
+/* Define to 1 if you have the `getsysinfo' function. */
+#mesondefine HAVE_GETSYSINFO
+
+/* Define to 1 if you have the `gettimeofday' function. */
+#mesondefine HAVE_GETTIMEOFDAY
+
+/* Define to 1 if the compiler accepts gcc style __attribute__ ((visibility))
+   and __attribute__ ((alias)) */
+#mesondefine HAVE_HIDDEN_ALIAS
+
+/* Define one of these to 1 for the host CPU family.
+   If your CPU is not in any of these families, leave all undefined.
+   For an AMD64 chip, define "x86" in ABI=32, but not in ABI=64. */
+#mesondefine HAVE_HOST_CPU_FAMILY_alpha
+#mesondefine HAVE_HOST_CPU_FAMILY_m68k
+#mesondefine HAVE_HOST_CPU_FAMILY_power
+#mesondefine HAVE_HOST_CPU_FAMILY_powerpc
+#mesondefine HAVE_HOST_CPU_FAMILY_x86
+#mesondefine HAVE_HOST_CPU_FAMILY_x86_64
+
+/* Define one of the following to 1 for the host CPU, as per the output of
+   ./config.guess.  If your CPU is not listed here, leave all undefined.  */
+#mesondefine HAVE_HOST_CPU_alphaev67
+#mesondefine HAVE_HOST_CPU_alphaev68
+#mesondefine HAVE_HOST_CPU_alphaev7
+#mesondefine HAVE_HOST_CPU_m68020
+#mesondefine HAVE_HOST_CPU_m68030
+#mesondefine HAVE_HOST_CPU_m68040
+#mesondefine HAVE_HOST_CPU_m68060
+#mesondefine HAVE_HOST_CPU_m68360
+#mesondefine HAVE_HOST_CPU_powerpc604
+#mesondefine HAVE_HOST_CPU_powerpc604e
+#mesondefine HAVE_HOST_CPU_powerpc750
+#mesondefine HAVE_HOST_CPU_powerpc7400
+#mesondefine HAVE_HOST_CPU_supersparc
+#mesondefine HAVE_HOST_CPU_i386
+#mesondefine HAVE_HOST_CPU_i586
+#mesondefine HAVE_HOST_CPU_i686
+#mesondefine HAVE_HOST_CPU_pentium
+#mesondefine HAVE_HOST_CPU_pentiummmx
+#mesondefine HAVE_HOST_CPU_pentiumpro
+#mesondefine HAVE_HOST_CPU_pentium2
+#mesondefine HAVE_HOST_CPU_pentium3
+#mesondefine HAVE_HOST_CPU_pentium4
+#mesondefine HAVE_HOST_CPU_core2
+#mesondefine HAVE_HOST_CPU_nehalem
+#mesondefine HAVE_HOST_CPU_westmere
+#mesondefine HAVE_HOST_CPU_sandybridge
+#mesondefine HAVE_HOST_CPU_ivybridge
+#mesondefine HAVE_HOST_CPU_haswell
+#mesondefine HAVE_HOST_CPU_broadwell
+#mesondefine HAVE_HOST_CPU_skylake
+#mesondefine HAVE_HOST_CPU_silvermont
+#mesondefine HAVE_HOST_CPU_goldmont
+#mesondefine HAVE_HOST_CPU_k8
+#mesondefine HAVE_HOST_CPU_k10
+#mesondefine HAVE_HOST_CPU_bulldozer
+#mesondefine HAVE_HOST_CPU_piledriver
+#mesondefine HAVE_HOST_CPU_steamroller
+#mesondefine HAVE_HOST_CPU_excavator
+#mesondefine HAVE_HOST_CPU_zen
+#mesondefine HAVE_HOST_CPU_bobcat
+#mesondefine HAVE_HOST_CPU_jaguar
+#mesondefine HAVE_HOST_CPU_s390_z900
+#mesondefine HAVE_HOST_CPU_s390_z990
+#mesondefine HAVE_HOST_CPU_s390_z9
+#mesondefine HAVE_HOST_CPU_s390_z10
+#mesondefine HAVE_HOST_CPU_s390_z196
+
+/* Define to 1 iff we have a s390 with 64-bit registers.  */
+#mesondefine HAVE_HOST_CPU_s390_zarch
+
+/* Define to 1 if the system has the type `intmax_t'. */
+#mesondefine HAVE_INTMAX_T
+
+/* Define to 1 if the system has the type `intptr_t'. */
+#mesondefine HAVE_INTPTR_T
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#mesondefine HAVE_INTTYPES_H
+
+/* Define to 1 if you have the <invent.h> header file. */
+#mesondefine HAVE_INVENT_H
+
+/* Define to 1 if you have the <langinfo.h> header file. */
+#mesondefine HAVE_LANGINFO_H
+
+/* Define one of these to 1 for the endianness of `mp_limb_t'.
+   If the endianness is not a simple big or little, or you don't know what
+   it is, then leave both undefined. */
+#mesondefine HAVE_LIMB_BIG_ENDIAN
+#mesondefine HAVE_LIMB_LITTLE_ENDIAN
+
+/* Define to 1 if you have the `localeconv' function. */
+#mesondefine HAVE_LOCALECONV
+
+/* Define to 1 if you have the <locale.h> header file. */
+#mesondefine HAVE_LOCALE_H
+
+/* Define to 1 if the system has the type `long double'. */
+#mesondefine HAVE_LONG_DOUBLE
+
+/* Define to 1 if the system has the type `long long'. */
+#mesondefine HAVE_LONG_LONG
+
+/* Define to 1 if you have the <machine/hal_sysinfo.h> header file. */
+#mesondefine HAVE_MACHINE_HAL_SYSINFO_H
+
+/* Define to 1 if you have the <memory.h> header file. */
+#mesondefine HAVE_MEMORY_H
+
+/* Define to 1 if you have the `memset' function. */
+#mesondefine HAVE_MEMSET
+
+/* Define to 1 if you have the `mmap' function. */
+#mesondefine HAVE_MMAP
+
+/* Define to 1 if you have the `mprotect' function. */
+#mesondefine HAVE_MPROTECT
+
+/* Define to 1 each of the following for which a native (ie. CPU specific)
+    implementation of the corresponding routine exists.  */
+#mesondefine HAVE_NATIVE_mpn_add_n
+#mesondefine HAVE_NATIVE_mpn_add_n_sub_n
+#mesondefine HAVE_NATIVE_mpn_add_nc
+#mesondefine HAVE_NATIVE_mpn_addaddmul_1msb0
+#mesondefine HAVE_NATIVE_mpn_addlsh1_n
+#mesondefine HAVE_NATIVE_mpn_addlsh2_n
+#mesondefine HAVE_NATIVE_mpn_addlsh_n
+#mesondefine HAVE_NATIVE_mpn_addlsh1_nc
+#mesondefine HAVE_NATIVE_mpn_addlsh2_nc
+#mesondefine HAVE_NATIVE_mpn_addlsh_nc
+#mesondefine HAVE_NATIVE_mpn_addlsh1_n_ip1
+#mesondefine HAVE_NATIVE_mpn_addlsh2_n_ip1
+#mesondefine HAVE_NATIVE_mpn_addlsh_n_ip1
+#mesondefine HAVE_NATIVE_mpn_addlsh1_nc_ip1
+#mesondefine HAVE_NATIVE_mpn_addlsh2_nc_ip1
+#mesondefine HAVE_NATIVE_mpn_addlsh_nc_ip1
+#mesondefine HAVE_NATIVE_mpn_addlsh1_n_ip2
+#mesondefine HAVE_NATIVE_mpn_addlsh2_n_ip2
+#mesondefine HAVE_NATIVE_mpn_addlsh_n_ip2
+#mesondefine HAVE_NATIVE_mpn_addlsh1_nc_ip2
+#mesondefine HAVE_NATIVE_mpn_addlsh2_nc_ip2
+#mesondefine HAVE_NATIVE_mpn_addlsh_nc_ip2
+#mesondefine HAVE_NATIVE_mpn_addmul_1c
+#mesondefine HAVE_NATIVE_mpn_addmul_2
+#mesondefine HAVE_NATIVE_mpn_addmul_3
+#mesondefine HAVE_NATIVE_mpn_addmul_4
+#mesondefine HAVE_NATIVE_mpn_addmul_5
+#mesondefine HAVE_NATIVE_mpn_addmul_6
+#mesondefine HAVE_NATIVE_mpn_addmul_7
+#mesondefine HAVE_NATIVE_mpn_addmul_8
+#mesondefine HAVE_NATIVE_mpn_addmul_2s
+#mesondefine HAVE_NATIVE_mpn_and_n
+#mesondefine HAVE_NATIVE_mpn_andn_n
+#mesondefine HAVE_NATIVE_mpn_bdiv_dbm1c
+#mesondefine HAVE_NATIVE_mpn_bdiv_q_1
+#mesondefine HAVE_NATIVE_mpn_pi1_bdiv_q_1
+#mesondefine HAVE_NATIVE_mpn_cnd_add_n
+#mesondefine HAVE_NATIVE_mpn_cnd_sub_n
+#mesondefine HAVE_NATIVE_mpn_com
+#mesondefine HAVE_NATIVE_mpn_copyd
+#mesondefine HAVE_NATIVE_mpn_copyi
+#mesondefine HAVE_NATIVE_mpn_div_qr_1n_pi1
+#mesondefine HAVE_NATIVE_mpn_div_qr_2
+#mesondefine HAVE_NATIVE_mpn_divexact_1
+#mesondefine HAVE_NATIVE_mpn_divexact_by3c
+#mesondefine HAVE_NATIVE_mpn_divrem_1
+#mesondefine HAVE_NATIVE_mpn_divrem_1c
+#mesondefine HAVE_NATIVE_mpn_divrem_2
+#mesondefine HAVE_NATIVE_mpn_gcd_1
+#mesondefine HAVE_NATIVE_mpn_gcd_11
+#mesondefine HAVE_NATIVE_mpn_gcd_22
+#mesondefine HAVE_NATIVE_mpn_hamdist
+#mesondefine HAVE_NATIVE_mpn_invert_limb
+#mesondefine HAVE_NATIVE_mpn_ior_n
+#mesondefine HAVE_NATIVE_mpn_iorn_n
+#mesondefine HAVE_NATIVE_mpn_lshift
+#mesondefine HAVE_NATIVE_mpn_lshiftc
+#mesondefine HAVE_NATIVE_mpn_lshsub_n
+#mesondefine HAVE_NATIVE_mpn_mod_1
+#mesondefine HAVE_NATIVE_mpn_mod_1_1p
+#mesondefine HAVE_NATIVE_mpn_mod_1c
+#mesondefine HAVE_NATIVE_mpn_mod_1s_2p
+#mesondefine HAVE_NATIVE_mpn_mod_1s_4p
+#mesondefine HAVE_NATIVE_mpn_mod_34lsub1
+#mesondefine HAVE_NATIVE_mpn_modexact_1_odd
+#mesondefine HAVE_NATIVE_mpn_modexact_1c_odd
+#mesondefine HAVE_NATIVE_mpn_mul_1
+#mesondefine HAVE_NATIVE_mpn_mul_1c
+#mesondefine HAVE_NATIVE_mpn_mul_2
+#mesondefine HAVE_NATIVE_mpn_mul_3
+#mesondefine HAVE_NATIVE_mpn_mul_4
+#mesondefine HAVE_NATIVE_mpn_mul_5
+#mesondefine HAVE_NATIVE_mpn_mul_6
+#mesondefine HAVE_NATIVE_mpn_mul_basecase
+#mesondefine HAVE_NATIVE_mpn_mullo_basecase
+#mesondefine HAVE_NATIVE_mpn_nand_n
+#mesondefine HAVE_NATIVE_mpn_nior_n
+#mesondefine HAVE_NATIVE_mpn_popcount
+#mesondefine HAVE_NATIVE_mpn_preinv_divrem_1
+#mesondefine HAVE_NATIVE_mpn_preinv_mod_1
+#mesondefine HAVE_NATIVE_mpn_redc_1
+#mesondefine HAVE_NATIVE_mpn_redc_2
+#mesondefine HAVE_NATIVE_mpn_rsblsh1_n
+#mesondefine HAVE_NATIVE_mpn_rsblsh2_n
+#mesondefine HAVE_NATIVE_mpn_rsblsh_n
+#mesondefine HAVE_NATIVE_mpn_rsblsh1_nc
+#mesondefine HAVE_NATIVE_mpn_rsblsh2_nc
+#mesondefine HAVE_NATIVE_mpn_rsblsh_nc
+#mesondefine HAVE_NATIVE_mpn_rsh1add_n
+#mesondefine HAVE_NATIVE_mpn_rsh1add_nc
+#mesondefine HAVE_NATIVE_mpn_rsh1sub_n
+#mesondefine HAVE_NATIVE_mpn_rsh1sub_nc
+#mesondefine HAVE_NATIVE_mpn_rshift
+#mesondefine HAVE_NATIVE_mpn_sbpi1_bdiv_r
+#mesondefine HAVE_NATIVE_mpn_sqr_basecase
+#mesondefine HAVE_NATIVE_mpn_sqr_diagonal
+#mesondefine HAVE_NATIVE_mpn_sqr_diag_addlsh1
+#mesondefine HAVE_NATIVE_mpn_sub_n
+#mesondefine HAVE_NATIVE_mpn_sub_nc
+#mesondefine HAVE_NATIVE_mpn_sublsh1_n
+#mesondefine HAVE_NATIVE_mpn_sublsh2_n
+#mesondefine HAVE_NATIVE_mpn_sublsh_n
+#mesondefine HAVE_NATIVE_mpn_sublsh1_nc
+#mesondefine HAVE_NATIVE_mpn_sublsh2_nc
+#mesondefine HAVE_NATIVE_mpn_sublsh_nc
+#mesondefine HAVE_NATIVE_mpn_sublsh1_n_ip1
+#mesondefine HAVE_NATIVE_mpn_sublsh2_n_ip1
+#mesondefine HAVE_NATIVE_mpn_sublsh_n_ip1
+#mesondefine HAVE_NATIVE_mpn_sublsh1_nc_ip1
+#mesondefine HAVE_NATIVE_mpn_sublsh2_nc_ip1
+#mesondefine HAVE_NATIVE_mpn_sublsh_nc_ip1
+#mesondefine HAVE_NATIVE_mpn_submul_1c
+#mesondefine HAVE_NATIVE_mpn_tabselect
+#mesondefine HAVE_NATIVE_mpn_udiv_qrnnd
+#mesondefine HAVE_NATIVE_mpn_udiv_qrnnd_r
+#mesondefine HAVE_NATIVE_mpn_umul_ppmm
+#mesondefine HAVE_NATIVE_mpn_umul_ppmm_r
+#mesondefine HAVE_NATIVE_mpn_xor_n
+#mesondefine HAVE_NATIVE_mpn_xnor_n
+
+/* Define to 1 if you have the `nl_langinfo' function. */
+#mesondefine HAVE_NL_LANGINFO
+
+/* Define to 1 if you have the <nl_types.h> header file. */
+#mesondefine HAVE_NL_TYPES_H
+
+/* Define to 1 if you have the `obstack_vprintf' function. */
+#mesondefine HAVE_OBSTACK_VPRINTF
+
+/* Define to 1 if you have the `popen' function. */
+#mesondefine HAVE_POPEN
+
+/* Define to 1 if you have the `processor_info' function. */
+#mesondefine HAVE_PROCESSOR_INFO
+
+/* Define to 1 if <sys/pstat.h> `struct pst_processor' exists and contains
+   `psp_iticksperclktick'. */
+#mesondefine HAVE_PSP_ITICKSPERCLKTICK
+
+/* Define to 1 if you have the `pstat_getprocessor' function. */
+#mesondefine HAVE_PSTAT_GETPROCESSOR
+
+/* Define to 1 if the system has the type `ptrdiff_t'. */
+#mesondefine HAVE_PTRDIFF_T
+
+/* Define to 1 if the system has the type `quad_t'. */
+#mesondefine HAVE_QUAD_T
+
+/* Define to 1 if you have the `raise' function. */
+#mesondefine HAVE_RAISE
+
+/* Define to 1 if you have the `read_real_time' function. */
+#mesondefine HAVE_READ_REAL_TIME
+
+/* Define to 1 if you have the `sigaction' function. */
+#mesondefine HAVE_SIGACTION
+
+/* Define to 1 if you have the `sigaltstack' function. */
+#mesondefine HAVE_SIGALTSTACK
+
+/* Define to 1 if you have the `sigstack' function. */
+#mesondefine HAVE_SIGSTACK
+
+/* Tune directory speed_cyclecounter, undef=none, 1=32bits, 2=64bits) */
+#mesondefine HAVE_SPEED_CYCLECOUNTER
+
+/* Define to 1 if you have the <sstream> header file. */
+#mesondefine HAVE_SSTREAM
+
+/* Define to 1 if the system has the type `stack_t'. */
+#mesondefine HAVE_STACK_T
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#mesondefine HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#mesondefine HAVE_STDLIB_H
+
+/* Define to 1 if the system has the type `std::locale'. */
+#mesondefine HAVE_STD__LOCALE
+
+/* Define to 1 if you have the `strchr' function. */
+#mesondefine HAVE_STRCHR
+
+/* Define to 1 if you have the `strerror' function. */
+#mesondefine HAVE_STRERROR
+
+/* Define to 1 if you have the <strings.h> header file. */
+#mesondefine HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#mesondefine HAVE_STRING_H
+
+/* Define to 1 if you have the `strnlen' function. */
+#mesondefine HAVE_STRNLEN
+
+/* Define to 1 if you have the `strtol' function. */
+#mesondefine HAVE_STRTOL
+
+/* Define to 1 if you have the `strtoul' function. */
+#mesondefine HAVE_STRTOUL
+
+/* Define to 1 if you have the `sysconf' function. */
+#mesondefine HAVE_SYSCONF
+
+/* Define to 1 if you have the `sysctl' function. */
+#mesondefine HAVE_SYSCTL
+
+/* Define to 1 if you have the `sysctlbyname' function. */
+#mesondefine HAVE_SYSCTLBYNAME
+
+/* Define to 1 if you have the `syssgi' function. */
+#mesondefine HAVE_SYSSGI
+
+/* Define to 1 if you have the <sys/attributes.h> header file. */
+#mesondefine HAVE_SYS_ATTRIBUTES_H
+
+/* Define to 1 if you have the <sys/iograph.h> header file. */
+#mesondefine HAVE_SYS_IOGRAPH_H
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+#mesondefine HAVE_SYS_MMAN_H
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+#mesondefine HAVE_SYS_PARAM_H
+
+/* Define to 1 if you have the <sys/processor.h> header file. */
+#mesondefine HAVE_SYS_PROCESSOR_H
+
+/* Define to 1 if you have the <sys/pstat.h> header file. */
+#mesondefine HAVE_SYS_PSTAT_H
+
+/* Define to 1 if you have the <sys/resource.h> header file. */
+#mesondefine HAVE_SYS_RESOURCE_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#mesondefine HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/sysctl.h> header file. */
+#mesondefine HAVE_SYS_SYSCTL_H
+
+/* Define to 1 if you have the <sys/sysinfo.h> header file. */
+#mesondefine HAVE_SYS_SYSINFO_H
+
+/* Define to 1 if you have the <sys/syssgi.h> header file. */
+#mesondefine HAVE_SYS_SYSSGI_H
+
+/* Define to 1 if you have the <sys/systemcfg.h> header file. */
+#mesondefine HAVE_SYS_SYSTEMCFG_H
+
+/* Define to 1 if you have the <sys/times.h> header file. */
+#mesondefine HAVE_SYS_TIMES_H
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#mesondefine HAVE_SYS_TIME_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#mesondefine HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the `times' function. */
+#mesondefine HAVE_TIMES
+
+/* Define to 1 if the system has the type `uint_least32_t'. */
+#mesondefine HAVE_UINT_LEAST32_T
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#mesondefine HAVE_UNISTD_H
+
+/* Define to 1 if you have the `vsnprintf' function and it works properly. */
+#mesondefine HAVE_VSNPRINTF
+
+/* Define to 1 for Windos/64 */
+#mesondefine HOST_DOS64
+
+/* Assembler local label prefix */
+#mesondefine LSYM_PREFIX
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#mesondefine LT_OBJDIR
+
+/* Define to 1 to disable the use of inline assembly */
+#mesondefine NO_ASM
+
+/* Name of package */
+#mesondefine PACKAGE
+
+/* Define to the address where bug reports for this package should be sent. */
+#mesondefine PACKAGE_BUGREPORT
+
+/* Define to the full name of this package. */
+#mesondefine PACKAGE_NAME
+
+/* Define to the full name and version of this package. */
+#mesondefine PACKAGE_STRING
+
+/* Define to the one symbol short name of this package. */
+#mesondefine PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#mesondefine PACKAGE_URL
+
+/* Define to the version of this package. */
+#mesondefine PACKAGE_VERSION
+
+/* Define as the return type of signal handlers (`int' or `void'). */
+#mesondefine RETSIGTYPE
+
+/* The size of `mp_limb_t', as computed by sizeof. */
+#mesondefine SIZEOF_MP_LIMB_T
+
+/* The size of `unsigned', as computed by sizeof. */
+#mesondefine SIZEOF_UNSIGNED
+
+/* The size of `unsigned long', as computed by sizeof. */
+#mesondefine SIZEOF_UNSIGNED_LONG
+
+/* The size of `unsigned short', as computed by sizeof. */
+#mesondefine SIZEOF_UNSIGNED_SHORT
+
+/* The size of `void *', as computed by sizeof. */
+#mesondefine SIZEOF_VOID_P
+
+/* Define to 1 if sscanf requires writable inputs */
+#mesondefine SSCANF_WRITABLE_INPUT
+
+/* Define to 1 if you have the ANSI C header files. */
+#mesondefine STDC_HEADERS
+
+/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
+#mesondefine TIME_WITH_SYS_TIME
+
+/* Maximum size the tune program can test for SQR_TOOM2_THRESHOLD */
+#mesondefine TUNE_SQR_TOOM2_MAX
+
+/* Version number of package */
+#mesondefine VERSION
+
+/* Define to 1 to enable ASSERT checking, per --enable-assert */
+#mesondefine WANT_ASSERT
+
+/* Define to 1 to enable GMP_CPU_TYPE faking cpuid, per --enable-fake-cpuid */
+#mesondefine WANT_FAKE_CPUID
+
+/* Define to 1 when building a fat binary. */
+#mesondefine WANT_FAT_BINARY
+
+/* Define to 1 to enable FFTs for multiplication, per --enable-fft */
+#mesondefine WANT_FFT
+
+/* Define to 1 to enable old mpn_mul_fft_full for multiplication, per
+   --enable-old-fft-full */
+#mesondefine WANT_OLD_FFT_FULL
+
+/* Define to 1 if --enable-profiling=gprof */
+#mesondefine WANT_PROFILING_GPROF
+
+/* Define to 1 if --enable-profiling=instrument */
+#mesondefine WANT_PROFILING_INSTRUMENT
+
+/* Define to 1 if --enable-profiling=prof */
+#mesondefine WANT_PROFILING_PROF
+
+/* Define one of these to 1 for the desired temporary memory allocation
+   method, per --enable-alloca. */
+#mesondefine WANT_TMP_ALLOCA
+#mesondefine WANT_TMP_REENTRANT
+#mesondefine WANT_TMP_NOTREENTRANT
+#mesondefine WANT_TMP_DEBUG
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+#  undef WORDS_BIGENDIAN
+# endif
+#endif
+
+/* Define to 1 if the assembler understands the mulx instruction */
+#mesondefine X86_ASM_MULX
+
+/* Define to 1 if `lex' declares `yytext' as a `char *' by default, not a
+   `char[]'. */
+#mesondefine YYTEXT_POINTER
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+#undef inline
+#endif
+
+/* Define to the equivalent of the C99 'restrict' keyword, or to
+   nothing if this is not supported.  Do not define if restrict is
+   supported directly.  */
+#undef restrict
+/* Work around a bug in Sun C++: it does not support _Restrict or
+   __restrict__, even though the corresponding Sun C compiler ends up with
+   "#define restrict _Restrict" or "#define restrict __restrict__" in the
+   previous line.  Perhaps some future version of Sun C++ will work with
+   restrict; if so, hopefully it defines __RESTRICT like Sun C does.  */
+#if defined __SUNPRO_CC && !defined __RESTRICT
+# define _Restrict
+# define __restrict__
+#endif
+
+/* Define to empty if the keyword `volatile' does not work. Warning: valid
+   code using `volatile' can become incorrect without. Disable with care. */
+#undef volatile

--- a/subprojects/packagefiles/gmp/configure.py
+++ b/subprojects/packagefiles/gmp/configure.py
@@ -1,0 +1,500 @@
+import argparse
+import copy
+from collections import OrderedDict
+from fnmatch import fnmatch
+from typing import Dict, List, NamedTuple, Optional
+
+CompilerAndABI = NamedTuple(
+    "CompilerAndABI",
+    [
+        ("compiler", str),
+        ("abi", str)
+    ]
+)
+# generic abi identifier that usually defaults to the 32-bit one
+STANDARD_ABI = "standard"
+
+# common abi + compiler defintions
+ANY_32 = CompilerAndABI(compiler="any", abi="32")
+ANY_64 = CompilerAndABI(compiler="any", abi="64")
+GCC = CompilerAndABI(compiler="gcc", abi=STANDARD_ABI)
+GCC_32 = CompilerAndABI(compiler="gcc", abi="32")
+GCC_64 = CompilerAndABI(compiler="gcc", abi="64")
+CC = CompilerAndABI(compiler="cc", abi=STANDARD_ABI)
+CC_64 = CompilerAndABI(compiler="cc", abi="64")
+
+CompilerOptions = NamedTuple(
+    "CompilerOptions"
+    [
+        ("flags", List[str]),
+        ("flags_maybe", List[str]),
+        ("optional_flags", OrderedDict[str, List[str]]),
+        ("testlist", List[str])
+    ],
+)
+
+ABIOptions = NamedTuple(
+    "ABIOptions",
+    [
+        ("ar_flags", List[str]),
+        ("nm_flags", List[str]),
+        ("limb", Optional[str]),
+        ("mpn_search_path", List[str]),
+        ("mpn_extra_functions", List[str]),
+        ("calling_conventions_objs", List[str]),
+    ]
+)
+
+Options = NamedTuple(
+    "Options",
+    [
+        ("compilers", Dict[CompilerAndABI, CompilerOptions]),
+        ("abis", Dict[str, ABIOptions]),  # ABI name -> objs
+        ("gmp_asm_syntax_testing", bool),
+        ("speed_cyclecounter_obj", Optional[str])
+        ("cyclecounter_size", int)
+    ]
+)
+
+def default_gcc_flags() -> List[str]:
+    return ["-O2", "-pedantic"]
+
+def default_gcc_options() -> CompilerOptions:
+    return CompilerOptions(
+        flags=default_gcc_flags(),
+        flags_maybe=[],
+        optional_flags=OrderedDict(),
+        testlist=[]
+    )    
+
+
+def default_cc_options() -> CompilerOptions:
+    return CompilerOptions(
+        flags=["-O"],
+        flags_maybe=[],
+        optional_flags=OrderedDict(),
+        testlist=[]
+    )
+
+def default_abi_options() -> ABIOptions:
+    return ABIOptions(
+        ar_flags=[],
+        nm_flags=[],
+        limb=None,
+        mpn_search_path=[],
+        mpn_extra_functions=[],
+        calling_conventions_objs=[],
+    )
+
+def default_options() -> Options:
+    return Options(
+        compilers={
+            GCC: default_gcc_options(),
+            CC: default_cc_options(),             
+        },
+        abis={
+            STANDARD_ABI: default_abi_options()
+        },
+        gmp_asm_syntax_testing=True,
+        speed_cyclecounter_obj=None,
+        cyclecounter_size=2,
+    )
+
+def empty_compiler_options() -> CompilerOptions:
+    return CompilerOptions(
+        flags=[],
+        flags_maybe=[],
+        optional_flags=OrderedDict(),
+        testlist=[]
+    )
+
+def match(text: str, *patterns: str) -> bool:
+    return any(fnmatch(text, pattern) for pattern in patterns)
+
+def mpn_search_path_for_alpha(host_cpu: str) -> List[str]:
+    if match(host_cpu, "alphaev5*", "alphapca5*"):
+        return ["alpha/ev5", "alpha"]
+    elif match(host_cpu, "alphaev67", "alphaev68", "alphaev7*"):
+        return ["alpha/ev67", "alpha/ev6", "alpha"]
+    elif match(host_cpu, "alphaev6"):
+        return ["alpha/ev6", "alpha"]
+    else:
+        return ["alpha"]
+
+def asm_flags_for_alpha_gcc(host_cpu: str) -> List[str]:
+    # gcc version "2.9-gnupro-99r1" on alphaev68-dec-osf5.1 has been seen
+    # accepting -mcpu=ev6, but not putting the assembler in the right mode
+    # for what it produces.  We need to do this for it, and need to do it
+    # before testing the -mcpu options.
+    #
+    # On old versions of gcc, which don't know -mcpu=, we believe an
+    # explicit -Wa,-mev5 etc will be necessary to put the assembler in
+    # the right mode for our .asm files and longlong.h asm blocks.
+    #
+    # On newer versions of gcc, when -mcpu= is known, we must give a -Wa
+    # which is at least as high as the code gcc will generate.  gcc
+    # establishes what it needs with a ".arch" directive, our command line
+    # option seems to override that.
+    #
+    # gas prior to 2.14 doesn't accept -mev67, but -mev6 seems enough for
+    # ctlz and cttz (in 2.10.0 at least).
+    #
+    # OSF `as' accepts ev68 but stupidly treats it as ev4.  -arch only seems
+    # to affect insns like ldbu which are expanded as macros when necessary.
+    # Insns like ctlz which were never available as macros are always
+    # accepted and always generate their plain code.
+    if match(host_cpu, "alpha"):
+        return ["-Wa,-arch,ev4", "-Wa,-mev4"]
+    elif match(host_cpu, "alphaev5"):
+        return ["-Wa,-arch,ev5", "-Wa,-mev5"]
+    elif match(host_cpu, "alphaev56"):
+        return ["-Wa,-arch,ev56", "-Wa,-mev56"]
+    elif match(host_cpu, "alphapca56", "alphapca57"):
+        return ["-Wa,-arch,pca56", "-Wa,-mpca56"]
+    elif match(host_cpu, "alphaev6"):
+        return ["-Wa,-arch,ev6", "-Wa,-mev6"]
+    elif match(host_cpu, "alphaev67", "alphaev68", "alphaev7*"):
+        return ["-Wa,-arch,ev67", "-Wa,-mev67", "-Wa,-arch,ev6", "-Wa,-mev6"]
+    else:
+        return []
+
+def cpu_flags_for_alpha_gcc(host_cpu: str) -> List[str]:
+    # gcc 2.7.2.3 doesn't know any -mcpu= for alpha, apparently.
+    # gcc 2.95 knows -mcpu= ev4, ev5, ev56, pca56, ev6.
+    # gcc 3.0 adds nothing.
+    # gcc 3.1 adds ev45, ev67 (but ev45 is the same as ev4).
+    # gcc 3.2 adds nothing.
+    #
+    # gcc version "2.9-gnupro-99r1" under "-O2 -mcpu=ev6" strikes internal
+    # compiler errors too easily and is rejected by GMP_PROG_CC_WORKS.  Each
+    # -mcpu=ev6 below has a fallback to -mcpu=ev56 for this reason.
+    if match(host_cpu, "alpha"):
+        return ["-mcpu=ev4"]
+    elif match(host_cpu, "alphaev5"):
+        return ["-mcpu=ev5"]
+    elif match(host_cpu, "alphaev56"):
+        return ["-mcpu=ev56"]
+    elif match(host_cpu, "alphapca56", "alphapca57"):
+        return ["-mcpu=pca56"]
+    elif match(host_cpu, "alphaev6"):
+        return ["-mcpu=ev6", "-mcpu=ev56"]
+    elif match(host_cpu, "alphaev67", "alphaev68", "alphaev7*"):
+        return ["-mcpu=ev67", "-mcpu=ev6", "-mcpu=ev56"]
+    else:
+        return []
+
+def cpu_flags_for_alpha_cc(host_cpu: str) -> List[str]:
+    # DEC C V5.9-005 knows ev4, ev5, ev56, pca56, ev6.
+    # Compaq C V6.3-029 adds ev67.
+    if match(host_cpu, "alpha"):
+        return ["-arch~ev4~-tune~ev4"]
+    elif match(host_cpu, "alphaev5"):
+        return ["-arch~ev5~-tune~ev5"]
+    elif match(host_cpu, "alphaev56"):
+        return ["-arch~ev56~-tune~ev56"]
+    elif match(host_cpu, "alphapca56", "alphapca57"):
+        return ["-arch~pca56~-tune~pca56"]
+    elif match(host_cpu, "alphaev6"):
+        return ["-arch~ev6~-tune~ev6"]
+    elif match(host_cpu, "alphaev67", "alphaev68", "alphaev7*"):
+        return ["-arch~ev67~-tune~ev67", "-arch~ev6~-tune~ev6"]
+    else:
+        return []
+
+def options_for_alpha_cc(host: str, host_cpu: str) -> CompilerOptions:
+    # It might be better to ask "cc" whether it's Cray C or DEC C,
+    # instead of relying on the OS part of $host.  But it's hard to
+    # imagine either of those compilers anywhere except their native
+    # systems.
+    options = default_cc_options()
+    if match(host, "*-cray-unicos*"):
+        # no -g, it silently disables all optimizations
+        return options._replace(flags=["-O"])
+    elif match(host, "*-cray-unicos*"):
+        return options._replace(
+            flags=[],
+            optional_flags=OrderedDict([
+                # not sure if -fast works on old versions, so make it optional
+                ("opt", ["-fast", "-O2"]),
+                ("cpu", cpu_flags_for_alpha_cc(host_cpu))
+            ])
+        )
+    else:
+        return options
+
+def options_for_alpha(host: str, host_cpu: str, assembly: bool) -> Options:
+    options = default_options()
+    abi_options = default_abi_options()._replace(
+        mpn_search_path=mpn_search_path_for_alpha(host_cpu)
+    )
+    if assembly:
+        abi_options = abi_options._replace(mpn_extra_functions=["cntlz"])
+    options.abis[STANDARD_ABI] = abi_options
+    options.compilers[GCC] = options.compilers[GCC]._replace(flags_maybe=["-mieee"])
+    # need asm ahead of cpu, see below
+    options.compilers[GCC].optional_flags["asm"] = asm_flags_for_alpha_gcc(host_cpu)
+    options.compilers[GCC].optional_flags["cpu"] = cpu_flags_for_alpha_gcc(host_cpu)
+    options.compilers[GCC].optional_flags["oldas"] = ["-Wa,-oldas"] # see GMP_GCC_WA_OLDAS.
+    options.compilers[CC] = options_for_alpha_cc(host, host_cpu)
+
+    if match(host, "*-cray-unicos*"):
+        # Don't perform any assembly syntax tests on this beast.
+        options = options._replace(gmp_asm_syntax_testing=False)
+    
+    if not match(host, "*-*-unicos*"):
+        # tune/alpha.asm assumes int==4bytes but unicos uses int==8bytes
+        options = options._replace(
+            speed_cyclecounter_obj="alpha.lo",
+            cyclecounter_size=1
+        )
+    
+    return options
+    
+def options_for_cray() -> Options:
+    # Cray vector machines.
+    # This must come after alpha* so that we can recognize present and future
+    # vector processors with a wildcard.
+    options = default_options()
+    # We used to have -hscalar0 here as a workaround for miscompilation of
+    # mpz/import.c, but let's hope Cray fixes their bugs instead, since
+    # -hscalar0 causes disastrously poor code to be generated.
+    cc_options = default_cc_options()._replace(
+        flags=["-O3", "-hnofastmd", "-htask0", "-Wa,-B"]
+    )
+    abi_options = default_abi_options()._replace(
+        mpn_search_path=["cray"]
+    )
+    return default_options()._replace(
+        gmp_asm_syntax_testing=False,
+        compilers={CC: cc_options},
+        abis={STANDARD_ABI: abi_options}
+    )
+
+def mpn_search_path_for_arm(host_cpu: str) -> List[str]:
+    if match(host_cpu, "armxscale", "arm7ej", "arm9te", "arm9e*", "arm10*", "armv5*"):
+        return ["arm/v5", "arm"]
+    elif match(host_cpu, "armsa1", "arm7t*", "arm9t*", "armv4t*"):
+        return ["arm"]
+    elif match(host_cpu, "arm1156", "armv6t2*"):
+        return ["arm/v6t2", "arm/v6", "arm/v5", "arm"]
+    elif match(host_cpu, "arm11*", "armv6*"):
+        return ["arm/v6", "arm/v5", "arm"]
+    elif match(host_cpu, "armcortexa5", "armv7*"):
+        return ["arm/v7a/cora5", "arm/v6t2", "arm/v6", "arm/v5", "arm"]
+    elif match(host_cpu, "armcortexa5neon"):
+        return ["arm/neon", "arm/v7a/cora5", "arm/v6t2", "arm/v6", "arm/v5", "arm"]
+    elif match(host_cpu, "armcortexa7"):
+        return ["arm/v7a/cora7", "arm/v6t2", "arm/v6", "arm/v5", "arm"]
+    elif match(host_cpu, "armcortexa7neon"):
+        return ["arm/neon", "arm/v7a/cora7", "arm/v6t2", "arm/v6", "arm/v5", "arm"]
+    elif match(host_cpu, "armcortexa8"):
+        return ["arm/v7a/cora8", "arm/v6t2", "arm/v6", "arm/v5", "arm"]
+    elif match(host_cpu, "armcortexa8neon"):
+        return ["arm/neon", "arm/v7a/cora8", "arm/v6t2", "arm/v6", "arm/v5", "arm"]
+    elif match(host_cpu, "armcortexa9"):
+        return ["arm/v7a/cora9", "arm/v6t2", "arm/v6", "arm/v5", "arm"]
+    elif match(host_cpu, "armcortexa9neon"):
+        return ["arm/neon", "arm/v7a/cora9", "arm/v6t2", "arm/v6", "arm/v5", "arm"]
+    elif match(host_cpu, "armcortexa15"):
+        return ["arm/v7a/cora15", "arm/v6t2", "arm/v6", "arm/v5", "arm"]
+    elif match(host_cpu, "armcortexa15neon"):
+        return ["arm/v7a/cora15/neon", "arm/neon", "arm/v7a/cora15", "arm/v6t2", "arm/v6", "arm/v5", "arm"]
+    elif match(host_cpu, "armcortexa12", "armcortexa17"):
+        return ["arm/v7a/cora17", "arm/v7a/cora15", "arm/v6t2", "arm/v6", "arm/v5", "arm"]
+    elif match(host_cpu, "armcortexa12neon", "armcortexa17neon"):
+        return [
+            "arm/v7a/cora17/neon",
+            "arm/v7a/cora15/neon",
+            "arm/neon",
+            "arm/v7a/cora17",
+            "arm/v7a/cora15",
+            "arm/v6t2",
+            "arm/v6",
+            "arm/v5",
+            "arm"
+        ]
+    elif match(host_cpu, "armcortexa53", "armcortexa53neon", "armcortexa55", "armcortexa55neon"):
+        return ["arm/neon", "arm/v7a/cora9", "arm/v6t2", "arm/v6", "arm/v5", "arm"]
+    elif match(
+        host_cpu,
+        "armcortexa57", "armcortexa57neon",
+        "armcortexa7[2-9]", "armcortexa7[2-9]neon",
+        "armexynosm1",
+        "armthunderx",
+        "armxgene1",
+        "aarch64*"
+    ):
+        return ["arm/v7a/cora15/neon", "arm/neon", "arm/v7a/cora15", "arm/v6t2", "arm/v6", "arm/v5", "arm"]
+    else:
+        return ["arm"]
+
+def arch_flags_for_arm_gcc(host_cpu: str) -> List[str]:
+    if match(host_cpu, "armxscale", "arm7ej", "arm9te", "arm9e*", "arm10*", "armv5*"):
+        return ["-march=armv5"]
+    elif match(host_cpu, "armsa1", "arm7t*", "arm9t*", "armv4t*"):
+        return ["-march=armv4"]
+    elif match(host_cpu, "arm1156", "armv6t2*"):
+        return ["-march=armv6t2"]
+    elif match(host_cpu, "arm11*", "armv6*"):
+        return ["-march=armv6"]
+    elif match(
+        host_cpu,
+        "armcortexa5", "armv7*",
+        "armcortexa5neon",
+        "armcortexa8", "armcortexa8neon",
+        "armcortexa9",
+        "armcortexa9neon"
+    ):
+        return ["-march=armv7-a"]
+    elif match(host_cpu, "armcortexa7", "armcortexa7neon"):
+        return ["-march=armv7ve", "-march=armv7-a"]
+    elif match(
+        host_cpu,
+        "armcortexa15",
+        "armcortexa15neon",
+        "armcortexa12", "armcortexa17",
+        "armcortexa12neon", "armcortexa17neon"
+    ):
+        return ["-march=armv7ve", "-march=armv7-a"]
+    elif match(
+        host_cpu,
+        "armcortexa53", "armcortexa53neon", "armcortexa55", "armcortexa55neon",
+        "armcortexa57", "armcortexa57neon",
+        "armcortexa7[2-9]", "armcortexa7[2-9]neon",
+        "armexynosm1",
+        "armthunderx",
+        "armxgene1",
+        "aarch64*"
+    ):
+        return ["-march=armv8-a"]
+    else:
+        return ["-march=armv4"]
+
+def tune_flags_for_arm_gcc(host_cpu: str) -> List[str]:
+    if match(host_cpu, "armcortexa5", "armcortexa5neon", "armv7*",):
+        return ["-mtune=cortex-a5"]
+    elif match(host_cpu, "armcortexa7", "armcortexa7neon"):
+        return ["-mtune=cortex-a7"]
+    elif match(host_cpu, "armcortexa8", "armcortexa8neon"):
+        return ["-mtune=cortex-a8"]
+    elif match(host_cpu, "armcortexa9", "armcortexa9neon"):
+        return ["-mtune=cortex-a9"]
+    elif match(
+        host_cpu,
+        "armcortexa12", "armcortexa12neon",
+        "armcortexa15", "armcortexa15neon",
+        "armcortexa17", "armcortexa17neon",
+    ):
+        return ["-mtune=cortex-a15", "-mtune=cortex-a9"]
+    elif match(
+        host_cpu,
+        "armcortexa53", "armcortexa53neon",
+        "armcortexa55", "armcortexa55neon",
+    ):
+        return ["-mtune=cortex-a53"]
+    elif match(host_cpu, "armcortexa57", "armcortexa57neon"):
+        return ["-mtune=cortex-a57"]
+    elif match(host_cpu, "armcortexa7[2-9]", "armcortexa7[2-9]neon"):
+        return ["-mtune=cortex-a72", "-mtune=cortex-a57"]
+    elif match(host_cpu, "armexynosm1"):
+        return ["-mtune=exynosm1"]
+    elif match(host_cpu, "armthunderx"):
+        return ["-mtune=thunderx"]
+    elif match(host_cpu, "armxgene1"):
+        return ["-mtune=xgene1"]
+    else:
+        return []
+
+def neon_flags_for_arm_gcc(host_cpu: str) -> List[str]:
+    if match(
+        host_cpu,
+        "*neon", # 5, 7, 8, 9, 12, 15, 17, 53, 55, 57, 7[2-9]
+        "armcortexa53",
+        "armcortexa55",
+        "armcortexa57",
+        "armcortexa7[2-9]",
+        "armexynosm1",
+        "armthunderx",
+        "armxgene1",
+        "aarch64*"
+    ):
+        return ["-mfpu=neon"]
+    else:
+        return []
+
+def options_for_arm(host: str, host_cpu: str, profiling: str) -> Options:
+    options = default_options()
+    options.abis[STANDARD_ABI] = default_abi_options()._replace(
+        mpn_search_path=mpn_search_path_for_arm(host_cpu),
+        calling_conventions_objs=["arm32call.lo", "arm32check.lo"]
+    )
+    options.abis["64"] = default_abi_options()._replace(
+        calling_conventions_objs=[]
+    )
+    options.calling_conventions_objs["64"] = []
+    options.compilers[CC_64] = default_cc_options()
+    if profiling != "gprof":
+        options.compilers[GCC] = options.compilers[GCC]._replace(
+            flags=default_gcc_flags() + ["-fomit-frame-pointer"]
+        )
+
+    options.compilers[GCC] = options.compilers[GCC]._replace(
+        optional_flags=OrderedDict([
+            ("arch", arch_flags_for_arm_gcc(host_cpu)),
+            ("fpmode", []),
+            ("neon", neon_flags_for_arm_gcc(host_cpu)),
+            ("tune", tune_flags_for_arm_gcc(host_cpu))
+        ]),
+        testlist=["gcc-arm-umodsi"]
+    )
+    options.compilers[GCC_64] = default_gcc_options()._replace(
+        optional_flags=OrderedDict([
+            ("arch", []),
+            ("tune", [])
+        ]),
+        testlist=[]
+    )
+
+    options.compilers[ANY_32] = empty_compiler_options()._replace(
+        testlist=["sizeof-void*-4"]
+    )
+    options.compilers[ANY_64] = empty_compiler_options()._replace(
+        testlist=["sizeof-void*-8"]
+    )
+
+    # This is needed for clang, which is not content with flags like -mfpu=neon
+    # alone.
+    if match(host, "*-*-*eabi"):
+        options.compilers[GCC].optional_flags["fpmode"] = ["-mfloat-abi=softfp"]
+    elif match(host, "*-*-*eabihf"):
+        options.compilers[GCC].optional_flags["fpmode"] = ["-mfloat-abi=hard"]
+    elif match(host, "*-*-mingw*"):
+        options.abis["64"] = options.abis["64"]._replace(limb="longlong")
+
+
+def options_for(
+    host: str,
+    host_cpu: str,
+    assembly: bool,
+    profiling: str
+) -> Options:
+    if match(host, "alpha*-*-*"):
+        return options_for_alpha(host, host_cpu, assembly)
+    elif match(host, "*-cray-unicos*"):
+        return options_for_cray()
+    elif match(host, "arm*-*-*", "aarch64*-*-*"):
+        return options_for_arm(host, host_cpu, profiling)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", required=True)
+    parser.add_argument("--host-cpu", required=True)
+    parser.add_argument("--assembly", action="store_true")
+    parser.add_argument("--profiling", required=True)
+    args = parser.parse_args()
+    options = options_for(
+        args.host,
+        args.host_cpu,
+        args.assembly,
+        args.profiling
+    )

--- a/subprojects/packagefiles/gmp/definitions.json
+++ b/subprojects/packagefiles/gmp/definitions.json
@@ -1,0 +1,33 @@
+{
+  "*": {
+    "abi": {
+      "standard": {
+        "compiler": {
+          "gcc": {
+            "c_flags": ["-O2", "-pedantic"]
+          },
+          "cc": {
+            "c_flags": ["-O"]
+          }
+        }
+      },
+      "64": {
+        "compiler": {
+          "gcc": {
+            "c_flags": ["-O2", "-pedantic"]
+          },
+          "cc": {
+            "c_flags": ["-O"]
+          }
+        }
+      }
+    }
+  },
+  "alpha*-*-*": {
+    "abi": {
+      "standard": {
+        "compiler": {}
+      }
+    }
+  }
+}

--- a/subprojects/packagefiles/gmp/meson.build
+++ b/subprojects/packagefiles/gmp/meson.build
@@ -1,0 +1,315 @@
+project(
+  'gmp',
+  'c',
+  'cpp',
+  version : '6.2.1',
+)
+
+conf = configuration_data()
+
+conf.set('WANT_ASSERT', get_option('assert').to_int())
+conf.set('WANT_FFT', get_option('fft').to_int())
+conf.set('WANT_OLD_FFT_FULL', get_option('old-fft-full').to_int())
+
+profiling = get_option('profiling')
+if profiling != 'no'
+  conf.set('WANT_PROFILING_' + profiling.to_upper(), 1)
+endif
+fomit_frame_pointer = []
+if profiling == 'gprof':
+  fomit_frame_pointer += ['-fomit-frame-pointer']
+endif
+
+fake_cpuid = get_option('fake-cpuid')
+conf.set('WANT_FAKE_CPUID', fake_cpuid.to_int())
+
+assembly = get_option('assembly')
+fat = get_option('fat')
+
+if fat and not assembly
+  error('when doing a fat build, disabling assembly will not work')
+endif
+
+if fake_cpuid and not fat
+  error('enabling fake-cpuid requires enabling fat')
+endif
+
+host_machine_cpu = host_machine.cpu()
+conf.set('HAVE_HOST_CPU_' + host_machine.cpu(), 1)
+conf.set('HAVE_HOST_CPU_FAMILY_' + host_machine.cpu_family(), 1)
+
+abi_list = ['standard']
+cc_list = ['gcc', 'cc']
+gcc_cflags = ['-O2', '-pedantic']
+gcc_64_cflags = ['-O2', '-pedantic']
+cc_cflags = ['-O']
+cc_64_cflags = ['-O']
+SPEED_CYCLECOUNTER_OBJ = []
+cyclecounter_size = 2
+mpn_search_path = []
+
+conf.set('HAVE_HOST_CPU_FAMILY_power', 0)
+conf.set('HAVE_HOST_CPU_FAMILY_powerpc', 0)
+
+variables = {
+  'alpha': {
+    'mpn_search_path': []
+  }
+}
+
+
+check_headers = [
+  'alloca.h',
+  'dlfcn.h',
+  'fcntl.h',
+  'float.h',
+  'inttypes.h',
+  'invent.h',
+  'langinfo.h',
+  'locale.h',
+  'machine/hal/sysinfo.h',
+  'memory.h',
+  'nl/types.h',
+  'stdint.h',
+  'stdlib.h',
+  'strings.h',
+  'string.h',
+  'sys/attributes.h',
+  'sys/iograph.h',
+  'sys/mman.h',
+  'sys/param.h',
+  'sys/processor.h',
+  'sys/pstat.h',
+  'sys/resource.h',
+  'sys/stat.h',
+  'sys/sysctl.h',
+  'sys/sysinfo.h',
+  'sys/syssgi.h',
+  'sys/systemcfg.h',
+  'sys/times.h',
+  'sys/time.h',
+  'sys/types.h',
+  'unistd.h',
+]
+
+cc = meson.get_compiler('c')
+
+foreach h : check_headers
+  if cc.has_header(h)
+    conf.set('HAVE_' + h.underscorify().to_upper(), 1)
+  endif
+endforeach
+
+check_functions = [
+  ['HAVE_ALARM', 'alarm', '#include<unistd.h>'],
+  ['HAVE_ALLOCA', 'alloca', '#include<alloca.h>'],
+# check token ['HAVE_ATTRIBUTE_CONST']
+# check token ['HAVE_ATTRIBUTE_MALLOC']
+# check token ['HAVE_ATTRIBUTE_MODE']
+# check token ['HAVE_ATTRIBUTE_NORETURN']
+# check token ['HAVE_ATTR_GET']
+# check token ['HAVE_CALLING_CONVENTIONS']
+  ['HAVE_CLOCK', 'clock', '#include<time.h>'],
+  ['HAVE_CLOCK_GETTIME', 'clock_gettime', '#include<time.h>'],
+# check token ['HAVE_CPUTIME']
+# check token ['HAVE_DECL_FGETC']
+# check token ['HAVE_DECL_FSCANF']
+# check token ['HAVE_DECL_OPTARG']
+# check token ['HAVE_DECL_SYS_ERRLIST']
+# check token ['HAVE_DECL_SYS_NERR']
+# check token ['HAVE_DECL_UNGETC']
+# check token ['HAVE_DECL_VFPRINTF']
+# check token ['HAVE_DOUBLE_IEEE_BIG_ENDIAN']
+# check token ['HAVE_DOUBLE_IEEE_LITTLE_ENDIAN']
+# check token ['HAVE_DOUBLE_IEEE_LITTLE_SWAPPED']
+# check token ['HAVE_DOUBLE_VAX_D']
+# check token ['HAVE_DOUBLE_VAX_G']
+# check token ['HAVE_DOUBLE_CRAY_CFP']
+  ['HAVE_GETPAGESIZE', 'getpagesize', '#include<unistd.h>'],
+# check token ['HAVE_GETRUSAGE']
+# check token ['HAVE_GETSYSINFO']
+  ['HAVE_GETTIMEOFDAY', 'gettimeofday', '#include<sys/time.h>'],
+# check token ['HAVE_HIDDEN_ALIAS']
+# check token ['HAVE_HOST_CPU_FAMILY_alpha']
+# check token ['HAVE_HOST_CPU_FAMILY_m68k']
+# check token ['HAVE_HOST_CPU_FAMILY_power']
+# check token ['HAVE_HOST_CPU_FAMILY_powerpc']
+# check token ['HAVE_HOST_CPU_FAMILY_x86']
+# check token ['HAVE_HOST_CPU_FAMILY_x86_64']
+# check token ['HAVE_INTMAX_T']
+# check token ['HAVE_INTPTR_T']
+# check token ['HAVE_LIMB_BIG_ENDIAN']
+# check token ['HAVE_LIMB_LITTLE_ENDIAN']
+# check token ['HAVE_LOCALECONV']
+# check token ['HAVE_LONG_DOUBLE']
+# check token ['HAVE_LONG_LONG']
+  ['HAVE_MEMSET', 'memset', '#include<string.h>'],
+  ['HAVE_MMAP', 'mmap', '#include<sys/mman.h>'],
+  ['HAVE_MPROTECT', 'mprotect', '#include<sys/mman.h>'],
+# check token ['HAVE_NATIVE_mpn_add_n']
+# check token ['HAVE_NATIVE_mpn_add_n_sub_n']
+# check token ['HAVE_NATIVE_mpn_add_nc']
+# check token ['HAVE_NATIVE_mpn_addaddmul_1msb0']
+# check token ['HAVE_NATIVE_mpn_addlsh1_n']
+# check token ['HAVE_NATIVE_mpn_addlsh2_n']
+# check token ['HAVE_NATIVE_mpn_addlsh_n']
+# check token ['HAVE_NATIVE_mpn_addlsh1_nc']
+# check token ['HAVE_NATIVE_mpn_addlsh2_nc']
+# check token ['HAVE_NATIVE_mpn_addlsh_nc']
+# check token ['HAVE_NATIVE_mpn_addlsh1_n_ip1']
+# check token ['HAVE_NATIVE_mpn_addlsh2_n_ip1']
+# check token ['HAVE_NATIVE_mpn_addlsh_n_ip1']
+# check token ['HAVE_NATIVE_mpn_addlsh1_nc_ip1']
+# check token ['HAVE_NATIVE_mpn_addlsh2_nc_ip1']
+# check token ['HAVE_NATIVE_mpn_addlsh_nc_ip1']
+# check token ['HAVE_NATIVE_mpn_addlsh1_n_ip2']
+# check token ['HAVE_NATIVE_mpn_addlsh2_n_ip2']
+# check token ['HAVE_NATIVE_mpn_addlsh_n_ip2']
+# check token ['HAVE_NATIVE_mpn_addlsh1_nc_ip2']
+# check token ['HAVE_NATIVE_mpn_addlsh2_nc_ip2']
+# check token ['HAVE_NATIVE_mpn_addlsh_nc_ip2']
+# check token ['HAVE_NATIVE_mpn_addmul_1c']
+# check token ['HAVE_NATIVE_mpn_addmul_2']
+# check token ['HAVE_NATIVE_mpn_addmul_3']
+# check token ['HAVE_NATIVE_mpn_addmul_4']
+# check token ['HAVE_NATIVE_mpn_addmul_5']
+# check token ['HAVE_NATIVE_mpn_addmul_6']
+# check token ['HAVE_NATIVE_mpn_addmul_7']
+# check token ['HAVE_NATIVE_mpn_addmul_8']
+# check token ['HAVE_NATIVE_mpn_addmul_2s']
+# check token ['HAVE_NATIVE_mpn_and_n']
+# check token ['HAVE_NATIVE_mpn_andn_n']
+# check token ['HAVE_NATIVE_mpn_bdiv_dbm1c']
+# check token ['HAVE_NATIVE_mpn_bdiv_q_1']
+# check token ['HAVE_NATIVE_mpn_pi1_bdiv_q_1']
+# check token ['HAVE_NATIVE_mpn_cnd_add_n']
+# check token ['HAVE_NATIVE_mpn_cnd_sub_n']
+# check token ['HAVE_NATIVE_mpn_com']
+# check token ['HAVE_NATIVE_mpn_copyd']
+# check token ['HAVE_NATIVE_mpn_copyi']
+# check token ['HAVE_NATIVE_mpn_div_qr_1n_pi1']
+# check token ['HAVE_NATIVE_mpn_div_qr_2']
+# check token ['HAVE_NATIVE_mpn_divexact_1']
+# check token ['HAVE_NATIVE_mpn_divexact_by3c']
+# check token ['HAVE_NATIVE_mpn_divrem_1']
+# check token ['HAVE_NATIVE_mpn_divrem_1c']
+# check token ['HAVE_NATIVE_mpn_divrem_2']
+# check token ['HAVE_NATIVE_mpn_gcd_1']
+# check token ['HAVE_NATIVE_mpn_gcd_11']
+# check token ['HAVE_NATIVE_mpn_gcd_22']
+# check token ['HAVE_NATIVE_mpn_hamdist']
+# check token ['HAVE_NATIVE_mpn_invert_limb']
+# check token ['HAVE_NATIVE_mpn_ior_n']
+# check token ['HAVE_NATIVE_mpn_iorn_n']
+# check token ['HAVE_NATIVE_mpn_lshift']
+# check token ['HAVE_NATIVE_mpn_lshiftc']
+# check token ['HAVE_NATIVE_mpn_lshsub_n']
+# check token ['HAVE_NATIVE_mpn_mod_1']
+# check token ['HAVE_NATIVE_mpn_mod_1_1p']
+# check token ['HAVE_NATIVE_mpn_mod_1c']
+# check token ['HAVE_NATIVE_mpn_mod_1s_2p']
+# check token ['HAVE_NATIVE_mpn_mod_1s_4p']
+# check token ['HAVE_NATIVE_mpn_mod_34lsub1']
+# check token ['HAVE_NATIVE_mpn_modexact_1_odd']
+# check token ['HAVE_NATIVE_mpn_modexact_1c_odd']
+# check token ['HAVE_NATIVE_mpn_mul_1']
+# check token ['HAVE_NATIVE_mpn_mul_1c']
+# check token ['HAVE_NATIVE_mpn_mul_2']
+# check token ['HAVE_NATIVE_mpn_mul_3']
+# check token ['HAVE_NATIVE_mpn_mul_4']
+# check token ['HAVE_NATIVE_mpn_mul_5']
+# check token ['HAVE_NATIVE_mpn_mul_6']
+# check token ['HAVE_NATIVE_mpn_mul_basecase']
+# check token ['HAVE_NATIVE_mpn_mullo_basecase']
+# check token ['HAVE_NATIVE_mpn_nand_n']
+# check token ['HAVE_NATIVE_mpn_nior_n']
+# check token ['HAVE_NATIVE_mpn_popcount']
+# check token ['HAVE_NATIVE_mpn_preinv_divrem_1']
+# check token ['HAVE_NATIVE_mpn_preinv_mod_1']
+# check token ['HAVE_NATIVE_mpn_redc_1']
+# check token ['HAVE_NATIVE_mpn_redc_2']
+# check token ['HAVE_NATIVE_mpn_rsblsh1_n']
+# check token ['HAVE_NATIVE_mpn_rsblsh2_n']
+# check token ['HAVE_NATIVE_mpn_rsblsh_n']
+# check token ['HAVE_NATIVE_mpn_rsblsh1_nc']
+# check token ['HAVE_NATIVE_mpn_rsblsh2_nc']
+# check token ['HAVE_NATIVE_mpn_rsblsh_nc']
+# check token ['HAVE_NATIVE_mpn_rsh1add_n']
+# check token ['HAVE_NATIVE_mpn_rsh1add_nc']
+# check token ['HAVE_NATIVE_mpn_rsh1sub_n']
+# check token ['HAVE_NATIVE_mpn_rsh1sub_nc']
+# check token ['HAVE_NATIVE_mpn_rshift']
+# check token ['HAVE_NATIVE_mpn_sbpi1_bdiv_r']
+# check token ['HAVE_NATIVE_mpn_sqr_basecase']
+# check token ['HAVE_NATIVE_mpn_sqr_diagonal']
+# check token ['HAVE_NATIVE_mpn_sqr_diag_addlsh1']
+# check token ['HAVE_NATIVE_mpn_sub_n']
+# check token ['HAVE_NATIVE_mpn_sub_nc']
+# check token ['HAVE_NATIVE_mpn_sublsh1_n']
+# check token ['HAVE_NATIVE_mpn_sublsh2_n']
+# check token ['HAVE_NATIVE_mpn_sublsh_n']
+# check token ['HAVE_NATIVE_mpn_sublsh1_nc']
+# check token ['HAVE_NATIVE_mpn_sublsh2_nc']
+# check token ['HAVE_NATIVE_mpn_sublsh_nc']
+# check token ['HAVE_NATIVE_mpn_sublsh1_n_ip1']
+# check token ['HAVE_NATIVE_mpn_sublsh2_n_ip1']
+# check token ['HAVE_NATIVE_mpn_sublsh_n_ip1']
+# check token ['HAVE_NATIVE_mpn_sublsh1_nc_ip1']
+# check token ['HAVE_NATIVE_mpn_sublsh2_nc_ip1']
+# check token ['HAVE_NATIVE_mpn_sublsh_nc_ip1']
+# check token ['HAVE_NATIVE_mpn_submul_1c']
+# check token ['HAVE_NATIVE_mpn_tabselect']
+# check token ['HAVE_NATIVE_mpn_udiv_qrnnd']
+# check token ['HAVE_NATIVE_mpn_udiv_qrnnd_r']
+# check token ['HAVE_NATIVE_mpn_umul_ppmm']
+# check token ['HAVE_NATIVE_mpn_umul_ppmm_r']
+# check token ['HAVE_NATIVE_mpn_xor_n']
+# check token ['HAVE_NATIVE_mpn_xnor_n']
+# check token ['HAVE_NL_LANGINFO']
+# check token ['HAVE_OBSTACK_VPRINTF']
+# check token ['HAVE_POPEN']
+# check token ['HAVE_PROCESSOR_INFO']
+# check token ['HAVE_PSP_ITICKSPERCLKTICK']
+# check token ['HAVE_PSTAT_GETPROCESSOR']
+# check token ['HAVE_PTRDIFF_T']
+# check token ['HAVE_QUAD_T']
+  ['HAVE_RAISE', 'raise', '#include<signal.h>'],
+# check token ['HAVE_READ_REAL_TIME']
+  ['HAVE_SIGACTION', 'sigaction', '#include<signal.h>'],
+  ['HAVE_SIGALTSTACK', 'sigaltstack', '#include<signal.h>'],
+# check token ['HAVE_SIGSTACK']
+# check token ['HAVE_SPEED_CYCLECOUNTER']
+# check token ['HAVE_SSTREAM']
+# check token ['HAVE_STACK_T']
+# check token ['HAVE_STD__LOCALE']
+  ['HAVE_STRCHR', 'strchr', '#include<string.h>'],
+  ['HAVE_STRERROR', 'strerror', '#include<string.h>'],
+# check token ['HAVE_STRNLEN']
+  ['HAVE_STRTOL', 'strtol', '#include<stdlib.h>'],
+  ['HAVE_STRTOUL', 'strtoul', '#include<stdlib.h>'],
+  ['HAVE_SYSCONF', 'sysconf', '#include<unistd.h>'],
+# check token ['HAVE_SYSCTL']
+  ['HAVE_SYSCTLBYNAME', 'sysctlbyname', '#include<sys/sysctl.h>'],
+# check token ['HAVE_SYSSGI']
+  ['HAVE_TIMES', 'times', '#include<sys/times.h>'],
+# check token ['HAVE_UINT_LEAST32_T']
+  ['HAVE_VSNPRINTF', 'vsnprintf', '#include<stdio.h>'],
+]
+
+foreach f : check_functions
+  if cc.has_function(f.get(1), prefix : f.get(2))
+    conf.set(f.get(0), 1)
+  endif
+endforeach
+
+conf.set('SIZEOF_MP_LIMB_T', cc.sizeof('mp limb t'))
+conf.set('SIZEOF_UNSIGNED', cc.sizeof('unsigned'))
+conf.set('SIZEOF_UNSIGNED_LONG', cc.sizeof('unsigned long'))
+conf.set('SIZEOF_UNSIGNED_SHORT', cc.sizeof('unsigned short'))
+conf.set('SIZEOF_VOID_P', cc.sizeof('void*'))
+
+configure_file(
+  input: 'config.h.meson',
+  output: 'config.h',
+  configuration: conf,
+)

--- a/subprojects/packagefiles/gmp/meson.build
+++ b/subprojects/packagefiles/gmp/meson.build
@@ -15,9 +15,11 @@ profiling = get_option('profiling')
 if profiling != 'no'
   conf.set('WANT_PROFILING_' + profiling.to_upper(), 1)
 endif
-fomit_frame_pointer = []
-if profiling == 'gprof':
-  fomit_frame_pointer += ['-fomit-frame-pointer']
+
+fomit_frame_pointer = ['-fomit-frame-pointer']
+# -fomit-frame-pointer is incompatible with -pg on some chips
+if profiling == 'gprof'
+  fomit_frame_pointer = []
 endif
 
 fake_cpuid = get_option('fake-cpuid')
@@ -37,25 +39,6 @@ endif
 host_machine_cpu = host_machine.cpu()
 conf.set('HAVE_HOST_CPU_' + host_machine.cpu(), 1)
 conf.set('HAVE_HOST_CPU_FAMILY_' + host_machine.cpu_family(), 1)
-
-abi_list = ['standard']
-cc_list = ['gcc', 'cc']
-gcc_cflags = ['-O2', '-pedantic']
-gcc_64_cflags = ['-O2', '-pedantic']
-cc_cflags = ['-O']
-cc_64_cflags = ['-O']
-SPEED_CYCLECOUNTER_OBJ = []
-cyclecounter_size = 2
-mpn_search_path = []
-
-conf.set('HAVE_HOST_CPU_FAMILY_power', 0)
-conf.set('HAVE_HOST_CPU_FAMILY_powerpc', 0)
-
-variables = {
-  'alpha': {
-    'mpn_search_path': []
-  }
-}
 
 
 check_headers = [

--- a/subprojects/packagefiles/gmp/meson_options.txt
+++ b/subprojects/packagefiles/gmp/meson_options.txt
@@ -1,0 +1,146 @@
+option(
+    'assert',
+    type : 'boolean',
+    value : false,
+    description : 'enable ASSERT checking'
+)
+
+option(
+    'alloca',
+    type : 'combo',
+    choices : [
+        'alloca',
+        'malloc-reentrant',
+        'malloc-notreentrant',
+        'yes',
+        'no',
+        'reentrant',
+        'notreentrant',
+        'debug',
+    ],
+    value : 'reentrant',
+    description: 'how to get temp memory',
+)
+
+option(
+    'cxx',
+    type : 'feature',
+    value : 'disabled',
+    description: 'enable C++ support',
+)
+
+option(
+    'assembly',
+    type : 'boolean',
+    value : true,
+    description: 'enable the use of assembly loops',
+)
+
+option(
+    'fft',
+    type : 'boolean',
+    value : true,
+    description: 'enable FFTs for multiplication',
+)
+
+option(
+    'old-fft-full',
+    type : 'boolean',
+    value : false,
+    description: 'enable old mpn_mul_fft_full for multiplication',
+)
+
+option(
+    'nails',
+    type : 'boolean',
+    value : false,
+    description: 'use nails on limbs', # wtf are these ?
+)
+
+option(
+    'nail_size',
+    type : 'integer',
+    value : 1,
+    min: 1
+    max: 50,
+    description: 
+        'number of pairs of nail bits to use (only makes sense when the nails'
+        'option is used)', # again, wtf are these ?
+)
+
+option(
+    'profiling',
+    type : 'combo',
+    choices : [
+        'no',
+        'prof',
+        'gprof',
+        'instrument',
+    ],
+    value : 'no',
+    description: 'build with profiler support',
+)
+
+option(
+    'readline',
+    type : 'feature',
+    value : 'auto',
+    description: 'readline support in demo programs',
+)
+
+option(
+    'fat',
+    type : 'boolean',
+    value : false,
+    description: 'build fat libraries on systems that support it',
+)
+
+option(
+    'minithres',
+    type : 'boolean',
+    value : false,
+    description: 'choose minimal thresholds for testing',
+)
+
+option(
+    'fake-cpuid',
+    type : 'boolean',
+    value : false,
+    description: 'enable GMP_CPU_TYPE faking cpuid',
+)
+
+option(
+    'abi',
+    type : 'combo',
+    choices : [
+        'auto',
+        # arm, aarch64, armcortexa5(3|5|7)(neon)?, armcortexa7[2-9](neon)?
+        # armexynosm1, armthunderx, armxgene1, ia64*, itanium, itanium2
+        # powerpc*, power[3-9], s390, z900esa, z990esa, z9esa, z10esa, s390x
+        # z900, z990, z9, z10, z196, *sparc*, x86, x86_64
+        '32',
+        # armcortexa5(3|5|7)(neon)?, armcortexa7[2-9](neon)?, armexynosm1
+        # armthunderx, armxgene1, aarch64, ia64*, itanium, itanium2, mips64*,
+        # mipsisa64*, mips*-*-irix[6-9]*, s390x, z900, z990, z9, z10, z196
+        # sparc64 with BSD, sparcv9* with BSD, ultrasparc* with BSD, x86_64
+        '64',
+        # hppa2.0*, hppa64
+        '1.0',
+        # hppa2.0*, hppa64
+        '2.0n',
+        # hppa2.0 or 2.0 w with HPUX > 10
+        '2.0w',
+        # mips*
+        'o32',
+        # mips64*, mipsisa64*, mips*-*-irix[6-9]*
+        'n32',
+        # *-*-aix*, *-*-darwin*
+        'mode64',
+        # *-*-darwin*
+        'mode32',
+        # x86_64
+        'x32'
+    ],
+    value : 'auto',
+    description: 'desired ABI (for processors supporting more than one ABI)'
+)

--- a/subprojects/packagefiles/gmp/meson_options.txt
+++ b/subprojects/packagefiles/gmp/meson_options.txt
@@ -61,11 +61,11 @@ option(
     'nail_size',
     type : 'integer',
     value : 1,
-    min: 1
+    min: 1,
     max: 50,
     description: 
         'number of pairs of nail bits to use (only makes sense when the nails'
-        'option is used)', # again, wtf are these ?
+        + 'option is used)', # again, wtf are these ?
 )
 
 option(


### PR DESCRIPTION
I'm creating this wip PR so I can ask for help.

`gmp` is a project with a *huge* autotools script. Since this PR is my very first attempt at porting an autotools project, I'm really unsure what I should keep or not. The dedicated wiki page on porting autotools projects didn't fully answer the questions I have.

A *very* large portion of `gmp`'s configure script is dedicated to setting flags and options of all sorts for a dauntingly long list of compilers and supported hosts : 

- default compiler flags
- sets of flags to be tested and used if working
- available compilers for the host
- available abis for each compiler
- search path for assembly implementations of the "mpn" functions
- tests to be performed for given compiler + abi combinations
- some precompiled things related with profiling ? (`speed_cyclecounter_obj`, `cyclecounter_size`)
- etc ...

This list is not even exhaustive, you can have a look at the top of `configure.py` to see everything that's currently handled by my port.

1. Are there things in this (non-exhaustive) list we don't need to port over to meson ?
2. The original script relies **heavily** on pattern matching on the `host` and `host_cpu` values. Since i don't know how to do that in meson, I resorted to porting that part to python because and use [`fnmatch()`](https://docs.python.org/3/library/fnmatch.html?highlight=fnmatch#module-fnmatch). Isn't it a problem for a meson wrap to rely on python ?