### PR TITLE
Add bshoshany-thread-pool

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -95,6 +95,14 @@
       "2.3.1-2"
     ]
   },
+  "bshoshany-thread-pool": {
+    "dependency_names": [
+      "bshoshany-thread-pool"
+    ],
+    "versions": [
+      "3.3.0-1"
+    ]
+  },
   "c-flags": {
     "dependency_names": [
         "c-flags"

--- a/subprojects/bshoshany-thread-pool.wrap
+++ b/subprojects/bshoshany-thread-pool.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = thread-pool-3.3.0
+source_url = https://github.com/bshoshany/thread-pool/archive/refs/tags/v3.3.0.zip
+source_filename = thread-pool-3.3.0.zip
+source_hash = 23b603b38aa4b4dbb0baafde2c1ef16a2ac16a7a105efdd10ecb8db1e89f0555
+patch_directory = bshoshany-thread-pool
+
+[provide]
+bshoshany-thread-pool = bshoshany_thread_pool_dep

--- a/subprojects/packagefiles/bshoshany-thread-pool/meson.build
+++ b/subprojects/packagefiles/bshoshany-thread-pool/meson.build
@@ -1,0 +1,33 @@
+project('bshoshany-thread-pool', 'cpp',
+  version : '3.3.0',
+  license : 'MIT',
+  meson_version: '>=0.47.0',
+  default_options: ['cpp_std=c++17'],
+)
+
+thread_dep = dependency('threads')
+
+bshoshany_thread_pool_dep = declare_dependency(include_directories: include_directories('.'), dependencies: thread_dep)
+
+BS_thread_pool_test_exe = executable('thread_pool_test',
+  'BS_thread_pool_test.cpp',
+  dependencies: [bshoshany_thread_pool_dep],
+  build_by_default: false)
+
+test('thread_pool_test', BS_thread_pool_test_exe)
+benchmark('thread_pool_test benchmark', BS_thread_pool_test_exe)
+
+BS_thread_pool_light_test_exe = executable('thread_pool_light_test',
+  'BS_thread_pool_light_test.cpp',
+  dependencies: [bshoshany_thread_pool_dep],
+  build_by_default: false)
+
+test('thread_pool_light_test', BS_thread_pool_light_test_exe)
+
+if not meson.is_subproject()
+  install_headers('BS_thread_pool.hpp', 'BS_thread_pool_light.hpp')
+endif
+
+if meson.version().version_compare('>=0.54.0')
+  meson.override_dependency('bshoshany-thread-pool', bshoshany_thread_pool_dep)
+endif


### PR DESCRIPTION
Add https://github.com/bshoshany/thread-pool - a header-only C++ thread pool implementation. I've [PRed](https://github.com/bshoshany/thread-pool/pull/106) `meson.build` upstream, so hopefully next release will include it, allowing us to only keep wrap around. Includes built-in tests.

As for wrap name, it was taken from conan and vcpkg versions of this library.