### PR TITLE
liburing: override "liburing" dependency name

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1350,9 +1350,11 @@
   },
   "liburing": {
     "dependency_names": [
+      "liburing",
       "uring"
     ],
     "versions": [
+      "2.3-2",
       "2.3-1",
       "2.2-2",
       "2.2-1",

--- a/subprojects/liburing.wrap
+++ b/subprojects/liburing.wrap
@@ -6,4 +6,4 @@ source_hash = 60b367dbdc6f2b0418a6e0cd203ee0049d9d629a36706fcf91dfb9428bae23c8
 patch_directory = liburing
 
 [provide]
-uring = uring
+dependency_names = liburing, uring

--- a/subprojects/packagefiles/liburing/src/meson.build
+++ b/subprojects/packagefiles/liburing/src/meson.build
@@ -16,3 +16,6 @@ liburing = library('uring',
 
 uring = declare_dependency(link_with: liburing,
                            include_directories: inc)
+
+meson.override_dependency('liburing', uring)
+meson.override_dependency('uring', uring)


### PR DESCRIPTION
```
The pkg-config name of liburing is "liburing", so ideally it would be
possible to use just

  dependency('liburing')

to find either the system provided liburing or fall back to the subproject.
However, that does not work since the liburing wrap project does not
override or provide the "liburing" dependency name, so one has to use

  dependency('liburing', fallback: ['liburing', 'uring'])

or

  dependency('liburing', 'uring')

This change makes it possible to use

  dependency('liburing')

with both system (pkg-config) and the wrapdb provided liburing.
```