### PR TITLE
Add glbinding

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -100,6 +100,15 @@
       "windows": false
     }
   },
+  "glbinding": {
+    "debian_packages": [
+      "libxi-dev",
+      "libxkbcommon-dev"
+    ],
+    "build_options": [
+      "glbinding:build_tests=enabled"
+    ]
+  },
   "glew": {
     "debian_packages": [
       "libgl-dev"

--- a/releases.json
+++ b/releases.json
@@ -588,6 +588,15 @@
       "1.14.1-1"
     ]
   },
+  "glbinding": {
+    "dependency_names": [
+      "glbinding",
+      "glbinding-aux"
+    ],
+    "versions": [
+      "3.3.0-1"
+    ]
+  },
   "glew": {
     "dependency_names": [
       "glew"

--- a/subprojects/glbinding.wrap
+++ b/subprojects/glbinding.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = glbinding-3.3.0
+source_url = https://github.com/cginternals/glbinding/archive/refs/tags/v3.3.0.zip
+source_filename = glbinding-3.3.0.zip
+source_hash = e035385dab8e9e687229e6b95b36c00bc0407669691913de5b63ca734e82b617
+patch_directory = glbinding
+
+[provide]
+glbinding = glbinding_dep
+glbinding-aux = glbinding_aux_dep

--- a/subprojects/packagefiles/glbinding/bundled_headers/glbinding-aux/glbinding-aux_api.h
+++ b/subprojects/packagefiles/glbinding/bundled_headers/glbinding-aux/glbinding-aux_api.h
@@ -1,0 +1,21 @@
+// Modified manually for Meson wrap
+
+#ifndef GLBINDING_AUX_TEMPLATE_API_H
+#define GLBINDING_AUX_TEMPLATE_API_H
+
+#include <glbinding-aux/glbinding-aux_export.h>
+
+#ifdef GLBINDING_AUX_STATIC_DEFINE
+#  define GLBINDING_AUX_TEMPLATE_API
+#else
+#  ifndef GLBINDING_AUX_TEMPLATE_API
+#    ifdef _MSC_VER
+#      define GLBINDING_AUX_TEMPLATE_API
+#    else
+#      define GLBINDING_AUX_TEMPLATE_API __attribute__((visibility("default")))
+#    endif
+#  endif
+
+#endif
+
+#endif

--- a/subprojects/packagefiles/glbinding/bundled_headers/glbinding-aux/glbinding-aux_export.h
+++ b/subprojects/packagefiles/glbinding/bundled_headers/glbinding-aux/glbinding-aux_export.h
@@ -1,0 +1,55 @@
+// Modified manually for Meson wrap
+
+#ifndef GLBINDING_AUX_API_H
+#define GLBINDING_AUX_API_H
+
+#ifdef GLBINDING_AUX_STATIC_DEFINE
+#  define GLBINDING_AUX_API
+#  define GLBINDING_AUX_NO_EXPORT
+#else
+#  ifndef GLBINDING_AUX_API
+#    ifdef _MSC_VER
+#      ifdef glbinding_aux_EXPORTS
+          /* We are building this library */
+#        define GLBINDING_AUX_API __declspec(dllexport)
+#      else
+          /* We are using this library */
+#        define GLBINDING_AUX_API __declspec(dllimport)
+#      endif
+#    else
+#      define GLBINDING_AUX_API __attribute__((visibility("default")))
+#    endif
+#  endif
+
+#  ifndef GLBINDING_AUX_NO_EXPORT
+#    ifdef _MSC_VER
+#      define GLBINDING_AUX_NO_EXPORT __attribute__((visibility("hidden")))
+#    else
+#      define GLBINDING_AUX_NO_EXPORT
+#    endif
+#  endif
+#endif
+
+#ifndef GLBINDING_AUX_DEPRECATED
+#  ifndef _MSC_VER
+#    define GLBINDING_AUX_DEPRECATED __attribute__ ((__deprecated__))
+#  else
+#    define GLBINDING_AUX_DEPRECATED __declspec(deprecated)
+#  endif
+#endif
+
+#ifndef GLBINDING_AUX_DEPRECATED_EXPORT
+#  define GLBINDING_AUX_DEPRECATED_EXPORT GLBINDING_AUX_API GLBINDING_AUX_DEPRECATED
+#endif
+
+#ifndef GLBINDING_AUX_DEPRECATED_NO_EXPORT
+#  define GLBINDING_AUX_DEPRECATED_NO_EXPORT GLBINDING_AUX_NO_EXPORT GLBINDING_AUX_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef GLBINDING_AUX_NO_DEPRECATED
+#    define GLBINDING_AUX_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* GLBINDING_AUX_API_H */

--- a/subprojects/packagefiles/glbinding/bundled_headers/glbinding-aux/glbinding-aux_features.h
+++ b/subprojects/packagefiles/glbinding/bundled_headers/glbinding-aux/glbinding-aux_features.h
@@ -1,0 +1,394 @@
+
+// This is a generated file. Do not edit!
+
+#ifndef GLBINDING_AUX_COMPILER_DETECTION_H
+#define GLBINDING_AUX_COMPILER_DETECTION_H
+
+#ifdef __cplusplus
+# define GLBINDING_AUX_COMPILER_IS_Comeau 0
+# define GLBINDING_AUX_COMPILER_IS_Intel 0
+# define GLBINDING_AUX_COMPILER_IS_IntelLLVM 0
+# define GLBINDING_AUX_COMPILER_IS_PathScale 0
+# define GLBINDING_AUX_COMPILER_IS_Embarcadero 0
+# define GLBINDING_AUX_COMPILER_IS_Borland 0
+# define GLBINDING_AUX_COMPILER_IS_Watcom 0
+# define GLBINDING_AUX_COMPILER_IS_OpenWatcom 0
+# define GLBINDING_AUX_COMPILER_IS_SunPro 0
+# define GLBINDING_AUX_COMPILER_IS_HP 0
+# define GLBINDING_AUX_COMPILER_IS_Compaq 0
+# define GLBINDING_AUX_COMPILER_IS_zOS 0
+# define GLBINDING_AUX_COMPILER_IS_IBMClang 0
+# define GLBINDING_AUX_COMPILER_IS_XLClang 0
+# define GLBINDING_AUX_COMPILER_IS_XL 0
+# define GLBINDING_AUX_COMPILER_IS_VisualAge 0
+# define GLBINDING_AUX_COMPILER_IS_NVHPC 0
+# define GLBINDING_AUX_COMPILER_IS_PGI 0
+# define GLBINDING_AUX_COMPILER_IS_Cray 0
+# define GLBINDING_AUX_COMPILER_IS_TI 0
+# define GLBINDING_AUX_COMPILER_IS_FujitsuClang 0
+# define GLBINDING_AUX_COMPILER_IS_Fujitsu 0
+# define GLBINDING_AUX_COMPILER_IS_GHS 0
+# define GLBINDING_AUX_COMPILER_IS_SCO 0
+# define GLBINDING_AUX_COMPILER_IS_ARMCC 0
+# define GLBINDING_AUX_COMPILER_IS_AppleClang 0
+# define GLBINDING_AUX_COMPILER_IS_ARMClang 0
+# define GLBINDING_AUX_COMPILER_IS_Clang 0
+# define GLBINDING_AUX_COMPILER_IS_LCC 0
+# define GLBINDING_AUX_COMPILER_IS_GNU 0
+# define GLBINDING_AUX_COMPILER_IS_MSVC 0
+# define GLBINDING_AUX_COMPILER_IS_ADSP 0
+# define GLBINDING_AUX_COMPILER_IS_IAR 0
+# define GLBINDING_AUX_COMPILER_IS_MIPSpro 0
+
+#if defined(__COMO__)
+# undef GLBINDING_AUX_COMPILER_IS_Comeau
+# define GLBINDING_AUX_COMPILER_IS_Comeau 1
+
+#elif defined(__INTEL_COMPILER) || defined(__ICC)
+# undef GLBINDING_AUX_COMPILER_IS_Intel
+# define GLBINDING_AUX_COMPILER_IS_Intel 1
+
+#elif (defined(__clang__) && defined(__INTEL_CLANG_COMPILER)) || defined(__INTEL_LLVM_COMPILER)
+# undef GLBINDING_AUX_COMPILER_IS_IntelLLVM
+# define GLBINDING_AUX_COMPILER_IS_IntelLLVM 1
+
+#elif defined(__PATHCC__)
+# undef GLBINDING_AUX_COMPILER_IS_PathScale
+# define GLBINDING_AUX_COMPILER_IS_PathScale 1
+
+#elif defined(__BORLANDC__) && defined(__CODEGEARC_VERSION__)
+# undef GLBINDING_AUX_COMPILER_IS_Embarcadero
+# define GLBINDING_AUX_COMPILER_IS_Embarcadero 1
+
+#elif defined(__BORLANDC__)
+# undef GLBINDING_AUX_COMPILER_IS_Borland
+# define GLBINDING_AUX_COMPILER_IS_Borland 1
+
+#elif defined(__WATCOMC__) && __WATCOMC__ < 1200
+# undef GLBINDING_AUX_COMPILER_IS_Watcom
+# define GLBINDING_AUX_COMPILER_IS_Watcom 1
+
+#elif defined(__WATCOMC__)
+# undef GLBINDING_AUX_COMPILER_IS_OpenWatcom
+# define GLBINDING_AUX_COMPILER_IS_OpenWatcom 1
+
+#elif defined(__SUNPRO_CC)
+# undef GLBINDING_AUX_COMPILER_IS_SunPro
+# define GLBINDING_AUX_COMPILER_IS_SunPro 1
+
+#elif defined(__HP_aCC)
+# undef GLBINDING_AUX_COMPILER_IS_HP
+# define GLBINDING_AUX_COMPILER_IS_HP 1
+
+#elif defined(__DECCXX)
+# undef GLBINDING_AUX_COMPILER_IS_Compaq
+# define GLBINDING_AUX_COMPILER_IS_Compaq 1
+
+#elif defined(__IBMCPP__) && defined(__COMPILER_VER__)
+# undef GLBINDING_AUX_COMPILER_IS_zOS
+# define GLBINDING_AUX_COMPILER_IS_zOS 1
+
+#elif defined(__open_xl__) && defined(__clang__)
+# undef GLBINDING_AUX_COMPILER_IS_IBMClang
+# define GLBINDING_AUX_COMPILER_IS_IBMClang 1
+
+#elif defined(__ibmxl__) && defined(__clang__)
+# undef GLBINDING_AUX_COMPILER_IS_XLClang
+# define GLBINDING_AUX_COMPILER_IS_XLClang 1
+
+#elif defined(__IBMCPP__) && !defined(__COMPILER_VER__) && __IBMCPP__ >= 800
+# undef GLBINDING_AUX_COMPILER_IS_XL
+# define GLBINDING_AUX_COMPILER_IS_XL 1
+
+#elif defined(__IBMCPP__) && !defined(__COMPILER_VER__) && __IBMCPP__ < 800
+# undef GLBINDING_AUX_COMPILER_IS_VisualAge
+# define GLBINDING_AUX_COMPILER_IS_VisualAge 1
+
+#elif defined(__NVCOMPILER)
+# undef GLBINDING_AUX_COMPILER_IS_NVHPC
+# define GLBINDING_AUX_COMPILER_IS_NVHPC 1
+
+#elif defined(__PGI)
+# undef GLBINDING_AUX_COMPILER_IS_PGI
+# define GLBINDING_AUX_COMPILER_IS_PGI 1
+
+#elif defined(_CRAYC)
+# undef GLBINDING_AUX_COMPILER_IS_Cray
+# define GLBINDING_AUX_COMPILER_IS_Cray 1
+
+#elif defined(__TI_COMPILER_VERSION__)
+# undef GLBINDING_AUX_COMPILER_IS_TI
+# define GLBINDING_AUX_COMPILER_IS_TI 1
+
+#elif defined(__CLANG_FUJITSU)
+# undef GLBINDING_AUX_COMPILER_IS_FujitsuClang
+# define GLBINDING_AUX_COMPILER_IS_FujitsuClang 1
+
+#elif defined(__FUJITSU)
+# undef GLBINDING_AUX_COMPILER_IS_Fujitsu
+# define GLBINDING_AUX_COMPILER_IS_Fujitsu 1
+
+#elif defined(__ghs__)
+# undef GLBINDING_AUX_COMPILER_IS_GHS
+# define GLBINDING_AUX_COMPILER_IS_GHS 1
+
+#elif defined(__SCO_VERSION__)
+# undef GLBINDING_AUX_COMPILER_IS_SCO
+# define GLBINDING_AUX_COMPILER_IS_SCO 1
+
+#elif defined(__ARMCC_VERSION) && !defined(__clang__)
+# undef GLBINDING_AUX_COMPILER_IS_ARMCC
+# define GLBINDING_AUX_COMPILER_IS_ARMCC 1
+
+#elif defined(__clang__) && defined(__apple_build_version__)
+# undef GLBINDING_AUX_COMPILER_IS_AppleClang
+# define GLBINDING_AUX_COMPILER_IS_AppleClang 1
+
+#elif defined(__clang__) && defined(__ARMCOMPILER_VERSION)
+# undef GLBINDING_AUX_COMPILER_IS_ARMClang
+# define GLBINDING_AUX_COMPILER_IS_ARMClang 1
+
+#elif defined(__clang__)
+# undef GLBINDING_AUX_COMPILER_IS_Clang
+# define GLBINDING_AUX_COMPILER_IS_Clang 1
+
+#elif defined(__LCC__) && (defined(__GNUC__) || defined(__GNUG__) || defined(__MCST__))
+# undef GLBINDING_AUX_COMPILER_IS_LCC
+# define GLBINDING_AUX_COMPILER_IS_LCC 1
+
+#elif defined(__GNUC__) || defined(__GNUG__)
+# undef GLBINDING_AUX_COMPILER_IS_GNU
+# define GLBINDING_AUX_COMPILER_IS_GNU 1
+
+#elif defined(_MSC_VER)
+# undef GLBINDING_AUX_COMPILER_IS_MSVC
+# define GLBINDING_AUX_COMPILER_IS_MSVC 1
+
+#elif defined(_ADI_COMPILER)
+# undef GLBINDING_AUX_COMPILER_IS_ADSP
+# define GLBINDING_AUX_COMPILER_IS_ADSP 1
+
+#elif defined(__IAR_SYSTEMS_ICC__) || defined(__IAR_SYSTEMS_ICC)
+# undef GLBINDING_AUX_COMPILER_IS_IAR
+# define GLBINDING_AUX_COMPILER_IS_IAR 1
+
+
+#endif
+
+#  if GLBINDING_AUX_COMPILER_IS_AppleClang
+
+#    if !(((__clang_major__ * 100) + __clang_minor__) >= 400)
+#      error Unsupported compiler version
+#    endif
+
+# define GLBINDING_AUX_COMPILER_VERSION_MAJOR (__clang_major__)
+# define GLBINDING_AUX_COMPILER_VERSION_MINOR (__clang_minor__)
+# define GLBINDING_AUX_COMPILER_VERSION_PATCH (__clang_patchlevel__)
+# if defined(_MSC_VER)
+   /* _MSC_VER = VVRR */
+#  define GLBINDING_AUX_SIMULATE_VERSION_MAJOR (_MSC_VER / 100)
+#  define GLBINDING_AUX_SIMULATE_VERSION_MINOR (_MSC_VER % 100)
+# endif
+# define GLBINDING_AUX_COMPILER_VERSION_TWEAK (__apple_build_version__)
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_thread_local)
+#      define GLBINDING_AUX_COMPILER_CXX_THREAD_LOCAL 1
+#    else
+#      define GLBINDING_AUX_COMPILER_CXX_THREAD_LOCAL 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_constexpr)
+#      define GLBINDING_AUX_COMPILER_CXX_CONSTEXPR 1
+#    else
+#      define GLBINDING_AUX_COMPILER_CXX_CONSTEXPR 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 501 && __cplusplus > 201103L
+#      define GLBINDING_AUX_COMPILER_CXX_ATTRIBUTE_DEPRECATED 1
+#    else
+#      define GLBINDING_AUX_COMPILER_CXX_ATTRIBUTE_DEPRECATED 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_noexcept)
+#      define GLBINDING_AUX_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define GLBINDING_AUX_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#  elif GLBINDING_AUX_COMPILER_IS_Clang
+
+#    if !(((__clang_major__ * 100) + __clang_minor__) >= 301)
+#      error Unsupported compiler version
+#    endif
+
+# define GLBINDING_AUX_COMPILER_VERSION_MAJOR (__clang_major__)
+# define GLBINDING_AUX_COMPILER_VERSION_MINOR (__clang_minor__)
+# define GLBINDING_AUX_COMPILER_VERSION_PATCH (__clang_patchlevel__)
+# if defined(_MSC_VER)
+   /* _MSC_VER = VVRR */
+#  define GLBINDING_AUX_SIMULATE_VERSION_MAJOR (_MSC_VER / 100)
+#  define GLBINDING_AUX_SIMULATE_VERSION_MINOR (_MSC_VER % 100)
+# endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_thread_local)
+#      define GLBINDING_AUX_COMPILER_CXX_THREAD_LOCAL 1
+#    else
+#      define GLBINDING_AUX_COMPILER_CXX_THREAD_LOCAL 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_constexpr)
+#      define GLBINDING_AUX_COMPILER_CXX_CONSTEXPR 1
+#    else
+#      define GLBINDING_AUX_COMPILER_CXX_CONSTEXPR 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 304 && __cplusplus > 201103L
+#      define GLBINDING_AUX_COMPILER_CXX_ATTRIBUTE_DEPRECATED 1
+#    else
+#      define GLBINDING_AUX_COMPILER_CXX_ATTRIBUTE_DEPRECATED 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_noexcept)
+#      define GLBINDING_AUX_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define GLBINDING_AUX_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#  elif GLBINDING_AUX_COMPILER_IS_GNU
+
+#    if !((__GNUC__ * 100 + __GNUC_MINOR__) >= 404)
+#      error Unsupported compiler version
+#    endif
+
+# if defined(__GNUC__)
+#  define GLBINDING_AUX_COMPILER_VERSION_MAJOR (__GNUC__)
+# else
+#  define GLBINDING_AUX_COMPILER_VERSION_MAJOR (__GNUG__)
+# endif
+# if defined(__GNUC_MINOR__)
+#  define GLBINDING_AUX_COMPILER_VERSION_MINOR (__GNUC_MINOR__)
+# endif
+# if defined(__GNUC_PATCHLEVEL__)
+#  define GLBINDING_AUX_COMPILER_VERSION_PATCH (__GNUC_PATCHLEVEL__)
+# endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 && __cplusplus >= 201103L
+#      define GLBINDING_AUX_COMPILER_CXX_THREAD_LOCAL 1
+#    else
+#      define GLBINDING_AUX_COMPILER_CXX_THREAD_LOCAL 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 406 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define GLBINDING_AUX_COMPILER_CXX_CONSTEXPR 1
+#    else
+#      define GLBINDING_AUX_COMPILER_CXX_CONSTEXPR 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 409 && __cplusplus > 201103L
+#      define GLBINDING_AUX_COMPILER_CXX_ATTRIBUTE_DEPRECATED 1
+#    else
+#      define GLBINDING_AUX_COMPILER_CXX_ATTRIBUTE_DEPRECATED 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 406 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define GLBINDING_AUX_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define GLBINDING_AUX_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#  elif GLBINDING_AUX_COMPILER_IS_MSVC
+
+#    if !(_MSC_VER >= 1600)
+#      error Unsupported compiler version
+#    endif
+
+  /* _MSC_VER = VVRR */
+# define GLBINDING_AUX_COMPILER_VERSION_MAJOR (_MSC_VER / 100)
+# define GLBINDING_AUX_COMPILER_VERSION_MINOR (_MSC_VER % 100)
+# if defined(_MSC_FULL_VER)
+#  if _MSC_VER >= 1400
+    /* _MSC_FULL_VER = VVRRPPPPP */
+#   define GLBINDING_AUX_COMPILER_VERSION_PATCH (_MSC_FULL_VER % 100000)
+#  else
+    /* _MSC_FULL_VER = VVRRPPPP */
+#   define GLBINDING_AUX_COMPILER_VERSION_PATCH (_MSC_FULL_VER % 10000)
+#  endif
+# endif
+# if defined(_MSC_BUILD)
+#  define GLBINDING_AUX_COMPILER_VERSION_TWEAK (_MSC_BUILD)
+# endif
+
+#    if _MSC_VER >= 1900
+#      define GLBINDING_AUX_COMPILER_CXX_THREAD_LOCAL 1
+#    else
+#      define GLBINDING_AUX_COMPILER_CXX_THREAD_LOCAL 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define GLBINDING_AUX_COMPILER_CXX_CONSTEXPR 1
+#    else
+#      define GLBINDING_AUX_COMPILER_CXX_CONSTEXPR 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define GLBINDING_AUX_COMPILER_CXX_ATTRIBUTE_DEPRECATED 1
+#    else
+#      define GLBINDING_AUX_COMPILER_CXX_ATTRIBUTE_DEPRECATED 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define GLBINDING_AUX_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define GLBINDING_AUX_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#  else
+#    error Unsupported compiler
+#  endif
+
+#  if defined(GLBINDING_AUX_COMPILER_CXX_THREAD_LOCAL) && GLBINDING_AUX_COMPILER_CXX_THREAD_LOCAL
+#    define GLBINDING_AUX_THREAD_LOCAL thread_local
+#  elif GLBINDING_AUX_COMPILER_IS_GNU || GLBINDING_AUX_COMPILER_IS_Clang || GLBINDING_AUX_COMPILER_IS_AppleClang
+#    define GLBINDING_AUX_THREAD_LOCAL __thread
+#  elif GLBINDING_AUX_COMPILER_IS_MSVC
+#    define GLBINDING_AUX_THREAD_LOCAL __declspec(thread)
+#  else
+// GLBINDING_AUX_THREAD_LOCAL not defined for this configuration.
+#  endif
+
+
+#  if defined(GLBINDING_AUX_COMPILER_CXX_CONSTEXPR) && GLBINDING_AUX_COMPILER_CXX_CONSTEXPR
+#    define GLBINDING_AUX_CONSTEXPR constexpr
+#  else
+#    define GLBINDING_AUX_CONSTEXPR 
+#  endif
+
+
+#  ifndef GLBINDING_AUX_DEPRECATED
+#    if defined(GLBINDING_AUX_COMPILER_CXX_ATTRIBUTE_DEPRECATED) && GLBINDING_AUX_COMPILER_CXX_ATTRIBUTE_DEPRECATED
+#      define GLBINDING_AUX_DEPRECATED [[deprecated]]
+#      define GLBINDING_AUX_DEPRECATED_MSG(MSG) [[deprecated(MSG)]]
+#    elif GLBINDING_AUX_COMPILER_IS_GNU || GLBINDING_AUX_COMPILER_IS_Clang
+#      define GLBINDING_AUX_DEPRECATED __attribute__((__deprecated__))
+#      define GLBINDING_AUX_DEPRECATED_MSG(MSG) __attribute__((__deprecated__(MSG)))
+#    elif GLBINDING_AUX_COMPILER_IS_MSVC
+#      define GLBINDING_AUX_DEPRECATED __declspec(deprecated)
+#      define GLBINDING_AUX_DEPRECATED_MSG(MSG) __declspec(deprecated(MSG))
+#    else
+#      define GLBINDING_AUX_DEPRECATED
+#      define GLBINDING_AUX_DEPRECATED_MSG(MSG)
+#    endif
+#  endif
+
+
+#  if defined(GLBINDING_AUX_COMPILER_CXX_NOEXCEPT) && GLBINDING_AUX_COMPILER_CXX_NOEXCEPT
+#    define GLBINDING_AUX_NOEXCEPT noexcept
+#    define GLBINDING_AUX_NOEXCEPT_EXPR(X) noexcept(X)
+#  else
+#    define GLBINDING_AUX_NOEXCEPT
+#    define GLBINDING_AUX_NOEXCEPT_EXPR(X)
+#  endif
+
+#endif
+
+#endif

--- a/subprojects/packagefiles/glbinding/bundled_headers/glbinding/glbinding_api.h
+++ b/subprojects/packagefiles/glbinding/bundled_headers/glbinding/glbinding_api.h
@@ -1,0 +1,21 @@
+// Modified manually for Meson wrap
+
+#ifndef GLBINDING_TEMPLATE_API_H
+#define GLBINDING_TEMPLATE_API_H
+
+#include <glbinding/glbinding_export.h>
+
+#ifdef GLBINDING_STATIC_DEFINE
+#  define GLBINDING_TEMPLATE_API
+#else
+#  ifndef GLBINDING_TEMPLATE_API
+#    ifdef _MSC_VER
+#      define GLBINDING_TEMPLATE_API
+#    else
+#      define GLBINDING_TEMPLATE_API __attribute__((visibility("default")))
+#    endif
+#  endif
+
+#endif
+
+#endif

--- a/subprojects/packagefiles/glbinding/bundled_headers/glbinding/glbinding_export.h
+++ b/subprojects/packagefiles/glbinding/bundled_headers/glbinding/glbinding_export.h
@@ -1,0 +1,55 @@
+// Modified manually for Meson wrap
+
+#ifndef GLBINDING_API_H
+#define GLBINDING_API_H
+
+#ifdef GLBINDING_STATIC_DEFINE
+#  define GLBINDING_API
+#  define GLBINDING_NO_EXPORT
+#else
+#  ifndef GLBINDING_API
+#    ifdef _MSC_VER
+#      ifdef glbinding_EXPORTS
+          /* We are building this library */
+#        define GLBINDING_API __declspec(dllexport)
+#      else
+          /* We are using this library */
+#        define GLBINDING_API __declspec(dllimport)
+#      endif
+#    else
+#      define GLBINDING_API __attribute__((visibility("default")))
+#    endif
+#  endif
+
+#  ifndef GLBINDING_NO_EXPORT
+#    ifdef _MSC_VER
+#      define GLBINDING_NO_EXPORT __attribute__((visibility("hidden")))
+#    else
+#      define GLBINDING_NO_EXPORT
+#    endif
+#  endif
+#endif
+
+#ifndef GLBINDING_DEPRECATED
+#  ifndef _MSC_VER
+#    define GLBINDING_DEPRECATED __attribute__ ((__deprecated__))
+#  else
+#    define GLBINDING_DEPRECATED __declspec(deprecated)
+#  endif
+#endif
+
+#ifndef GLBINDING_DEPRECATED_EXPORT
+#  define GLBINDING_DEPRECATED_EXPORT GLBINDING_API GLBINDING_DEPRECATED
+#endif
+
+#ifndef GLBINDING_DEPRECATED_NO_EXPORT
+#  define GLBINDING_DEPRECATED_NO_EXPORT GLBINDING_NO_EXPORT GLBINDING_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef GLBINDING_NO_DEPRECATED
+#    define GLBINDING_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* GLBINDING_API_H */

--- a/subprojects/packagefiles/glbinding/bundled_headers/glbinding/glbinding_features.h
+++ b/subprojects/packagefiles/glbinding/bundled_headers/glbinding/glbinding_features.h
@@ -1,0 +1,394 @@
+
+// This is a generated file. Do not edit!
+
+#ifndef GLBINDING_COMPILER_DETECTION_H
+#define GLBINDING_COMPILER_DETECTION_H
+
+#ifdef __cplusplus
+# define GLBINDING_COMPILER_IS_Comeau 0
+# define GLBINDING_COMPILER_IS_Intel 0
+# define GLBINDING_COMPILER_IS_IntelLLVM 0
+# define GLBINDING_COMPILER_IS_PathScale 0
+# define GLBINDING_COMPILER_IS_Embarcadero 0
+# define GLBINDING_COMPILER_IS_Borland 0
+# define GLBINDING_COMPILER_IS_Watcom 0
+# define GLBINDING_COMPILER_IS_OpenWatcom 0
+# define GLBINDING_COMPILER_IS_SunPro 0
+# define GLBINDING_COMPILER_IS_HP 0
+# define GLBINDING_COMPILER_IS_Compaq 0
+# define GLBINDING_COMPILER_IS_zOS 0
+# define GLBINDING_COMPILER_IS_IBMClang 0
+# define GLBINDING_COMPILER_IS_XLClang 0
+# define GLBINDING_COMPILER_IS_XL 0
+# define GLBINDING_COMPILER_IS_VisualAge 0
+# define GLBINDING_COMPILER_IS_NVHPC 0
+# define GLBINDING_COMPILER_IS_PGI 0
+# define GLBINDING_COMPILER_IS_Cray 0
+# define GLBINDING_COMPILER_IS_TI 0
+# define GLBINDING_COMPILER_IS_FujitsuClang 0
+# define GLBINDING_COMPILER_IS_Fujitsu 0
+# define GLBINDING_COMPILER_IS_GHS 0
+# define GLBINDING_COMPILER_IS_SCO 0
+# define GLBINDING_COMPILER_IS_ARMCC 0
+# define GLBINDING_COMPILER_IS_AppleClang 0
+# define GLBINDING_COMPILER_IS_ARMClang 0
+# define GLBINDING_COMPILER_IS_Clang 0
+# define GLBINDING_COMPILER_IS_LCC 0
+# define GLBINDING_COMPILER_IS_GNU 0
+# define GLBINDING_COMPILER_IS_MSVC 0
+# define GLBINDING_COMPILER_IS_ADSP 0
+# define GLBINDING_COMPILER_IS_IAR 0
+# define GLBINDING_COMPILER_IS_MIPSpro 0
+
+#if defined(__COMO__)
+# undef GLBINDING_COMPILER_IS_Comeau
+# define GLBINDING_COMPILER_IS_Comeau 1
+
+#elif defined(__INTEL_COMPILER) || defined(__ICC)
+# undef GLBINDING_COMPILER_IS_Intel
+# define GLBINDING_COMPILER_IS_Intel 1
+
+#elif (defined(__clang__) && defined(__INTEL_CLANG_COMPILER)) || defined(__INTEL_LLVM_COMPILER)
+# undef GLBINDING_COMPILER_IS_IntelLLVM
+# define GLBINDING_COMPILER_IS_IntelLLVM 1
+
+#elif defined(__PATHCC__)
+# undef GLBINDING_COMPILER_IS_PathScale
+# define GLBINDING_COMPILER_IS_PathScale 1
+
+#elif defined(__BORLANDC__) && defined(__CODEGEARC_VERSION__)
+# undef GLBINDING_COMPILER_IS_Embarcadero
+# define GLBINDING_COMPILER_IS_Embarcadero 1
+
+#elif defined(__BORLANDC__)
+# undef GLBINDING_COMPILER_IS_Borland
+# define GLBINDING_COMPILER_IS_Borland 1
+
+#elif defined(__WATCOMC__) && __WATCOMC__ < 1200
+# undef GLBINDING_COMPILER_IS_Watcom
+# define GLBINDING_COMPILER_IS_Watcom 1
+
+#elif defined(__WATCOMC__)
+# undef GLBINDING_COMPILER_IS_OpenWatcom
+# define GLBINDING_COMPILER_IS_OpenWatcom 1
+
+#elif defined(__SUNPRO_CC)
+# undef GLBINDING_COMPILER_IS_SunPro
+# define GLBINDING_COMPILER_IS_SunPro 1
+
+#elif defined(__HP_aCC)
+# undef GLBINDING_COMPILER_IS_HP
+# define GLBINDING_COMPILER_IS_HP 1
+
+#elif defined(__DECCXX)
+# undef GLBINDING_COMPILER_IS_Compaq
+# define GLBINDING_COMPILER_IS_Compaq 1
+
+#elif defined(__IBMCPP__) && defined(__COMPILER_VER__)
+# undef GLBINDING_COMPILER_IS_zOS
+# define GLBINDING_COMPILER_IS_zOS 1
+
+#elif defined(__open_xl__) && defined(__clang__)
+# undef GLBINDING_COMPILER_IS_IBMClang
+# define GLBINDING_COMPILER_IS_IBMClang 1
+
+#elif defined(__ibmxl__) && defined(__clang__)
+# undef GLBINDING_COMPILER_IS_XLClang
+# define GLBINDING_COMPILER_IS_XLClang 1
+
+#elif defined(__IBMCPP__) && !defined(__COMPILER_VER__) && __IBMCPP__ >= 800
+# undef GLBINDING_COMPILER_IS_XL
+# define GLBINDING_COMPILER_IS_XL 1
+
+#elif defined(__IBMCPP__) && !defined(__COMPILER_VER__) && __IBMCPP__ < 800
+# undef GLBINDING_COMPILER_IS_VisualAge
+# define GLBINDING_COMPILER_IS_VisualAge 1
+
+#elif defined(__NVCOMPILER)
+# undef GLBINDING_COMPILER_IS_NVHPC
+# define GLBINDING_COMPILER_IS_NVHPC 1
+
+#elif defined(__PGI)
+# undef GLBINDING_COMPILER_IS_PGI
+# define GLBINDING_COMPILER_IS_PGI 1
+
+#elif defined(_CRAYC)
+# undef GLBINDING_COMPILER_IS_Cray
+# define GLBINDING_COMPILER_IS_Cray 1
+
+#elif defined(__TI_COMPILER_VERSION__)
+# undef GLBINDING_COMPILER_IS_TI
+# define GLBINDING_COMPILER_IS_TI 1
+
+#elif defined(__CLANG_FUJITSU)
+# undef GLBINDING_COMPILER_IS_FujitsuClang
+# define GLBINDING_COMPILER_IS_FujitsuClang 1
+
+#elif defined(__FUJITSU)
+# undef GLBINDING_COMPILER_IS_Fujitsu
+# define GLBINDING_COMPILER_IS_Fujitsu 1
+
+#elif defined(__ghs__)
+# undef GLBINDING_COMPILER_IS_GHS
+# define GLBINDING_COMPILER_IS_GHS 1
+
+#elif defined(__SCO_VERSION__)
+# undef GLBINDING_COMPILER_IS_SCO
+# define GLBINDING_COMPILER_IS_SCO 1
+
+#elif defined(__ARMCC_VERSION) && !defined(__clang__)
+# undef GLBINDING_COMPILER_IS_ARMCC
+# define GLBINDING_COMPILER_IS_ARMCC 1
+
+#elif defined(__clang__) && defined(__apple_build_version__)
+# undef GLBINDING_COMPILER_IS_AppleClang
+# define GLBINDING_COMPILER_IS_AppleClang 1
+
+#elif defined(__clang__) && defined(__ARMCOMPILER_VERSION)
+# undef GLBINDING_COMPILER_IS_ARMClang
+# define GLBINDING_COMPILER_IS_ARMClang 1
+
+#elif defined(__clang__)
+# undef GLBINDING_COMPILER_IS_Clang
+# define GLBINDING_COMPILER_IS_Clang 1
+
+#elif defined(__LCC__) && (defined(__GNUC__) || defined(__GNUG__) || defined(__MCST__))
+# undef GLBINDING_COMPILER_IS_LCC
+# define GLBINDING_COMPILER_IS_LCC 1
+
+#elif defined(__GNUC__) || defined(__GNUG__)
+# undef GLBINDING_COMPILER_IS_GNU
+# define GLBINDING_COMPILER_IS_GNU 1
+
+#elif defined(_MSC_VER)
+# undef GLBINDING_COMPILER_IS_MSVC
+# define GLBINDING_COMPILER_IS_MSVC 1
+
+#elif defined(_ADI_COMPILER)
+# undef GLBINDING_COMPILER_IS_ADSP
+# define GLBINDING_COMPILER_IS_ADSP 1
+
+#elif defined(__IAR_SYSTEMS_ICC__) || defined(__IAR_SYSTEMS_ICC)
+# undef GLBINDING_COMPILER_IS_IAR
+# define GLBINDING_COMPILER_IS_IAR 1
+
+
+#endif
+
+#  if GLBINDING_COMPILER_IS_AppleClang
+
+#    if !(((__clang_major__ * 100) + __clang_minor__) >= 400)
+#      error Unsupported compiler version
+#    endif
+
+# define GLBINDING_COMPILER_VERSION_MAJOR (__clang_major__)
+# define GLBINDING_COMPILER_VERSION_MINOR (__clang_minor__)
+# define GLBINDING_COMPILER_VERSION_PATCH (__clang_patchlevel__)
+# if defined(_MSC_VER)
+   /* _MSC_VER = VVRR */
+#  define GLBINDING_SIMULATE_VERSION_MAJOR (_MSC_VER / 100)
+#  define GLBINDING_SIMULATE_VERSION_MINOR (_MSC_VER % 100)
+# endif
+# define GLBINDING_COMPILER_VERSION_TWEAK (__apple_build_version__)
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_thread_local)
+#      define GLBINDING_COMPILER_CXX_THREAD_LOCAL 1
+#    else
+#      define GLBINDING_COMPILER_CXX_THREAD_LOCAL 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_constexpr)
+#      define GLBINDING_COMPILER_CXX_CONSTEXPR 1
+#    else
+#      define GLBINDING_COMPILER_CXX_CONSTEXPR 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 501 && __cplusplus > 201103L
+#      define GLBINDING_COMPILER_CXX_ATTRIBUTE_DEPRECATED 1
+#    else
+#      define GLBINDING_COMPILER_CXX_ATTRIBUTE_DEPRECATED 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_noexcept)
+#      define GLBINDING_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define GLBINDING_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#  elif GLBINDING_COMPILER_IS_Clang
+
+#    if !(((__clang_major__ * 100) + __clang_minor__) >= 301)
+#      error Unsupported compiler version
+#    endif
+
+# define GLBINDING_COMPILER_VERSION_MAJOR (__clang_major__)
+# define GLBINDING_COMPILER_VERSION_MINOR (__clang_minor__)
+# define GLBINDING_COMPILER_VERSION_PATCH (__clang_patchlevel__)
+# if defined(_MSC_VER)
+   /* _MSC_VER = VVRR */
+#  define GLBINDING_SIMULATE_VERSION_MAJOR (_MSC_VER / 100)
+#  define GLBINDING_SIMULATE_VERSION_MINOR (_MSC_VER % 100)
+# endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_thread_local)
+#      define GLBINDING_COMPILER_CXX_THREAD_LOCAL 1
+#    else
+#      define GLBINDING_COMPILER_CXX_THREAD_LOCAL 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_constexpr)
+#      define GLBINDING_COMPILER_CXX_CONSTEXPR 1
+#    else
+#      define GLBINDING_COMPILER_CXX_CONSTEXPR 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 304 && __cplusplus > 201103L
+#      define GLBINDING_COMPILER_CXX_ATTRIBUTE_DEPRECATED 1
+#    else
+#      define GLBINDING_COMPILER_CXX_ATTRIBUTE_DEPRECATED 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_noexcept)
+#      define GLBINDING_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define GLBINDING_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#  elif GLBINDING_COMPILER_IS_GNU
+
+#    if !((__GNUC__ * 100 + __GNUC_MINOR__) >= 404)
+#      error Unsupported compiler version
+#    endif
+
+# if defined(__GNUC__)
+#  define GLBINDING_COMPILER_VERSION_MAJOR (__GNUC__)
+# else
+#  define GLBINDING_COMPILER_VERSION_MAJOR (__GNUG__)
+# endif
+# if defined(__GNUC_MINOR__)
+#  define GLBINDING_COMPILER_VERSION_MINOR (__GNUC_MINOR__)
+# endif
+# if defined(__GNUC_PATCHLEVEL__)
+#  define GLBINDING_COMPILER_VERSION_PATCH (__GNUC_PATCHLEVEL__)
+# endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 && __cplusplus >= 201103L
+#      define GLBINDING_COMPILER_CXX_THREAD_LOCAL 1
+#    else
+#      define GLBINDING_COMPILER_CXX_THREAD_LOCAL 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 406 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define GLBINDING_COMPILER_CXX_CONSTEXPR 1
+#    else
+#      define GLBINDING_COMPILER_CXX_CONSTEXPR 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 409 && __cplusplus > 201103L
+#      define GLBINDING_COMPILER_CXX_ATTRIBUTE_DEPRECATED 1
+#    else
+#      define GLBINDING_COMPILER_CXX_ATTRIBUTE_DEPRECATED 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 406 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define GLBINDING_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define GLBINDING_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#  elif GLBINDING_COMPILER_IS_MSVC
+
+#    if !(_MSC_VER >= 1600)
+#      error Unsupported compiler version
+#    endif
+
+  /* _MSC_VER = VVRR */
+# define GLBINDING_COMPILER_VERSION_MAJOR (_MSC_VER / 100)
+# define GLBINDING_COMPILER_VERSION_MINOR (_MSC_VER % 100)
+# if defined(_MSC_FULL_VER)
+#  if _MSC_VER >= 1400
+    /* _MSC_FULL_VER = VVRRPPPPP */
+#   define GLBINDING_COMPILER_VERSION_PATCH (_MSC_FULL_VER % 100000)
+#  else
+    /* _MSC_FULL_VER = VVRRPPPP */
+#   define GLBINDING_COMPILER_VERSION_PATCH (_MSC_FULL_VER % 10000)
+#  endif
+# endif
+# if defined(_MSC_BUILD)
+#  define GLBINDING_COMPILER_VERSION_TWEAK (_MSC_BUILD)
+# endif
+
+#    if _MSC_VER >= 1900
+#      define GLBINDING_COMPILER_CXX_THREAD_LOCAL 1
+#    else
+#      define GLBINDING_COMPILER_CXX_THREAD_LOCAL 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define GLBINDING_COMPILER_CXX_CONSTEXPR 1
+#    else
+#      define GLBINDING_COMPILER_CXX_CONSTEXPR 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define GLBINDING_COMPILER_CXX_ATTRIBUTE_DEPRECATED 1
+#    else
+#      define GLBINDING_COMPILER_CXX_ATTRIBUTE_DEPRECATED 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define GLBINDING_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define GLBINDING_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#  else
+#    error Unsupported compiler
+#  endif
+
+#  if defined(GLBINDING_COMPILER_CXX_THREAD_LOCAL) && GLBINDING_COMPILER_CXX_THREAD_LOCAL
+#    define GLBINDING_THREAD_LOCAL thread_local
+#  elif GLBINDING_COMPILER_IS_GNU || GLBINDING_COMPILER_IS_Clang || GLBINDING_COMPILER_IS_AppleClang
+#    define GLBINDING_THREAD_LOCAL __thread
+#  elif GLBINDING_COMPILER_IS_MSVC
+#    define GLBINDING_THREAD_LOCAL __declspec(thread)
+#  else
+// GLBINDING_THREAD_LOCAL not defined for this configuration.
+#  endif
+
+
+#  if defined(GLBINDING_COMPILER_CXX_CONSTEXPR) && GLBINDING_COMPILER_CXX_CONSTEXPR
+#    define GLBINDING_CONSTEXPR constexpr
+#  else
+#    define GLBINDING_CONSTEXPR 
+#  endif
+
+
+#  ifndef GLBINDING_DEPRECATED
+#    if defined(GLBINDING_COMPILER_CXX_ATTRIBUTE_DEPRECATED) && GLBINDING_COMPILER_CXX_ATTRIBUTE_DEPRECATED
+#      define GLBINDING_DEPRECATED [[deprecated]]
+#      define GLBINDING_DEPRECATED_MSG(MSG) [[deprecated(MSG)]]
+#    elif GLBINDING_COMPILER_IS_GNU || GLBINDING_COMPILER_IS_Clang
+#      define GLBINDING_DEPRECATED __attribute__((__deprecated__))
+#      define GLBINDING_DEPRECATED_MSG(MSG) __attribute__((__deprecated__(MSG)))
+#    elif GLBINDING_COMPILER_IS_MSVC
+#      define GLBINDING_DEPRECATED __declspec(deprecated)
+#      define GLBINDING_DEPRECATED_MSG(MSG) __declspec(deprecated(MSG))
+#    else
+#      define GLBINDING_DEPRECATED
+#      define GLBINDING_DEPRECATED_MSG(MSG)
+#    endif
+#  endif
+
+
+#  if defined(GLBINDING_COMPILER_CXX_NOEXCEPT) && GLBINDING_COMPILER_CXX_NOEXCEPT
+#    define GLBINDING_NOEXCEPT noexcept
+#    define GLBINDING_NOEXCEPT_EXPR(X) noexcept(X)
+#  else
+#    define GLBINDING_NOEXCEPT
+#    define GLBINDING_NOEXCEPT_EXPR(X)
+#  endif
+
+#endif
+
+#endif

