### PR TITLE
sdl2: provide sdl2main and sdl2_test dependencies, don't link to sdl2main by default

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -2079,9 +2079,12 @@
   },
   "sdl2": {
     "dependency_names": [
-      "sdl2"
+      "sdl2",
+      "sdl2main",
+      "sdl2_test"
     ],
     "versions": [
+      "2.26.5-4",
       "2.26.5-3",
       "2.26.5-2",
       "2.26.5-1",

--- a/subprojects/packagefiles/sdl2/meson.build
+++ b/subprojects/packagefiles/sdl2/meson.build
@@ -1,7 +1,7 @@
 project('sdl2', 'c',
     version : '2.26.5',
     license : 'zlib',
-    meson_version : '>=0.54.1',
+    meson_version : '>=0.60',
     default_options : ['c_std=none'],
 )
 
@@ -267,7 +267,7 @@ wayland_libdecor_dep = dependency('libdecor-0', required : opt_video_wayland_lib
 
 if wayland_scanner_dep.found()
     wayland_scanner = find_program(
-        wayland_scanner_dep.get_pkgconfig_variable('wayland_scanner'),
+        wayland_scanner_dep.get_variable(pkgconfig : 'wayland_scanner', default_value : 'wayland-scanner'),
         required : opt_video_wayland
     )
 
@@ -390,7 +390,7 @@ endif
 
 extra_deps = []
 
-if meson.get_cross_property('threads_dep_is_broken', false)
+if meson.get_external_property('threads_dep_is_broken', false)
     if opt_threads.disabled()
         threads_dep = fake_dep
     else
@@ -1150,12 +1150,35 @@ sdl2_dep = declare_dependency(
     compile_args : c_args,
 )
 
-if meson.version().version_compare('>=0.54')
-    meson.override_dependency('sdl2', sdl2_dep)
+test_deps = []
+
+if cdata.get('HAVE_LIBUNWIND_H', 0) == 1
+    test_deps += dependency('libunwind', required : false)
+    test_deps += dependency('libunwind-generic', required : false)
 endif
 
 # MSVC does not correctly resolve the symbols when linking dynamically
 # works fine when linking statically or MinGW
+sdl2_test = static_library('sdl2_test',
+    test_all_source,
+    c_args : core_args,
+    link_args : core_ldflags,
+    dependencies : [sdl2_dep, test_deps],
+    override_options : ['c_std=none'],
+    build_by_default : false,
+)
+
+sdl2_test_dep = declare_dependency(
+    link_with : sdl2_test,
+    dependencies : [sdl2_dep],
+    include_directories : core_inc,
+    compile_args : c_args,
+)
+
+meson.override_dependency('sdl2', sdl2_dep)
+meson.override_dependency('sdl2main', sdl2main_dep)
+meson.override_dependency('sdl2_test', sdl2_test_dep)
+
 if get_option('test')
     subdir('test')
 endif

--- a/subprojects/packagefiles/sdl2/meson_options.txt
+++ b/subprojects/packagefiles/sdl2/meson_options.txt
@@ -234,6 +234,7 @@ option(
 option(
     'with_main',
     type : 'boolean',
-    value : true,
-    description : 'automatically link against sdl2main'
+    value : false,
+    deprecated: true,
+    description : 'automatically link against sdl2main (deprecated, link to dependency sdl2_main instead)'
 )

--- a/subprojects/packagefiles/sdl2/test/meson.build
+++ b/subprojects/packagefiles/sdl2/test/meson.build
@@ -1,27 +1,3 @@
-test_deps = []
-
-if cdata.get('HAVE_LIBUNWIND_H', 0) == 1
-    test_deps += dependency('libunwind', required : false)
-    test_deps += dependency('libunwind-generic', required : false)
-endif
-
-sdl2_test = static_library('sdl2_test',
-    test_all_source,
-    include_directories : core_inc,
-    c_args : core_args,
-    link_args : core_ldflags,
-    dependencies : [deps, test_deps],
-    override_options : ['c_std=none'],
-    objects: sdl2.extract_all_objects(recursive: true),
-)
-
-sdl2_test_dep = declare_dependency(
-    link_with : sdl2_test,
-    dependencies : deps,
-    include_directories : core_inc,
-    compile_args : c_args,
-)
-
 tests = [
     { 'name': 'checkkeys',          'sources': ['checkkeys.c']},
     { 'name': 'checkkeysthreads',   'sources': ['checkkeysthreads.c']},
@@ -97,7 +73,7 @@ tests = [
 ]
 
 foreach test_entry : tests
-    test_executable = executable(test_entry['name'], test_entry['sources'], dependencies: sdl2_test_dep)
+    test_executable = executable(test_entry['name'], test_entry['sources'], dependencies: [sdl2main_dep, sdl2_test_dep])
     if get_option('run_test')
         test(test_entry['name'], test_executable, is_parallel: false)
     endif

--- a/subprojects/sdl2.wrap
+++ b/subprojects/sdl2.wrap
@@ -7,3 +7,5 @@ patch_directory = sdl2
 
 [provide]
 sdl2 = sdl2_dep
+sdl2main = sdl2main_dep
+sdl2_test = sdl2_test_dep


### PR DESCRIPTION
This better reflects how sdl2main should be used and actually works when a library (e.g. sdl2_image) links to sdl2 in a project that builds with `with_main=true`.

Mark `with_main` deprecated and default it to false - this is a sensible default now that linking to sdl2main the right way is simple.

sdl2_test is used for testing by some other projects, e.g. sdl2_image - which motivated me to do this change in the first place.

Additionally, bump required meson version to 0.60 and replace deprecated functions with alternatives.