### PR TITLE
Roll back some CI changes

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -66,8 +66,8 @@ jobs:
       - name: Install packages
         run: |
           brew update
-          brew install ninja
-          python3 -m pip install --pre meson
+          brew install ninja python
+          python3 -m pip install git+https://github.com/mesonbuild/meson
 
       - name: Sanity Checks
         run: |

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -63,10 +63,16 @@ jobs:
       - name: Fetch tags and unshallow
         run: git fetch --unshallow --tags
 
+      - run: brew update
+      # github actions overwrites brew's python. Force it to reassert itself, by running in a separate step.
+      - name: unbreak python in github actions
+        run: |
+          find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
+          sudo rm -rf /Library/Frameworks/Python.framework/
+          brew install --force python3 && brew unlink python3 && brew unlink python3 && brew link --overwrite python3
       - name: Install packages
         run: |
-          brew update
-          brew install ninja python
+          brew install ninja
           python3 -m pip install git+https://github.com/mesonbuild/meson
 
       - name: Sanity Checks

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y install build-essential python3-pip ninja-build
-          python3 -m pip install --pre meson
+          python3 -m pip install git+https://github.com/mesonbuild/meson
 
       - name: Sanity Checks
         run: |
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install packages
         run: |
-          python -m pip install --pre meson
+          python -m pip install git+https://github.com/mesonbuild/meson
 
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Sanity Checks

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -51,9 +51,15 @@ jobs:
       - name: Fetch tags and unshallow
         run: git fetch --unshallow --tags
 
+      - run: brew update
+      # github actions overwrites brew's python. Force it to reassert itself, by running in a separate step.
+      - name: unbreak python in github actions
+        run: |
+          find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
+          sudo rm -rf /Library/Frameworks/Python.framework/
+          brew install --force python3 && brew unlink python3 && brew unlink python3 && brew link --overwrite python3
       - name: Install packages
         run: |
-          brew update
           brew install ninja
           python3 -m pip install --pre meson
 


### PR DESCRIPTION
The recent changes to `.github/workflows/` mixed some harmless/good changes together with some that aren't so great. Specifically:
- we absolutely positively want to use meson from git master in the build_all CI, because the entire point of that CI is to run regression tests against bleeding-edge future versions of Meson and catch issues before release.
- macOS is broken. It's broken on multiple levels, and one of them caused CI to go red, but the real solution is the same one I PR'ed to the Meson repository, which includes a more thorough fix. I probably forgot to sync that over.