--- a/subprojects/packagefiles/glbinding/meson.build
+++ b/subprojects/packagefiles/glbinding/meson.build
@@ -1,0 +1,176 @@
+project('glbinding', 'cpp',
+  version : '3.3.0',
+  license : 'MIT',
+  meson_version: '>=0.62.0',
+  default_options: ['cpp_std=c++11', 'warning_level=0'],
+)
+
+cpp = meson.get_compiler('cpp')
+
+if get_option('default_library') == 'both' and cc.get_argument_syntax() == 'msvc'
+  error('default_library=both not supported when compiling with MSVC')
+endif
+
+system_name_arg = '-DSYSTEM_@0@'.format(host_machine.system().to_upper())
+
+glbinding_args = [system_name_arg]
+glbinding_aux_args = [system_name_arg]
+glbinding_public_args = []
+glbinding_aux_public_args = []
+
+if host_machine.system() != 'windows'
+  dl_dep = dependency('dl')
+else
+  dl_dep = declare_dependency()
+endif
+
+if get_option('default_library') == 'shared' or get_option('default_library') == 'both'
+  glbinding_args += ['-Dglbinding_EXPORTS']
+  glbinding_aux_args += ['-Dglbinding_aux_EXPORTS']
+else
+  glbinding_args += '-DGLBINDING_STATIC_DEFINE'
+  glbinding_public_args += '-DGLBINDING_STATIC_DEFINE'
+  glbinding_aux_args += '-DGLBINDING_AUX_STATIC_DEFINE'
+  glbinding_aux_public_args += '-DGLBINDING_AUX_STATIC_DEFINE'
+endif
+
+glbinding_includes = ['source/glbinding/include', 'bundled_headers']
+
+use_system_khrplatform = cpp.has_header('KHR/khrplatform.h')
+summary('Use system KHR/khrplatform.h', use_system_khrplatform)
+
+if not use_system_khrplatform
+  glbinding_includes += 'source/3rdparty/KHR/include'
+endif
+
+glbinding_sources = files(
+  'source/glbinding/source/AbstractFunction.cpp',
+  'source/glbinding/source/AbstractState.cpp',
+  'source/glbinding/source/AbstractValue.cpp',
+  'source/glbinding/source/Binding.cpp',
+  'source/glbinding/source/Binding_list.cpp',
+  'source/glbinding/source/FunctionCall.cpp',
+  'source/glbinding/source/State.cpp',
+  'source/glbinding/source/getProcAddress.cpp',
+  'source/glbinding/source/gl/functions-patches.cpp',
+  'source/glbinding/source/glbinding.cpp',
+
+  'source/glbinding/source/Binding_objects_0.cpp',
+  'source/glbinding/source/Binding_objects_a.cpp',
+  'source/glbinding/source/Binding_objects_b.cpp',
+  'source/glbinding/source/Binding_objects_c.cpp',
+  'source/glbinding/source/Binding_objects_d.cpp',
+  'source/glbinding/source/Binding_objects_e.cpp',
+  'source/glbinding/source/Binding_objects_f.cpp',
+  'source/glbinding/source/Binding_objects_g.cpp',
+  'source/glbinding/source/Binding_objects_h.cpp',
+  'source/glbinding/source/Binding_objects_i.cpp',
+  'source/glbinding/source/Binding_objects_j.cpp',
+  'source/glbinding/source/Binding_objects_k.cpp',
+  'source/glbinding/source/Binding_objects_l.cpp',
+  'source/glbinding/source/Binding_objects_m.cpp',
+  'source/glbinding/source/Binding_objects_n.cpp',
+  'source/glbinding/source/Binding_objects_o.cpp',
+  'source/glbinding/source/Binding_objects_p.cpp',
+  'source/glbinding/source/Binding_objects_q.cpp',
+  'source/glbinding/source/Binding_objects_r.cpp',
+  'source/glbinding/source/Binding_objects_s.cpp',
+  'source/glbinding/source/Binding_objects_t.cpp',
+  'source/glbinding/source/Binding_objects_u.cpp',
+  'source/glbinding/source/Binding_objects_v.cpp',
+  'source/glbinding/source/Binding_objects_w.cpp',
+  'source/glbinding/source/Binding_objects_x.cpp',
+  'source/glbinding/source/Binding_objects_y.cpp',
+  'source/glbinding/source/Binding_objects_z.cpp',
+
+  'source/glbinding/source/gl/functions_0.cpp',
+  'source/glbinding/source/gl/functions_a.cpp',
+  'source/glbinding/source/gl/functions_b.cpp',
+  'source/glbinding/source/gl/functions_c.cpp',
+  'source/glbinding/source/gl/functions_d.cpp',
+  'source/glbinding/source/gl/functions_e.cpp',
+  'source/glbinding/source/gl/functions_f.cpp',
+  'source/glbinding/source/gl/functions_g.cpp',
+  'source/glbinding/source/gl/functions_h.cpp',
+  'source/glbinding/source/gl/functions_i.cpp',
+  'source/glbinding/source/gl/functions_j.cpp',
+  'source/glbinding/source/gl/functions_k.cpp',
+  'source/glbinding/source/gl/functions_l.cpp',
+  'source/glbinding/source/gl/functions_m.cpp',
+  'source/glbinding/source/gl/functions_n.cpp',
+  'source/glbinding/source/gl/functions_o.cpp',
+  'source/glbinding/source/gl/functions_p.cpp',
+  'source/glbinding/source/gl/functions_q.cpp',
+  'source/glbinding/source/gl/functions_r.cpp',
+  'source/glbinding/source/gl/functions_s.cpp',
+  'source/glbinding/source/gl/functions_t.cpp',
+  'source/glbinding/source/gl/functions_u.cpp',
+  'source/glbinding/source/gl/functions_v.cpp',
+  'source/glbinding/source/gl/functions_w.cpp',
+  'source/glbinding/source/gl/functions_x.cpp',
+  'source/glbinding/source/gl/functions_y.cpp',
+  'source/glbinding/source/gl/functions_z.cpp'
+)
+
+glbinding_lib = library(
+  'glbinding',
+  glbinding_sources,
+  cpp_args: glbinding_args,
+  dependencies: [dl_dep],
+  include_directories: glbinding_includes,
+  gnu_symbol_visibility: 'hidden',
+  cpp_pch: 'pch/pch.h'
+)
+
+glbinding_dep = declare_dependency(
+  link_with: glbinding_lib,
+  include_directories: glbinding_includes,
+  compile_args: glbinding_public_args
+)
+
+glbinding_aux_includes = ['source/glbinding-aux/include', 'bundled_headers']
+
+glbinding_aux_sources = files(
+  'source/glbinding-aux/source/ContextInfo.cpp',
+  'source/glbinding-aux/source/Meta.cpp',
+  'source/glbinding-aux/source/Meta_BitfieldsByString.cpp',
+  'source/glbinding-aux/source/Meta_BooleansByString.cpp',
+  'source/glbinding-aux/source/Meta_EnumsByString.cpp',
+  'source/glbinding-aux/source/Meta_ExtensionsByFunctionString.cpp',
+  'source/glbinding-aux/source/Meta_ExtensionsByString.cpp',
+  'source/glbinding-aux/source/Meta_FunctionStringsByExtension.cpp',
+  'source/glbinding-aux/source/Meta_FunctionStringsByVersion.cpp',
+  'source/glbinding-aux/source/Meta_ReqVersionsByExtension.cpp',
+  'source/glbinding-aux/source/Meta_StringsByBitfield.cpp',
+  'source/glbinding-aux/source/Meta_StringsByBoolean.cpp',
+  'source/glbinding-aux/source/Meta_StringsByEnum.cpp',
+  'source/glbinding-aux/source/Meta_StringsByExtension.cpp',
+  'source/glbinding-aux/source/Meta_getStringByBitfield.cpp',
+  'source/glbinding-aux/source/ValidVersions.cpp',
+  'source/glbinding-aux/source/ValidVersions_list.cpp',
+  'source/glbinding-aux/source/debug.cpp',
+  'source/glbinding-aux/source/logging.cpp',
+  'source/glbinding-aux/source/types_to_string.cpp',
+  'source/glbinding-aux/source/types_to_string_private.cpp'
+)
+
+glbinding_aux_lib = library(
+  'glbinding-aux',
+  glbinding_aux_sources,
+  cpp_args: glbinding_aux_args,
+  dependencies: [glbinding_dep],
+  include_directories: glbinding_aux_includes,
+  cpp_pch: 'pch/pch.h',
+  gnu_symbol_visibility: 'hidden',
+  build_by_default: false
+)
+
+glbinding_aux_dep = declare_dependency(
+  link_with: glbinding_aux_lib,
+  dependencies: [glbinding_dep],
+  include_directories: glbinding_aux_includes,
+  compile_args: glbinding_aux_public_args
+)
+
+meson.override_dependency('glbinding', glbinding_dep)
+meson.override_dependency('glbinding-aux', glbinding_aux_dep)

