### PR TITLE
unittest-cpp: use proper check for Windows

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -2404,7 +2404,11 @@
     ]
   },
   "unittest-cpp": {
+    "dependency_names": [
+      "unittest-cpp"
+    ],
     "versions": [
+      "2.0.0-2",
       "2.0.0-1"
     ]
   },

--- a/subprojects/packagefiles/unittest-cpp/UnitTest++/meson.build
+++ b/subprojects/packagefiles/unittest-cpp/UnitTest++/meson.build
@@ -21,7 +21,7 @@ unittest_cpp_src += files(
     'XmlTestReporter.cpp'
 )
 
-if build_machine.system() == 'windows'
+if host_machine.system() == 'windows'
     subdir('Win32')
 else
     subdir('Posix')

--- a/subprojects/packagefiles/unittest-cpp/meson.build
+++ b/subprojects/packagefiles/unittest-cpp/meson.build
@@ -4,9 +4,13 @@ project('UnitTest++', 'cpp',
 
 unittest_cpp_src = []
 
+if meson.get_compiler('cpp').get_argument_syntax() == 'msvc'
+  add_project_arguments('-D_CRT_SECURE_NO_WARNINGS', language: 'cpp')
+endif
+
 subdir('UnitTest++')
 
-unittest_cpp_lib = static_library('unittest-cpp', 
+unittest_cpp_lib = static_library('unittest-cpp',
     unittest_cpp_src,
     include_directories : '.')
 

--- a/subprojects/unittest-cpp.wrap
+++ b/subprojects/unittest-cpp.wrap
@@ -4,3 +4,6 @@ source_url = https://github.com/unittest-cpp/unittest-cpp/archive/v2.0.0.tar.gz
 source_filename = unittest-cpp-2.0.0.tar.gz
 source_hash = 74852198877dc2fdebdc4e5e9bd074018bf8ee03a13de139bfe41f4585b2f5b9
 patch_directory = unittest-cpp
+
+[provide]
+unittest-cpp = unittest_cpp_dep


### PR DESCRIPTION
Also silence warnings under MSVC.