### PR TITLE
libevdev: add 1.13.1

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -411,6 +411,17 @@
       "windows": false
     }
   },
+  "libevdev": {
+    "alpine_packages": [
+      "bash"
+    ],
+    "build_options": [
+      "libevdev:documentation=disabled"
+    ],
+    "_comment": "targets '>=0.50.0' but uses cmakedefine without exactly two tokens ('>=0.54.1').",
+    "fatal_warnings": false,
+    "linux_only": true
+  },
   "libjpeg-turbo": {
     "brew_packages": [
       "nasm"

--- a/releases.json
+++ b/releases.json
@@ -1369,6 +1369,14 @@
       "1.4.2-1"
     ]
   },
+  "libevdev": {
+    "dependency_names": [
+      "libevdev"
+    ],
+    "versions": [
+      "1.13.1-1"
+    ]
+  },
   "libexif": {
     "dependency_names": [
       "libexif"

--- a/subprojects/libevdev.wrap
+++ b/subprojects/libevdev.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = libevdev-libevdev-1.13.1
+source_url = https://gitlab.freedesktop.org/libevdev/libevdev/-/archive/libevdev-1.13.1/libevdev-libevdev-1.13.1.tar.gz
+source_filename = libevdev-1.13.1.tar.gz
+source_hash = 438a9060dca43a305f75a590624412d1f858a908d4807433c67c58770f676a47
+
+[provide]
+libevdev = dep_libevdev


### PR DESCRIPTION
Upstream: https://gitlab.freedesktop.org/libevdev/libevdev.