--- a/subprojects/packagefiles/glbinding/meson.build
+++ b/subprojects/packagefiles/glbinding/meson.build
@@ -172,5 +172,11 @@ glbinding_aux_dep = declare_dependency(
   compile_args: glbinding_aux_public_args
 )
 
+if get_option('main_glbinding_includes_aux')
+  glbinding_dep = declare_dependency(
+    dependencies: [glbinding_dep, glbinding_aux_dep]
+  )
+endif
+
 meson.override_dependency('glbinding', glbinding_dep)
 meson.override_dependency('glbinding-aux', glbinding_aux_dep)

--- a/subprojects/packagefiles/glbinding/meson.build
+++ b/subprojects/packagefiles/glbinding/meson.build
@@ -172,6 +172,8 @@ glbinding_aux_dep = declare_dependency(
   compile_args: glbinding_aux_public_args
 )
 
+subdir('source/tests')
+
 if get_option('main_glbinding_includes_aux')
   glbinding_dep = declare_dependency(
     dependencies: [glbinding_dep, glbinding_aux_dep]

--- a/subprojects/packagefiles/glbinding/meson_options.txt
+++ b/subprojects/packagefiles/glbinding/meson_options.txt
@@ -1,0 +1,6 @@
+option(
+    'main_glbinding_includes_aux',
+    type : 'boolean',
+    value: false,
+    description : 'Make glbinding dependency include both glbinding and glbinding-aux, otherwise glbinding-aux will only be available as a separate dependency. Provided for convenience when using as a fallback.'
+)

--- a/subprojects/packagefiles/glbinding/meson_options.txt
+++ b/subprojects/packagefiles/glbinding/meson_options.txt
@@ -4,3 +4,17 @@ option(
     value: false,
     description : 'Make glbinding dependency include both glbinding and glbinding-aux, otherwise glbinding-aux will only be available as a separate dependency. Provided for convenience when using as a fallback.'
 )
+
+option(
+    'build_tests',
+    type : 'feature',
+    value: 'auto',
+    description : 'Build tests. Requires glfw3, gtest and gmock.'
+)
+
+option(
+    'run_tests',
+    type : 'boolean',
+    value: false,
+    description : 'Run tests. Requires video output and will not work on headless machines.'
+)

--- a/subprojects/packagefiles/glbinding/pch/pch.h
+++ b/subprojects/packagefiles/glbinding/pch/pch.h
@@ -1,0 +1,1 @@
+#include <glbinding/Binding.h>

--- a/subprojects/packagefiles/glbinding/source/tests/meson.build
+++ b/subprojects/packagefiles/glbinding/source/tests/meson.build
@@ -1,0 +1,32 @@
+build_tests_opt = get_option('build_tests')
+
+glfw3_dep = dependency('glfw3', required: build_tests_opt, disabler: true)
+gtest_dep = dependency('gtest', required: build_tests_opt, disabler: true)
+gmock_dep = dependency('gmock', required: build_tests_opt, disabler: true)
+
+# Commented out tests are broken and unused upstream - see https://github.com/cginternals/glbinding/pull/345
+glbinding_test_sources = files(
+  'glbinding-test/AllVersions_test.cpp',
+  'glbinding-test/Boolean_compilation_test.cpp',
+  #'glbinding-test/MultiContext_test.cpp',
+  #'glbinding-test/MultiThreading_test.cpp',
+  'glbinding-test/Regression_test_185.cpp',
+  'glbinding-test/Regression_test_198.cpp',
+  'glbinding-test/Regression_test_82.cpp',
+  'glbinding-test/RingBuffer_test.cpp',
+  'glbinding-test/SharedBitfield_test.cpp',
+  'glbinding-test/main.cpp',
+)
+
+glbinding_test_exe = executable(
+  'glbinding-test',
+  glbinding_test_sources,
+
+  cpp_args: [system_name_arg],
+  override_options: ['cpp_std=c++14'],
+  dependencies: [glbinding_dep, glbinding_aux_dep, glfw3_dep, gtest_dep, gmock_dep]
+)
+
+if get_option('run_tests')
+  test('glbinding test suite', glbinding_test_exe, protocol: 'gtest')
+endif

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -32,6 +32,15 @@ PER_PROJECT_PERMITTED_FILES = {
     'box2d': [
         'doctest.h'
     ],
+    'glbinding': [
+        'pch.h',
+        'glbinding_api.h',
+        'glbinding_features.h',
+        'glbinding_export.h',
+        'glbinding-aux_api.h',
+        'glbinding-aux_features.h',
+        'glbinding-aux_export.h'
+    ],
     'jbigkit': [
         'jbig.def',
         'jbig85.def'


### PR DESCRIPTION
Add https://github.com/cginternals/glbinding - a C++ OpenGL binding/loader with enhanced type safety. Includes glbinding-aux library, which is not built by default.

Upstream relies on CMake-generated headers that are far too complex to reproduce nicely with meson, so I've bundled them and tweaked where needed.

I'm not quite sure about tests - it's an OpenGL library, so I doubt CI will manage to run them.