### PR TITLE
CI: don't test clang32

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -86,7 +86,7 @@ jobs:
       TEST_FATAL_WARNINGS: ${{ github.event.inputs.fatal_warnings }}
     strategy:
       matrix:
-        platform: ['UCRT64', 'CLANG32', 'CLANG64']
+        platform: ['UCRT64', 'CLANG64']
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -67,7 +67,7 @@ jobs:
     name: MSYS2-${{matrix.platform}}
     strategy:
       matrix:
-        platform: ['UCRT64', 'CLANG32', 'CLANG64']
+        platform: ['UCRT64', 'CLANG64']
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
For some reason it keeps failing on generating symbols. The other backends seem to be fine.