### PR TITLE
liburing: drop "uring" dependency name

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1350,10 +1350,10 @@
   },
   "liburing": {
     "dependency_names": [
-      "liburing",
-      "uring"
+      "liburing"
     ],
     "versions": [
+      "2.3-3",
       "2.3-2",
       "2.3-1",
       "2.2-2",

--- a/subprojects/liburing.wrap
+++ b/subprojects/liburing.wrap
@@ -6,4 +6,4 @@ source_hash = 60b367dbdc6f2b0418a6e0cd203ee0049d9d629a36706fcf91dfb9428bae23c8
 patch_directory = liburing
 
 [provide]
-dependency_names = liburing, uring
+dependency_names = liburing

--- a/subprojects/packagefiles/liburing/src/meson.build
+++ b/subprojects/packagefiles/liburing/src/meson.build
@@ -18,4 +18,3 @@ uring = declare_dependency(link_with: liburing,
                            include_directories: inc)
 
 meson.override_dependency('liburing', uring)
-meson.override_dependency('uring', uring)


### PR DESCRIPTION
The upstream project ships a pkg-confing file with the "liburing" name, so use that.