### PR TITLE
Add physfs

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1899,6 +1899,14 @@
       "10.23-1"
     ]
   },
+  "physfs": {
+    "dependency_names": [
+      "physfs"
+    ],
+    "versions": [
+      "3.2.0-1"
+    ]
+  },
   "pkgconf": {
     "dependency_names": [
       "libpkgconf"

--- a/subprojects/packagefiles/physfs/meson.build
+++ b/subprojects/packagefiles/physfs/meson.build
@@ -1,0 +1,80 @@
+project(
+  'physfs',
+  'c',
+  version: '3.2.0',
+  meson_version: '>=0.54.0',
+)
+
+feature_args = []
+extra_library_args = []
+
+if get_option('default_library') == 'static'
+    extra_library_args += '-DPHYSFS_STATIC'
+endif
+
+# Files that don't correspond to configurable archivers
+sources = files(
+  'src/physfs.c',
+  'src/physfs_byteorder.c',
+  'src/physfs_unicode.c',
+  'src/physfs_platform_posix.c',
+  'src/physfs_platform_unix.c',
+  'src/physfs_platform_windows.c',
+  'src/physfs_platform_os2.c',
+  'src/physfs_platform_qnx.c',
+  'src/physfs_platform_android.c',
+  'src/physfs_archiver_dir.c',
+  'src/physfs_archiver_unpacked.c',
+)
+
+deps = [dependency('threads')]
+
+if host_machine.system() == 'darwin'
+  add_languages('objc', native: false)
+  sources += files('src/physfs_platform_apple.m')
+  deps += dependency('appleframeworks', modules : ['IOKit', 'Foundation'])
+elif host_machine.system() == 'haiku'
+  add_languages('cpp', native: false)
+  sources += files('src/physfs_platform_haiku.cpp')
+  deps += [dependency('be'), dependency('root')]
+endif
+
+# Values are defaults (for auto feature value)
+archivers = {
+  'zip'     : true,
+  '7z'      : true,
+  'grp'     : false,
+  'wad'     : false,
+  'hog'     : false,
+  'mvl'     : false,
+  'qpak'    : false,
+  'slb'     : false,
+  'iso9660' : false,
+  'vdf'     : false,
+}
+
+foreach archiver, default_value : archivers
+  sources += files('src/physfs_archiver_@0@.c'.format(archiver))
+  archiver_opt = get_option(archiver)
+  is_enabled = archiver_opt.auto() ? default_value : archiver_opt.enabled()
+  feature_args += '-DPHYSFS_SUPPORTS_@0@=@1@'.format(archiver.to_upper(), is_enabled.to_int())
+  summary(archiver, is_enabled.to_string('enabled', 'disabled'), section: 'Archive support')
+endforeach
+
+full_library_args = [feature_args, extra_library_args]
+
+physfs_lib = library(
+  'physfs',
+  sources,
+  c_args: full_library_args,
+  cpp_args: full_library_args,
+  objc_args: full_library_args,
+  dependencies: deps,
+  gnu_symbol_visibility: 'hidden',
+)
+
+depinc = include_directories('src')
+physfs_dep = declare_dependency(
+  include_directories: depinc,
+  link_with: physfs_lib,
+)

--- a/subprojects/packagefiles/physfs/meson.build
+++ b/subprojects/packagefiles/physfs/meson.build
@@ -6,10 +6,10 @@ project(
 )
 
 feature_args = []
-extra_library_args = []
+public_args = []
 
 if get_option('default_library') == 'static'
-    extra_library_args += '-DPHYSFS_STATIC'
+    public_args += '-DPHYSFS_STATIC'
 endif
 
 # Files that don't correspond to configurable archivers
@@ -61,7 +61,7 @@ foreach archiver, default_value : archivers
   summary(archiver, is_enabled.to_string('enabled', 'disabled'), section: 'Archive support')
 endforeach
 
-full_library_args = [feature_args, extra_library_args]
+full_library_args = [feature_args, public_args]
 
 physfs_lib = library(
   'physfs',
@@ -77,4 +77,5 @@ depinc = include_directories('src')
 physfs_dep = declare_dependency(
   include_directories: depinc,
   link_with: physfs_lib,
+  compile_args: public_args,
 )

--- a/subprojects/packagefiles/physfs/meson_options.txt
+++ b/subprojects/packagefiles/physfs/meson_options.txt
@@ -1,0 +1,49 @@
+option('zip',
+  type: 'feature',
+  description: 'ZIP support',
+)
+
+option('7z',
+  type: 'feature',
+  description: '7zip support',
+)
+
+option('grp',
+  type: 'feature',
+  description: 'Build Engine GRP support',
+)
+
+option('wad',
+  type: 'feature',
+  description: 'Doom WAD support',
+)
+
+option('hog',
+  type: 'feature',
+  description: 'Descent I/II HOG support',
+)
+
+option('mvl',
+  type: 'feature',
+  description: 'Descent I/II MVL support',
+)
+
+option('qpak',
+  type: 'feature',
+  description: 'Quake I/II QPAK support',
+)
+
+option('slb',
+  type: 'feature',
+  description: 'I-War / Independence War SLB support',
+)
+
+option('iso9660',
+  type: 'feature',
+  description: 'ISO9660 support',
+)
+
+option('vdf',
+  type: 'feature',
+  description: 'Gothic I/II VDF archive support',
+)

--- a/subprojects/physfs.wrap
+++ b/subprojects/physfs.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = physfs-release-3.2.0
+source_url = https://github.com/icculus/physfs/archive/refs/tags/release-3.2.0.zip
+source_filename = physfs-release-3.2.0.zip
+source_hash = 18adad9a2d5e165a709588d1d942d73e3ffcb0495244b108cfe402690489990c
+patch_directory = physfs
+
+[provide]
+physfs = physfs_dep


### PR DESCRIPTION
Add [physfs](https://github.com/icculus/physfs) - a portable filesystem/archive access wrapper often used by games. Does not depend on anything except threads (and a bit of platform-specific stuff which is not really notable).

I've decided to disable most archivers by default, since they are pretty unlikely to be used by most applications these days, only leaving zip and 7z. However, users are free to re-enable those archivers by explicitly enabling options.

I've included a very simple test to verify that it links and runs, since `test.c` from upstream is interactive and not very portable.