### PR TITLE
ci: Do not fail build-all job for expected failures

### DIFF
--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -108,6 +108,11 @@ PER_PROJECT_PERMITTED_FILES = {
 NO_TABS_FILES = ['meson.build', 'meson_options.txt']
 PERMITTED_KEYS = {'versions', 'dependency_names', 'program_names'}
 
+class ExpectedError(Exception):
+    pass
+
+class UnexpectedSuccess(Exception):
+    pass
 
 class TestReleases(unittest.TestCase):
     @classmethod
@@ -252,6 +257,7 @@ class TestReleases(unittest.TestCase):
         skipped = []
         failed = []
         errored = []
+        succeed = []
         for name, info in self.releases.items():
             if name in self.skip:
                 skipped.append(name)
@@ -264,14 +270,17 @@ class TestReleases(unittest.TestCase):
                 passed.append(name)
             except subprocess.CalledProcessError:
                 failed.append(name)
-            except Exception:
+            except ExpectedError:
                 errored.append(name)
+            except UnexpectedSuccess:
+                succeed.append(name)
         print(f'{len(passed)} passed:', ', '.join(passed))
         print(f'{len(skipped)} skipped:', ', '.join(skipped))
         print(f'{len(failed)} failed:', ', '.join(failed))
-        print(f'{len(errored)} errored:', ', '.join(errored))
+        print(f'{len(errored)} expected errored:', ', '.join(errored))
+        print(f'{len(succeed)} unexpected succeed:', ', '.join(succeed))
         self.assertFalse(failed)
-        self.assertFalse(errored)
+        self.assertFalse(succeed)
 
     def check_has_no_path_separators(self, value: str) -> None:
         self.assertNotIn('/', value)
@@ -344,7 +353,7 @@ class TestReleases(unittest.TestCase):
         res = subprocess.run(['meson', 'setup', builddir] + options, env=meson_env)
         if res.returncode == 0:
             if not expect_working:
-                raise Exception(f'Wrap {name} successfully configured but was expected to fail')
+                raise UnexpectedSuccess(f'Wrap {name} successfully configured but was expected to fail')
         else:
             log_file = Path(builddir, 'meson-logs', 'meson-log.txt')
             logs = log_file.read_text(encoding='utf-8')
@@ -354,6 +363,8 @@ class TestReleases(unittest.TestCase):
                 print('::endgroup::')
                 res.check_returncode()
             else:
+                # It failed as expected, still raise an exception if it's not an explicit
+                # error message about unsupported platform.
                 loglines = logs.splitlines()
                 lasterror = [i for i, j in enumerate(loglines) if 'ERROR: ' in j][-1]
                 error = ' '.join(loglines[lasterror:])
@@ -364,7 +375,7 @@ class TestReleases(unittest.TestCase):
                     if 'not found' in error:
                         print('cannot verify in wrapdb due to missing dependency')
                         return
-            raise Exception(f'Wrap {name} failed to configure due to bugs in the wrap, rather than due to being unsupported')
+                raise ExpectedError(f'Wrap {name} failed to configure due to bugs in the wrap, rather than due to being unsupported')
         subprocess.check_call(['meson', 'compile', '-C', builddir], env=meson_env)
         try:
             subprocess.check_call(['meson', 'test', '-C', builddir, '--suite', name, '--print-errorlogs'])


### PR DESCRIPTION
Some wraps (e.g. Wayland) fail on some platforms as expected but without an explicit unsupported error message. We consider that to be a failure for PRs, but for the build-all job it is not a problem.

Wraps that were expected to fail but suddenly succeed is still an issue that should fail the build-all job.

Fixes: #906