### PR TITLE
minizip-ng: add include-workaround-meson

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1772,9 +1772,10 @@
   },
   "minizip-ng": {
     "dependency_names": [
-      "minizip-ng"
+      "minizip"
     ],
     "versions": [
+      "4.0.0-2",
       "4.0.0-1",
       "3.0.10-1",
       "3.0.8-1",

--- a/subprojects/minizip-ng.wrap
+++ b/subprojects/minizip-ng.wrap
@@ -6,4 +6,4 @@ source_hash = f9062e576de026fd5026d65597de3b05263cd4d91400cacdbbe36dfa8a642fff
 patch_directory = minizip-ng
 
 [provide]
-minizip-ng = minizip_ng_dep
+minizip = minizip_ng_dep

--- a/subprojects/packagefiles/minizip-ng/include-workaround-meson/minizip/meson.build
+++ b/subprojects/packagefiles/minizip-ng/include-workaround-meson/minizip/meson.build
@@ -1,0 +1,9 @@
+# This is a workaround for creating a cjson/ folder with the headers in it in
+# the builddir space.
+
+# See https://github.com/mesonbuild/meson/issues/2546 for where the technique
+# comes from
+
+foreach h : headers
+  configure_file(copy: true, input: h, output: '@PLAINNAME@')
+endforeach

--- a/subprojects/packagefiles/minizip-ng/meson.build
+++ b/subprojects/packagefiles/minizip-ng/meson.build
@@ -67,18 +67,22 @@ if cc.has_function('arc4random', dependencies: bsd_dep)
   margs += '-DHAVE_ARC4RANDOM'
 endif
 
-crypt_dep = dependency('openssl', required: get_option('wzaes'))
-if crypt_dep.found()
-  sources += files('mz_crypt_openssl.c')
-elif host_machine.system() == 'windows'
+bcrypt_dep = []
+if host_machine.system() == 'windows'
   crypt_dep = cc.find_library('crypt32', required: get_option('wzaes'))
   if crypt_dep.found()
     sources += files('mz_crypt_winvista.c')
   endif
+  bcrypt_dep = cc.find_library('bcrypt')
 elif host_machine.system() == 'darwin'
   crypt_dep = dependency('appleframeworks', modules: ['CoreFoundation', 'Security'], required: get_option('wzaes'))
   if crypt_dep.found()
     sources += files('mz_crypt_apple.c')
+  endif
+else
+  crypt_dep = dependency('openssl', required: get_option('wzaes'))
+  if crypt_dep.found()
+    sources += files('mz_crypt_openssl.c')
   endif
 endif
 
@@ -143,6 +147,7 @@ minizip_ng = library(
   soversion: host_machine.system() == 'windows' ? '' : '3',
   vs_module_defs: 'mz.def',
   dependencies: [
+    bcrypt_dep,
     bsd_dep,
     crypt_dep,
     iconv_dep,
@@ -158,6 +163,7 @@ pconf = import('pkgconfig')
 pconf.generate(
   minizip_ng,
   description: 'Minizip zip file manipulation library',
+  subdirs: 'minizip',
 )
 
 headers = files(
@@ -201,7 +207,9 @@ install_headers(
   headers,
 )
 
-depinc = include_directories('.')
+subdir('include-workaround-meson/minizip')
+
+depinc = include_directories('.', 'include-workaround-meson')
 minizip_ng_dep = declare_dependency(
   include_directories: depinc,
   link_with: minizip_ng,

--- a/subprojects/packagefiles/minizip-ng/test/meson.build
+++ b/subprojects/packagefiles/minizip-ng/test/meson.build
@@ -3,7 +3,7 @@ add_languages('cpp')
 testlib = static_library(
   'testlib',
   objects: minizip_ng.extract_all_objects(recursive: false),
-  dependencies: [bsd_dep, crypt_dep, iconv_dep, bzip2_dep, lzma_dep, zlib_dep, zstd_dep, minizip_ng_dep],
+  dependencies: [bcrypt_dep, bsd_dep, crypt_dep, iconv_dep, bzip2_dep, lzma_dep, zlib_dep, zstd_dep, minizip_ng_dep],
 )
 
 testinc = include_directories('.')


### PR DESCRIPTION
While the proper thing to do is to include the headers without a minizip prefix, there are projects out there that do such a thing and compilation succeeds because of /usr/include being default.

Also rework crypt_dep to match on OS first. No point in a heavy dependency like OpenSSL.