### PR TITLE
ci: fix transient MSYS2 failures

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -88,6 +88,8 @@ jobs:
             pkgconf:p
             python-certifi:p
             python-pip:p
+          # Make sure Python is updated to >=3.11 (fix https://github.com/msys2/MINGW-packages/issues/17415).
+          update: true
 
       - name: Install packages
         shell: msys2 {0}


### PR DESCRIPTION
Make sure Python is updated to >=3.11 (fix https://github.com/msys2/MINGW-packages/issues/17415).