### PR TITLE
Add cimg

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -41,6 +41,9 @@
   "cimg": {
     "build_options": [
       "cimg:examples=true"
+    ],
+    "brew_packages": [
+      "libomp"
     ]
   },
   "cli11": {

--- a/ci_config.json
+++ b/ci_config.json
@@ -38,6 +38,11 @@
       "cexception:werror=false"
     ]
   },
+  "cimg": {
+    "build_options": [
+      "cimg:examples=true"
+    ]
+  },
   "cli11": {
     "build_options": [
       "cpp_std=c++14"

--- a/releases.json
+++ b/releases.json
@@ -192,6 +192,14 @@
       "6.2.2-1"
     ]
   },
+  "cimg": {
+    "dependency_names": [
+      "cimg"
+    ],
+    "versions": [
+      "3.2.3-1"
+    ]
+  },
   "cjson": {
     "dependency_names": [
       "libcjson",

--- a/subprojects/cimg.wrap
+++ b/subprojects/cimg.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = CImg-3.2.3
+source_url = http://cimg.eu/files/CImg_3.2.3.zip
+source_filename = CImg_3.2.3.zip
+source_hash = 3961967cb5958a95c5fe152945b17a23fa96ebe9be48fe798effc1a7bd5a9e6c 
+patch_directory = cimg
+
+[provide]
+cimg = cimg_dep

--- a/subprojects/packagefiles/cimg/examples/meson.build
+++ b/subprojects/packagefiles/cimg/examples/meson.build
@@ -1,0 +1,40 @@
+examples = [
+  'CImg_demo',
+  'captcha',
+  'curve_editor2d',
+  'dtmri_view3d',
+  'edge_explorer2d',
+  'fade_images',
+  'gaussian_fit1d',
+  'generate_loop_macros',
+  'hough_transform2d',
+  'image_registration2d',
+  'image2ascii',
+  'image_surface3d',
+  'jawbreaker',
+  'mcf_levelsets2d',
+  'mcf_levelsets3d',
+  'odykill',
+  'pde_heatflow2d',
+  'pde_TschumperleDeriche2d',
+  'plotter1d',
+  'radon_transform2d',
+  'scene3d',
+  'spherical_function3d',
+  'tetris',
+  'tron',
+  'tutorial',
+  'wavelet_atrous',
+  'use_draw_gradient',
+  'use_nlmeans',
+  'use_skeleton',
+  'use_RGBclass',
+]
+
+foreach example_name: examples
+  executable(
+    example_name,
+    '@0@.cpp'.format(example_name),
+    dependencies: [cimg_dep],
+  )
+endforeach

--- a/subprojects/packagefiles/cimg/meson.build
+++ b/subprojects/packagefiles/cimg/meson.build
@@ -3,12 +3,18 @@ project(
   'cpp',
   version: '3.2.3',
   meson_version: '>=0.59.0',
+  default_options: ['werror=false']
 )
 
 cpp = meson.get_compiler('cpp')
 
 deps = [dependency('threads')]
 compile_args = []
+
+if host_machine.system() == 'windows'
+  # This helps in certain environments like msys2
+  compile_args += '-Dcimg_OS=2'
+endif
 
 # Feature option/define name : library name
 simple_deps = {

--- a/subprojects/packagefiles/cimg/meson.build
+++ b/subprojects/packagefiles/cimg/meson.build
@@ -12,7 +12,6 @@ compile_args = []
 
 # Feature option/define name : library name
 simple_deps = {
-  'openmp'  : 'openmp', # Meson's built-in support
   'opencv'  : 'OpenCV', # CMake module
   'zlib'    : 'zlib',
   'curl'    : 'libcurl',
@@ -33,6 +32,12 @@ foreach depname, libname: simple_deps
     compile_args += '-Dcimg_use_@0@'.format(depname)
   endif
 endforeach
+
+# Do not define macro to zero if not found - it's broken
+openmp_dep = dependency('openmp', required: get_option('openmp'))
+if openmp_dep.found()
+  deps += openmp_dep
+endif
 
 # FFTW3 requires us to link to an additional library
 fftw3_dep = dependency('fftw3', required: get_option('fftw3'))

--- a/subprojects/packagefiles/cimg/meson.build
+++ b/subprojects/packagefiles/cimg/meson.build
@@ -1,0 +1,119 @@
+project(
+  'cimg',
+  'cpp',
+  version: '3.2.3',
+  meson_version: '>=0.59.0',
+)
+
+cpp = meson.get_compiler('cpp')
+
+deps = [dependency('threads')]
+compile_args = []
+
+# Feature option/define name : library name
+simple_deps = {
+  'openmp'  : 'openmp', # Meson's built-in support
+  'opencv'  : 'OpenCV', # CMake module
+  'zlib'    : 'zlib',
+  'curl'    : 'libcurl',
+  'lapack'  : 'lapack',
+  'magick'  : 'Magick++',
+
+  'png'     : 'libpng',
+  'jpeg'    : 'libjpeg',
+  'tiff'    : 'libtiff-4',
+  'heif'    : 'libheif',
+  'openexr' : 'OpenEXR', # CMake module
+}
+
+foreach depname, libname: simple_deps
+  library_dep = dependency(libname, required: get_option(depname))
+  if library_dep.found()
+    deps += library_dep
+    compile_args += '-Dcimg_use_@0@'.format(depname)
+  endif
+endforeach
+
+# FFTW3 requires us to link to an additional library
+fftw3_dep = dependency('fftw3', required: get_option('fftw3'))
+if fftw3_dep.found()
+  fftw3_theads_dep = cpp.find_library('fftw3_threads', required: get_option('fftw3'))
+  if fftw3_theads_dep.found()
+    deps += [fftw3_dep, fftw3_theads_dep]
+    compile_args += '-Dcimg_use_fftw3'
+  endif
+endif
+
+# Windowing system configuration
+windowing_opt = get_option('display')
+windowing_required = true
+windowing_found = false
+
+if windowing_opt == 'auto'
+  windowing_opt = host_machine.system() == 'windows' ? 'GDI32' : 'X11'
+  windowing_required = false
+endif
+
+if windowing_opt == 'X11'
+  x11_dep = dependency('x11', required: windowing_required)
+  if x11_dep.found()
+    deps += x11_dep
+    compile_args += '-Dcimg_display=1'
+    windowing_found = true
+
+    x11_extras = {
+      'xshm' : 'xext',
+      'xrandr' : 'xrandr',
+    }
+
+    foreach depname, libname: x11_extras
+      library_dep = dependency(libname, required: get_option(depname))
+      if library_dep.found()
+        deps += library_dep
+        compile_args += '-Dcimg_use_@0@'.format(depname)
+      endif
+    endforeach
+  endif
+elif windowing_opt == 'GDI32'
+  gdi32_dep = cpp.find_library('gdi32', required: windowing_required)
+  if gdi32_dep.found()
+    deps += gdi32_dep
+    compile_args += '-Dcimg_display=2'
+    windowing_found = true
+  endif
+endif
+
+if not windowing_found
+  compile_args += '-Dcimg_display=0'
+endif
+
+# Logging settings
+
+veborsity_opt = get_option('veborsity')
+
+if veborsity_opt == 'quiet'
+  compile_args += '-Dcimg_verbosity=0'
+elif veborsity_opt == 'normal_console'
+  compile_args += '-Dcimg_verbosity=1'
+elif veborsity_opt == 'normal_gui'
+  compile_args += '-Dcimg_verbosity=2'
+elif veborsity_opt == 'veborse_console'
+  compile_args += '-Dcimg_verbosity=3'
+elif veborsity_opt == 'veborse_gui'
+  compile_args += '-Dcimg_verbosity=4'
+endif
+
+if host_machine.system() != 'windows' ? get_option('colorize_log').enabled() : get_option('colorize_log').allowed()
+  compile_args += '-Dcimg_use_vt100'
+endif
+
+depinc = include_directories('.')
+cimg_dep = declare_dependency(
+  include_directories: depinc,
+  dependencies: deps,
+  compile_args: compile_args,
+)
+
+if get_option('examples')
+  subdir('examples')
+endif

--- a/subprojects/packagefiles/cimg/meson_options.txt
+++ b/subprojects/packagefiles/cimg/meson_options.txt
@@ -1,0 +1,116 @@
+# Build settings
+
+option('examples',
+  type: 'boolean',
+  value: false,
+  description: 'Build examples',
+)
+
+# Library settings
+
+option('display',
+  type : 'combo',
+  choices : ['auto', 'none', 'X11', 'GDI32'],
+  value : 'auto',
+  description: 'Windowing backend to use',
+)
+
+option('xshm',
+  type: 'feature',
+  description: 'Use XSHM for accelerated image rendering when using X11',
+)
+
+option('xrandr',
+  type: 'feature',
+  description: 'Use XRandr for modesetting when using X11',
+)
+
+option('veborsity',
+  type : 'combo',
+  choices : ['auto', 'quiet', 'normal_console', 'normal_gui', 'veborse_console', 'veborse_gui'],
+  value : 'auto',
+  description: 'Logging configuration (auto will select one of normal settings depending on setup)',
+)
+
+option('colorize_log',
+  type: 'feature',
+  description: 'Use VT100 codes when printing messages to console',
+)
+
+# External image processing related libraries that don't directly correspond to formats
+
+option('openmp',
+  type: 'feature',
+  description: 'Use OpenMP to accelerate image processing on multicore systems',
+)
+
+option('opencv',
+  type: 'feature',
+  description: 'Use OpenCV for camera access and video processing',
+)
+
+option('zlib',
+  type: 'feature',
+  description: 'Use zlib to support compressed data in .cimgz format',
+)
+
+option('curl',
+  type: 'feature',
+  description: 'Use libcurl to download files from the network',
+)
+
+option('magick',
+  type: 'feature',
+  description: 'Use libmagick++ to support variety of file formats',
+)
+
+option('fftw3',
+  type: 'feature',
+  description: 'Use libfftw3 for Fast Fourier Transform computation',
+)
+
+# libboard seems to be dead
+#option('board',
+#  type: 'feature',
+#  description: 'Use libboard for basic 3D support',
+#)
+
+option('lapack',
+  type: 'feature',
+  description: 'Use liblapack to accelerate matrix computations',
+)
+
+# Image format support
+
+option('png',
+  type: 'feature',
+  description: 'Native PNG support, requires libpng',
+)
+
+option('jpeg',
+  type: 'feature',
+  description: 'Native JPEG support, requires libjpeg',
+)
+
+option('tiff',
+  type: 'feature',
+  description: 'Native TIFF support, requires libtiff',
+)
+
+option('heif',
+  type: 'feature',
+  description: 'Native HEIF support, requires libheif',
+)
+
+# libminc2 has rather broken CMake config file and cimg doesn't properly prefix its includes for it
+#option('minc',
+#  type: 'feature',
+#  description: 'Native MINC support, requires libminc2',
+#)
+
+option('openexr',
+  type: 'feature',
+  description: 'Native EXR support, requires libopenexr',
+)
+
+# tinyexr is not supported by this wrap (it comes with shared library, but cimg expects it to be header-only)


### PR DESCRIPTION
Add [cimg](https://cimg.eu/) - an image processing library for C++. While library itself is header-only, it has a rather wide range of configuration options, including support for other (non-header-only) libraries. As such, it makes for a rather sizable amount of meson options.

It does not include tests, so I've opted to enable building examples it ships with in CI.