### PR TITLE
giflib: add version 5.2.1

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -114,6 +114,15 @@
       "windows": false
     }
   },
+  "giflib": {
+    "_comment": "Unnecessary <unistd.h> include in gif_hash.h breaks the build",
+    "build_on": {
+      "windows": false
+    },
+    "msys_packages": [
+      "diffutils"
+    ]
+  },
   "glbinding": {
     "debian_packages": [
       "libxi-dev",

--- a/releases.json
+++ b/releases.json
@@ -708,6 +708,14 @@
       "1.14.1-1"
     ]
   },
+  "giflib": {
+    "dependency_names": [
+      "giflib"
+    ],
+    "versions": [
+      "5.2.1-1"
+    ]
+  },
   "glbinding": {
     "dependency_names": [
       "glbinding",

--- a/subprojects/giflib.wrap
+++ b/subprojects/giflib.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = giflib-5.2.1
+source_url = https://downloads.sourceforge.net/project/giflib/giflib-5.2.1.tar.gz
+source_filename = giflib-5.2.1.tar.gz
+source_hash = 31da5562f44c5f15d63340a09a4fd62b48c45620cd302f77a6d9acf0077879bd
+patch_directory = giflib
+
+[provide]
+dependency_names = giflib

--- a/subprojects/packagefiles/giflib/meson.build
+++ b/subprojects/packagefiles/giflib/meson.build
@@ -1,0 +1,380 @@
+project(
+  'giflib',
+  'c',
+  version: '5.2.1',
+  default_options: 'c_std=gnu99',
+  meson_version: '>=0.59.0',
+)
+
+cc = meson.get_compiler('c')
+fs = import('fs')
+
+enable_progs = get_option('progs').allowed()
+
+enable_tests = get_option('tests')
+sh = find_program('sh', required: enable_tests)
+enable_tests = enable_tests.require(sh.found())
+foreach _name : [
+  'cmp',
+  'diff',
+  'head',
+]
+  _prog = find_program(_name, required: enable_tests).found()
+  enable_tests = enable_tests.require(_prog)
+endforeach
+enable_tests = enable_tests.allowed()
+
+add_project_arguments(cc.get_supported_arguments('-Wno-format-truncation'), language: 'c')
+
+foreach _hdr : [
+  'limits.h',
+  'fcntl.h',
+  'stdint.h',
+  'stdarg.h',
+]
+  cc.has_header(_hdr, required: true)
+endforeach
+
+if host_machine.system() == 'windows'
+  # An unconditional include of <unistd.h> in `gif_hash.h` breaks the build on MSVC.
+  if not cc.has_header('unistd.h')
+    error('building on Windows without <unistd.h> is unsupported')
+  endif
+  # No `strtok_r` when building with MSVC, use `strtok_s` instead.
+  if (
+    not cc.has_header_symbol('string.h', 'strtok_r')
+    and cc.has_header_symbol('string.h', 'strtok_s')
+  )
+    add_project_arguments('-Dstrtok_r=strtok_s', language: 'c')
+  endif
+endif
+
+gif_lib = library(
+  'gif',
+  [
+    'dgif_lib.c',
+    'egif_lib.c',
+    'gif_err.c',
+    'gif_font.c',
+    'gif_hash.c',
+    'gifalloc.c',
+    'openbsd-reallocarray.c',
+    'quantize.c',
+  ],
+  install: true,
+  version: '7.2.0',
+)
+
+gif_dep = declare_dependency(
+  include_directories: include_directories('.'),
+  link_with: gif_lib,
+)
+
+meson.override_dependency('giflib', gif_dep)
+
+install_headers('gif_lib.h')
+
+if enable_progs or enable_tests
+
+  m_dep = cc.find_library('m', required: false)
+
+  util_lib = static_library(
+    'util',
+    [
+      'getarg.c',
+      'qprintf.c',
+      'quantize.c',
+    ],
+  )
+
+  _programs = [
+    # name        build?        install?
+    ['gif2rgb'  , true        , enable_progs],
+    ['gifbg'    , enable_progs, false       ],
+    ['gifbuild' , true        , enable_progs],
+    ['gifclrmp' , true        , enable_progs],
+    ['gifcolor' , enable_progs, false       ],
+    ['gifecho'  , true        , false       ],
+    ['giffilter', true        , false       ],
+    ['giffix'   , true        , enable_progs],
+    ['gifhisto' , enable_progs, false       ],
+    ['gifinto'  , true        , false       ],
+    ['gifsponge', true        , false       ],
+    ['giftext'  , true        , enable_progs],
+    ['gifwedge' , true        , false       ],
+  ]
+
+  if cc.has_header('getopt.h')
+    _programs += [['giftool', true, enable_progs]]
+    giftool_tests = [
+      ['copy'       , ''      , 'pic/gifgrid.gif'            , 'tests/gifgrid.rgb'            ],
+      ['deinterlace', '-i on' , 'pic/treescap-interlaced.gif', 'tests/treescap.rgb'           ],
+      ['interlace'  , '-i off', 'pic/treescap.gif'           , 'tests/treescap-interlaced.rgb'],
+    ]
+  else
+    giftool_tests = []
+  endif
+
+  foreach _spec : _programs
+    _name = _spec[0]
+    _build = _spec[1]
+    _install = _spec[2]
+    if _build
+      _exe = executable(
+        _name,
+        _name + '.c',
+        dependencies: [gif_dep, m_dep],
+        install: _install,
+        link_with: util_lib,
+      )
+      set_variable(_name, _exe)
+    endif
+  endforeach
+
+endif
+
+if enable_tests
+
+  gifs = [
+    'fire.gif',
+    'gifgrid.gif',
+    'porsche.gif',
+    'solid2.gif',
+    'treescap-interlaced.gif',
+    'treescap.gif',
+    'welcome2.gif',
+    'x-trans.gif',
+  ]
+
+  # Test gif2rgb.
+  foreach _gif : gifs
+    _stem = _gif.substring(0, -4)
+    test(
+      _gif,
+      sh,
+      args: [
+        '-xc',
+        '"$1" -1 -o "$2" "$3" && cmp "$4" "$2"',
+        '--',
+        gif2rgb,
+        'gif2rgb-@0@.regress'.format(_stem),
+        files('pic' / _gif),
+        files('tests' / (_stem + '.rgb')),
+      ],
+      suite: 'gif2rgb',
+    )
+  endforeach
+
+  # Test gifbuild.
+  test(
+    'basic',
+    sh,
+    args: [
+      '-xc',
+      ' && '.join(
+        '"$1" -d <"$2" >"$3"',
+        'diff --strip-trailing-cr --unified "$4" "$3"',
+      ),
+      '--',
+      gifbuild,
+      files('pic/treescap.gif'),
+      'gifbuild-treescap.ico',
+      files('tests/treescap.ico'),
+    ],
+    suite: 'gifbuild',
+  )
+  test(
+    'idempotency-icon',
+    sh,
+    args: [
+      '-xc',
+      ' && '.join(
+        '"$1" <"$2" | "$1" -d >"$3"',
+        '"$1" <"$3" | "$1" -d >"$4"',
+        'diff --strip-trailing-cr --unified "$3" "$4"',
+      ),
+      '--',
+      gifbuild,
+      files('pic/sample.ico'),
+      'gifbuild-sample1.ico',
+      'gifbuild-sample2.ico',
+    ],
+    suite: 'gifbuild',
+  )
+  test(
+    'idempotency-animation',
+    sh,
+    args: [
+      '-xc',
+      ' && '.join(
+        '"$1" -d <"$2" >"$3"',
+        '"$1" <"$3" >"$4"',
+        '"$1" -d <"$4" >"$5"',
+        'diff --strip-trailing-cr --unified "$3" "$5"',
+      ),
+      '--',
+      gifbuild,
+      files('pic/fire.gif'),
+      'gifbuild-fire1.ico',
+      'gifbuild-fire2.gif',
+      'gifbuild-fire3.ico',
+    ],
+    suite: 'gifbuild',
+  )
+
+  # Test gifclrmp, giftext.
+  foreach _suite, _ext : {
+    'gifclrmp': '.map',
+    'giftext' : '.dmp',
+  }
+    _prog = get_variable(_suite)
+    foreach _gif : gifs
+      _stem = _gif.substring(0, -4)
+      test(
+        _gif,
+        sh,
+        args: [
+          '-xc',
+          ' && '.join(
+            '"$1" <"$2" >"$3"',
+            'diff --strip-trailing-cr --unified "$4" "$3"',
+          ),
+          '--',
+          _prog,
+          files('pic' / _gif),
+          '@0@-@1@.regress'.format(_suite, _stem),
+          files('tests' / (_stem + _ext)),
+        ],
+        suite: _suite,
+      )
+    endforeach
+  endforeach
+
+  # Test giffilter, gifsponge.
+  foreach _suite : [
+    'giffilter',
+    'gifsponge',
+  ]
+    _prog = get_variable(_suite)
+    foreach _gif : gifs
+      _stem = _gif.substring(0, -4)
+      test(
+        _gif,
+        sh,
+        args: [
+          '-xc',
+          '"$1" <"$2" | "$3" >"$4" && cmp "$5" "$4"',
+          '--',
+          _prog,
+          files('pic' / _gif),
+          gif2rgb,
+          '@0@-@1@.regress'.format(_suite, _stem),
+          files('tests' / (_stem + '.rgb')),
+        ],
+        suite: _suite,
+      )
+    endforeach
+  endforeach
+
+  # Test gifecho.
+  test(
+    'regress',
+    sh,
+    args: [
+      '-xc',
+      ' && '.join(
+        '"$1" -t foobar | "$2" -d >"$3"',
+        'diff --strip-trailing-cr --unified "$4" "$3"',
+      ),
+      '--',
+      gifecho,
+      gifbuild,
+      'gifecho-foobar.ico',
+      files('tests/foobar.ico'),
+    ],
+    suite: 'gifecho',
+  )
+
+  # Test giffix.
+  test(
+    'regress',
+    sh,
+    args: [
+      '-xc',
+      ' && '.join(
+        'head --bytes="$1" <"$2" | "$3" | "$4" -d >"$5"',
+        'diff --strip-trailing-cr --unified "$6" "$5"',
+      ),
+      '--',
+      (fs.size('pic/treescap.gif') - 20).to_string(),
+      files('pic/treescap.gif'),
+      giffix,
+      gifbuild,
+      'giffix-giffixed.ico',
+      files('tests/giffixed.ico'),
+    ],
+    suite: 'giffix',
+  )
+
+  # Test gifinto.
+  test(
+    'regress',
+    sh,
+    args: [
+      '-xc',
+      ' && '.join(
+        'rm -f gifinto.tmp',
+        # Should create `gifinto.tmp`.
+        '"$1" <"$2" gifinto.tmp',
+        '[ -f gifinto.tmp ]',
+        'rm -f gifinto.tmp',
+        # Should not create `gifinto.tmp`.
+        'echo 0123456789 | "$1" gifinto.tmp',
+        '! [ -f gifinto.tmp ]',
+      ),
+      '--',
+      gifinto,
+      files('pic/porsche.gif'),
+      files('tests/giffixed.ico'),
+    ],
+    suite: 'gifinto',
+  )
+
+  # Test giftool.
+  foreach _spec : giftool_tests
+    _name = _spec[0]
+    _input_flags = _spec[1]
+    _input_file = _spec[2]
+    _expected_output = _spec[3]
+    test(
+      _name,
+      sh,
+      args: [
+        '-xc',
+        '"$1" $2 <"$3" | "$4" | cmp "$5" -',
+        '--',
+        giftool,
+        _input_flags,
+        files(_input_file),
+        gif2rgb,
+        files(_expected_output),
+      ],
+      suite: 'giftool',
+    )
+  endforeach
+
+  # Test gifwedge.
+  test(
+    'regress',
+    sh,
+    args: [
+      '-xc',
+      '"$1" | cmp "$2" -',
+      '--',
+      gifwedge,
+      files('tests/wedge.gif'),
+    ],
+    suite: 'gifwedge',
+  )
+
+endif

--- a/subprojects/packagefiles/giflib/meson_options.txt
+++ b/subprojects/packagefiles/giflib/meson_options.txt
@@ -1,0 +1,2 @@
+option('progs', type: 'feature', value: 'auto')
+option('tests', type: 'feature', value: 'auto')


### PR DESCRIPTION
Note: there's an unnecessary include of `unistd.h` in `gif_hash.h` that breaks the MSVC build, so I had to include a patched one… There hasn't been any activity on the upstream repository since the last release (4 years ago), so I don't think a fix is forthcoming.