### PR TITLE
fixing indent for c-flags

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -107,10 +107,10 @@
   },
   "c-flags": {
     "dependency_names": [
-        "c-flags"
+      "c-flags"
     ],
     "versions": [
-        "1.5.4-1"
+      "1.5.4-1"
     ]
   },
   "catch": {


### PR DESCRIPTION
This fixes the indentation for c-flags.
Before its version and dependency_names had an indent of 4 now they have one of 2 like the rest.

The only reason for this is to allow automatic updates of the releases file since every formatter requires consistent indentation (or at least they will produce them when writing).
In other words this pr is to prevent changes accidental changes to the releases file in the future.