### PR TITLE
Add IREPEAT wrap

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -981,6 +981,14 @@
       "r51-1"
     ]
   },
+  "irepeat": {
+    "dependency_names": [
+      "irepeat"
+    ],
+    "versions": [
+      "0.6-1"
+    ]
+  },
   "jansson": {
     "dependency_names": [
       "jansson"

--- a/subprojects/irepeat.wrap
+++ b/subprojects/irepeat.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = IREPEAT-0.6
+source_url = https://github.com/lemuriad/IREPEAT/archive/v0.6.tar.gz
+source_filename = irepeat-0.6.0.tar.gz
+source_hash = ee128300512337ad5b9c5ec8c13138eb901fef61d3bf0aebb836d307bd2bbd14
+
+[provide]
+irepeat = irepeat_dep


### PR DESCRIPTION
Native meson build. Release archive v0.6 created for this wrap.
Updated IREPEAT to use lowercase project and dependency names
as wrapDB appeared to require that change.
