### PR TITLE
git: set encoding, not working-tree-encoding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* -text eol=lf working-tree-encoding=UTF-8
+* -text eol=lf encoding=UTF-8


### PR DESCRIPTION
The original goal was to use utf8 for the git repo.