### PR TITLE
CI: do not run scheduled jobs in forks

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   Ubuntu:
+    if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
     runs-on: ubuntu-latest
     env:
       TEST_BUILD_ALL: 1
@@ -33,6 +34,7 @@ jobs:
           ./tools/sanity_checks.py
 
   VisualStudio:
+    if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
     runs-on: windows-latest
     env:
       TEST_BUILD_ALL: 1
@@ -53,6 +55,7 @@ jobs:
           python tools/sanity_checks.py
 
   MacOS:
+    if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
     runs-on: macos-latest
     env:
       TEST_BUILD_ALL: 1


### PR DESCRIPTION
Enabling CI in forks is reasonable because people might want to enable CI in order to test commits before submitting them as PRs. It's a bit less reasonable to run a weekly job no matter what -- this is intended primarily for upstream WrapDB usage to detect and investigate regressions, and won't provide meaningful results distinct from the upstream repository if run on forks. All it does is waste time and resources.

Like mesonbuild/meson's images.yml, this also allows running even on forks, if started for a reason other than automatic scheduling. In the case of Meson, it's still interesting to test whether updates to the image generation routines work, and in the case of the WrapDB, someone might want to manually test a fork for the same reason people with write permissions to the WrapDB would want to test it.

In both cases, doing so is fundamentally opt-in.