### PR TITLE
opencl-headers: update to 2023.04.17

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1998,9 +1998,10 @@
   },
   "opencl-headers": {
     "dependency_names": [
-      "openclheaders"
+      "opencl-headers"
     ],
     "versions": [
+      "2023.04.17-1",
       "2022.05.18-1",
       "2021.06.30-1"
     ]

--- a/subprojects/opencl-headers.wrap
+++ b/subprojects/opencl-headers.wrap
@@ -1,9 +1,9 @@
 [wrap-file]
-directory = OpenCL-Headers-2022.05.18
-source_url = https://github.com/KhronosGroup/OpenCL-Headers/archive/refs/tags/v2022.05.18.tar.gz
-source_filename = OpenCL-Headers-2022.05.18.tar.gz
-source_hash = 88a1177853b279eaf574e2aafad26a84be1a6f615ab1b00c20d5af2ace95c42e
+directory = OpenCL-Headers-2023.04.17
+source_url = https://github.com/KhronosGroup/OpenCL-Headers/archive/refs/tags/v2023.04.17.tar.gz
+source_filename = OpenCL-Headers-2023.04.17.tar.gz
+source_hash = 0ce992f4167f958f68a37918dec6325be18f848dee29a4521c633aae3304915d
 patch_directory = opencl-headers
 
 [provide]
-OpenCLHeaders = opencl_headers_dep
+OpenCL-Headers = opencl_headers_dep

--- a/subprojects/packagefiles/opencl-headers/meson.build
+++ b/subprojects/packagefiles/opencl-headers/meson.build
@@ -1,8 +1,8 @@
 project(
   'OpenCLHeaders',
   'c',
-  license : 'Apache-2.0',
-  version : '2022.05.18',
+  license: 'Apache-2.0',
+  version: '2023.04.17',
 )
 
 install_headers(
@@ -23,18 +23,20 @@ install_headers(
   'CL/cl_va_api_media_sharing_intel.h',
   'CL/cl_version.h',
   'CL/opencl.h',
-  subdir : 'CL',
+  subdir: 'CL',
 )
 
 pkgc = import('pkgconfig')
-pkgc.generate(name: 'OpenCLHeaders',
-  version: '2.2',
-  description: 'C language headers for the OpenCL API'
+pkgc.generate(
+  name: 'OpenCL-Headers',
+  description: 'C language headers for the OpenCL API',
+  version: '3.0',
 )
 
+depinc = include_directories('.')
 opencl_headers_dep = declare_dependency(
-  include_directories : include_directories('.'),
-  version : '2.2',
+  include_directories: depinc,
+  version: '3.0',
 )
 
 if get_option('tests')

--- a/subprojects/packagefiles/opencl-headers/tests/meson.build
+++ b/subprojects/packagefiles/opencl-headers/tests/meson.build
@@ -1,3 +1,13 @@
+cl_versions = [
+  '100',
+  '110',
+  '120',
+  '200',
+  '210',
+  '220',
+  '300',
+]
+
 cl_tests = [
   'cl',
   'cl_d3d10',
@@ -17,7 +27,17 @@ cl_tests = [
 ]
 
 foreach t : cl_tests
-  test('test_@0@'.format(t), executable(t, 'test_@0@.h.c'.format(t), dependencies: opencl_headers_dep))
+  foreach v : cl_versions
+    test(
+      'test_@0@_@1@'.format(t, v),
+      executable(
+        'test_@0@_@1@'.format(t, v),
+        'test_@0@.h.c'.format(t),
+        c_args: '-DCL_TARGET_OPENCL_VERSION=@0@'.format(v),
+        dependencies: opencl_headers_dep,
+      ),
+    )
+  endforeach
 endforeach
 
 test('test_headers', executable('headers', 'test_headers.c', dependencies: opencl_headers_dep))


### PR DESCRIPTION
Update dependency name to match pkgconfig. Also the version.

Various other cleanups.