### PR TITLE
Add robin-map

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -2097,6 +2097,14 @@
       "3.0.1-1"
     ]
   },
+  "robin-map": {
+    "dependency_names": [
+      "robin-map"
+    ],
+    "versions": [
+      "1.2.1"
+    ]
+  },
   "rtaudio": {
     "dependency_names": [
       "rtaudio"

--- a/releases.json
+++ b/releases.json
@@ -2102,7 +2102,7 @@
       "robin-map"
     ],
     "versions": [
-      "1.2.1"
+      "1.2.1-1"
     ]
   },
   "rtaudio": {

--- a/subprojects/packagefiles/robin-map/meson.build
+++ b/subprojects/packagefiles/robin-map/meson.build
@@ -1,0 +1,12 @@
+project(
+  'robin-map',
+  'cpp',
+  version : '1.2.1',
+  license : 'MIT'
+)
+
+robin_map_inc = include_directories('include')
+
+robin_map_dep = declare_dependency(
+  include_directories : robin_map_inc
+)

--- a/subprojects/robin-map.wrap
+++ b/subprojects/robin-map.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = robin-map-1.2.1
+source_url = https://github.com/Tessil/robin-map/archive/refs/tags/v1.2.1.tar.gz
+source_filename = robin-map-1.2.1.tar.gz
+source_hash = 2b54d2c1de2f73bea5c51d5dcbd64813a08caf1bfddcfdeee40ab74e9599e8e3
+patch_directory = robin-map
+
+[provide]
+robin-map = robin_map_dep


### PR DESCRIPTION
Added [robin-map](https://github.com/Tessil/robin-map). 

**Note**: `robin-map` is a dependency of [nanobind](https://github.com/wjakob/nanobind). I plan on adding a wrap for nanobind as well.