### PR TITLE
spdlog: Update fmt.cpp to bundled_fmtlib_format.cpp to track 1.11.0 change

### DIFF
--- a/subprojects/packagefiles/spdlog/src/meson.build
+++ b/subprojects/packagefiles/spdlog/src/meson.build
@@ -8,7 +8,7 @@ src = files(
 )
 
 if not fmt_dep.found()
-  src += files('fmt.cpp')
+  src += files('bundled_fmtlib_format.cpp')
 endif
 
 spdlog_lib = library(


### PR DESCRIPTION
When adding spdlog as a subproject with the default_option `compile_library=true` set while using internal fmt, build fails:

Example:
```
spdlog_proj = subproject(
    'spdlog',
    default_options: [
        'compile_library=true'
    ]
)
```

Error:
```
subprojects/spdlog-1.11.0/src/meson.build:11:2: ERROR: File fmt.cpp does not exist.
```

This is because spdlog renamed `fmt.cpp` in the 1.11.0 release. This PR updates the filename to match the new spdlog path.