### PR TITLE
ci: disable `fail-fast` option on MSYS2 matrix jobs

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -66,6 +66,7 @@ jobs:
     runs-on: windows-latest
     name: MSYS2-${{matrix.platform}}
     strategy:
+      fail-fast: false
       matrix:
         platform: ['UCRT64', 'CLANG32', 'CLANG64']
     steps:


### PR DESCRIPTION
Rational: the failure modes are not always the same, and you end up wasting more CI resources if you need to trigger multiple builds because you were not aware of different issues.