### PR TITLE
curl: add 8.0.1

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -73,6 +73,50 @@
       "windows": false
     }
   },
+  "curl": {
+    "_comment": [
+      "don't bother installing samba: not usable by the testuite due to smbd non-standard install name",
+      "don't install stunnel: it breaks the testsuite (certificates issues)",
+      "even with libpsl installed, the dependency is not detected…",
+      "ditto with openldap (“unknown version” at dependency check)"
+    ],
+    "brew_packages": [
+      "gnutls",
+      "krb5",
+      "libidn2",
+      "libpsl",
+      "nghttp2",
+      "openldap",
+      "rtmpdump"
+    ],
+    "debian_packages": [
+      "gnutls-bin",
+      "krb5-multidev",
+      "libgsasl-dev",
+      "libidn2-dev",
+      "libldap-dev",
+      "libnghttp2-dev",
+      "libpsl-dev",
+      "librtmp-dev",
+      "libssh2-1-dev",
+      "nghttp2-proxy",
+      "python3-impacket",
+      "samba",
+      "stunnel4",
+      "winbind"
+    ],
+    "msys_packages": [
+      "gss",
+      "libpsl",
+      "libssh2",
+      "nghttp2",
+      "rtmpdump"
+    ],
+    "build_options": [
+      "curl:ca_bundle=",
+      "curl:ca_path="
+    ]
+  },
   "dlfcn-win32": {
     "_comment": "- Requires Windows",
     "build_on": {

--- a/releases.json
+++ b/releases.json
@@ -393,6 +393,14 @@
       "1.3.0-1"
     ]
   },
+  "curl": {
+    "dependency_names": [
+      "libcurl"
+    ],
+    "versions": [
+      "8.0.1-1"
+    ]
+  },
   "cxxopts": {
     "dependency_names": [
       "cxxopts"

--- a/subprojects/curl.wrap
+++ b/subprojects/curl.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = curl-8.0.1
+source_url = https://github.com/curl/curl/releases/download/curl-8_0_1/curl-8.0.1.tar.xz
+source_fallback_url = https://curl.se/download/curl-8.0.1.tar.xz
+source_filename = curl-8.0.1.tar.xz
+source_hash = 0a381cd82f4d00a9a334438b8ca239afea5bfefcfa9a1025f2bf118e79e0b5f0
+patch_directory = curl
+
+[provide]
+dependency_names = libcurl

--- a/subprojects/packagefiles/curl/lib/meson.build
+++ b/subprojects/packagefiles/curl/lib/meson.build
@@ -1,0 +1,260 @@
+# `curl_config.h` generation. {{
+
+config_h = configure_file(
+  configuration: cdata,
+  input: '../meson/curl_config.h.meson',
+  output: 'curl_config.h',
+)
+
+add_project_arguments('-DHAVE_CONFIG_H', language: 'c')
+
+# }}}
+
+# To update this list: `make -f meson/rewrite.mk curl_lib_src`.
+curl_lib_src = files(
+  'vauth/cleartext.c',
+  'vauth/cram.c',
+  'vauth/digest.c',
+  'vauth/digest_sspi.c',
+  'vauth/gsasl.c',
+  'vauth/krb5_gssapi.c',
+  'vauth/krb5_sspi.c',
+  'vauth/ntlm.c',
+  'vauth/ntlm_sspi.c',
+  'vauth/oauth2.c',
+  'vauth/spnego_gssapi.c',
+  'vauth/spnego_sspi.c',
+  'vauth/vauth.c',
+  'vquic/curl_msh3.c',
+  'vquic/curl_ngtcp2.c',
+  'vquic/curl_quiche.c',
+  'vquic/vquic.c',
+  'vssh/libssh.c',
+  'vssh/libssh2.c',
+  'vssh/wolfssh.c',
+  'vtls/bearssl.c',
+  'vtls/gskit.c',
+  'vtls/gtls.c',
+  'vtls/hostcheck.c',
+  'vtls/keylog.c',
+  'vtls/mbedtls.c',
+  'vtls/mbedtls_threadlock.c',
+  'vtls/nss.c',
+  'vtls/openssl.c',
+  'vtls/rustls.c',
+  'vtls/schannel.c',
+  'vtls/schannel_verify.c',
+  'vtls/sectransp.c',
+  'vtls/vtls.c',
+  'vtls/wolfssl.c',
+  'vtls/x509asn1.c',
+  'altsvc.c',
+  'amigaos.c',
+  'asyn-ares.c',
+  'asyn-thread.c',
+  'base64.c',
+  'bufref.c',
+  'c-hyper.c',
+  'cf-https-connect.c',
+  'cf-socket.c',
+  'cfilters.c',
+  'conncache.c',
+  'connect.c',
+  'content_encoding.c',
+  'cookie.c',
+  'curl_addrinfo.c',
+  'curl_des.c',
+  'curl_endian.c',
+  'curl_fnmatch.c',
+  'curl_get_line.c',
+  'curl_gethostname.c',
+  'curl_gssapi.c',
+  'curl_log.c',
+  'curl_memrchr.c',
+  'curl_multibyte.c',
+  'curl_ntlm_core.c',
+  'curl_ntlm_wb.c',
+  'curl_path.c',
+  'curl_range.c',
+  'curl_rtmp.c',
+  'curl_sasl.c',
+  'curl_sspi.c',
+  'curl_threads.c',
+  'dict.c',
+  'doh.c',
+  'dynbuf.c',
+  'easy.c',
+  'easygetopt.c',
+  'easyoptions.c',
+  'escape.c',
+  'file.c',
+  'fileinfo.c',
+  'fopen.c',
+  'formdata.c',
+  'ftp.c',
+  'ftplistparser.c',
+  'getenv.c',
+  'getinfo.c',
+  'gopher.c',
+  'h2h3.c',
+  'hash.c',
+  'headers.c',
+  'hmac.c',
+  'hostasyn.c',
+  'hostip.c',
+  'hostip4.c',
+  'hostip6.c',
+  'hostsyn.c',
+  'hsts.c',
+  'http.c',
+  'http2.c',
+  'http_aws_sigv4.c',
+  'http_chunks.c',
+  'http_digest.c',
+  'http_negotiate.c',
+  'http_ntlm.c',
+  'http_proxy.c',
+  'idn.c',
+  'if2ip.c',
+  'imap.c',
+  'inet_ntop.c',
+  'inet_pton.c',
+  'krb5.c',
+  'ldap.c',
+  'llist.c',
+  'md4.c',
+  'md5.c',
+  'memdebug.c',
+  'mime.c',
+  'mprintf.c',
+  'mqtt.c',
+  'multi.c',
+  'netrc.c',
+  'nonblock.c',
+  'noproxy.c',
+  'openldap.c',
+  'parsedate.c',
+  'pingpong.c',
+  'pop3.c',
+  'progress.c',
+  'psl.c',
+  'rand.c',
+  'rename.c',
+  'rtsp.c',
+  'select.c',
+  'sendf.c',
+  'setopt.c',
+  'sha256.c',
+  'share.c',
+  'slist.c',
+  'smb.c',
+  'smtp.c',
+  'socketpair.c',
+  'socks.c',
+  'socks_gssapi.c',
+  'socks_sspi.c',
+  'speedcheck.c',
+  'splay.c',
+  'strcase.c',
+  'strdup.c',
+  'strerror.c',
+  'strtok.c',
+  'strtoofft.c',
+  'system_win32.c',
+  'telnet.c',
+  'tftp.c',
+  'timediff.c',
+  'timeval.c',
+  'transfer.c',
+  'url.c',
+  'urlapi.c',
+  'version.c',
+  'version_win32.c',
+  'warnless.c',
+  'ws.c',
+)
+
+curl_lib = library(
+  'curl',
+  config_h,
+  curl_lib_src,
+  c_args: [
+    '-DBUILDING_LIBCURL',
+    curl_symbols_hiding_flags,
+  ],
+  dependencies: [lib_deps, sys_deps],
+  gnu_symbol_visibility: curl_symbols_hiding_visibility,
+  include_directories: [CURL_PUBLIC_INC, CURL_INTERNAL_INC],
+  install: true,
+  version: '4.8.0',
+)
+
+pkg.generate(
+  curl_lib,
+  description: 'Library to transfer files with ftp, http, etc.',
+  name: 'libcurl',
+  unescaped_variables: (
+    # NOTE: variables with empty values are not allowed…
+    (
+      enabled_features.length() > 0 ? {
+        'supported_features': ' '.join(enabled_features),
+      } : {}
+    ) + (
+      enabled_protocols.length() > 0 ? {
+        'supported_protocols': ' '.join(enabled_protocols),
+      } : {}
+    )
+  ),
+  url: 'https://curl.se/',
+)
+
+curl_dep = declare_dependency(
+  include_directories: CURL_PUBLIC_INC,
+  link_with: curl_lib,
+  sources: config_h,
+)
+
+meson.override_dependency('libcurl', curl_dep)
+
+lib_deps_iflags = []
+foreach _dep : lib_deps
+  lib_deps_iflags += _dep.partial_dependency(
+    compile_args: true,
+    includes: true,
+  )
+endforeach
+
+curl_iflags_dep = declare_dependency(
+  dependencies: lib_deps_iflags,
+  include_directories: [CURL_PUBLIC_INC, CURL_INTERNAL_INC],
+)
+
+curl_ilib_dep = declare_dependency(
+  dependencies: [curl_dep, curl_iflags_dep, sys_deps],
+)
+
+curlu_flags = [
+  '-DCURL_STATICLIB',
+  '-DUNITTESTS',
+]
+
+curlu_lib = static_library(
+  'curlu',
+  config_h,
+  curl_lib_src,
+  c_args: [
+    curlu_flags,
+    '-DBUILDING_LIBCURL',
+  ],
+  dependencies: [build_unittests, lib_deps],
+  include_directories: [CURL_PUBLIC_INC, CURL_INTERNAL_INC],
+)
+
+curlu_dep = declare_dependency(
+  dependencies: sys_deps,
+  include_directories: [CURL_INTERNAL_INC, CURL_PUBLIC_INC],
+  link_with: curlu_lib,
+  sources: config_h,
+)
+
+# vim: foldmethod=marker foldlevel=0

--- a/subprojects/packagefiles/curl/meson.build
+++ b/subprojects/packagefiles/curl/meson.build
@@ -1,0 +1,1875 @@
+# Init. {{{
+
+project(
+  'curl',
+  'c',
+  version: '8.0.1',
+  # Version gated use of `test(…, verbose: true)` needs `0.62.0`.
+  meson_version: meson.version().version_compare('>=0.62.0') ? '>=0.62.0' : '>=0.60.0',
+)
+
+fs = import('fs')
+pkg = import('pkgconfig')
+cc = meson.get_compiler('c')
+cdata = configuration_data()
+
+sys_deps = []
+lib_deps = []
+
+# Constants. {{{
+
+CURL_PUBLIC_INC = include_directories('include')
+CURL_INTERNAL_INC = include_directories('lib')
+CURL_VERSION = cc.get_define(
+  'LIBCURL_VERSION',
+  include_directories: CURL_PUBLIC_INC,
+  prefix: '#include"curl/curlver.h"',
+).strip('"')
+CURL_VERSION_NUM = cc.get_define(
+  'LIBCURL_VERSION_NUM',
+  include_directories: CURL_PUBLIC_INC,
+  prefix: '#include"curl/curlver.h"',
+)
+
+if CURL_VERSION != meson.project_version()
+  error(
+    'versions mismatch, meson has @0@, while `culver.h` reports @1@!'.format(
+      meson.project_version(),
+      CURL_VERSION,
+    ),
+  )
+endif
+
+WINDOWS_ONLY_ERROR = 'only supported on Windows'
+MACOS_ONLY_ERROR   = 'only supported on macOS'
+
+MISSING_LIBS_ERROR = 'required libraries missing'
+
+SSL_DISABLED_ERROR  = 'feature ssl is disabled'
+HTTP_DISABLED_ERROR = 'feature http is disabled'
+
+DISABLED_OPT = get_option('_disabled')
+ENABLED_OPT  = get_option('_enabled')
+
+# }}}
+
+# Basic feature options. {{{
+# (not dependent on checks)
+
+foreach _opt : [
+  'cookies',
+  'crypto-auth',
+  'dict',
+  'doh',
+  'file',
+  'ftp',
+  'getoptions',
+  'gopher',
+  'imap',
+  'libcurl-option',
+  'mime',
+  'mqtt',
+  'netrc',
+  'parsedate',
+  'pop3',
+  'progress-meter',
+  'proxy',
+  'rtsp',
+  'shuffle-dns',
+  'smtp',
+  'socketpair',
+  'telnet',
+  'tftp',
+  'verbose-strings',
+]
+  set_variable(_opt.underscorify() + '_opt', get_option(_opt))
+endforeach
+
+# }}}
+
+# }}}
+
+# Platform dependencies. {{{
+
+if host_machine.system() == 'windows'
+  # For `BCryptGenRandom()`.
+  sys_deps += cc.find_library('bcrypt', required: false)
+  winmm_dep = cc.find_library('winmm', required: false)
+  if winmm_dep.found() and cc.has_function('getch', dependencies: winmm_dep)
+    sys_deps += winmm_dep
+  endif
+  ws2_32_dep = cc.find_library('ws2_32', required: false)
+  if ws2_32_dep.found() and cc.has_function('getch', dependencies: ws2_32_dep)
+    sys_deps += ws2_32_dep
+  endif
+endif
+
+# For `clock_gettime`.
+sys_deps += cc.find_library('rt', required: false)
+
+if host_machine.system() == 'darwin'
+  sys_deps += dependency(
+    'appleframeworks',
+    modules: [
+      'CoreFoundation',
+      'SystemConfiguration',
+    ],
+  )
+endif
+
+threads_dep = dependency('threads', required: false)
+
+# }}}
+
+# Basic checks. {{{
+
+check_args = []
+check_headers = []
+
+_headerlist = {
+  'arpa/inet.h': [
+    'getpeername',
+    'getsockname',
+    'inet_ntop',
+    'inet_pton',
+  ],
+  'arpa/tftp.h': [],
+  'bsd/unistd.h': [
+    'setmode',
+  ],
+  'fcntl.h': [
+    'fcntl',
+  ],
+  'fnmatch.h': [
+    'fnmatch',
+  ],
+  'ifaddrs.h': [],
+  'inttypes.h': [],
+  'io.h': [],
+  'krb.h': [],
+  'libgen.h': [
+    'basename',
+  ],
+  'linux/tcp.h': [],
+  'locale.h': [
+    'setlocale',
+  ],
+  'net/if.h': [
+    'if_nametoindex',
+  ],
+  'netdb.h': [
+    'freeaddrinfo',
+    'getaddrinfo',
+    'gethostbyname_r',
+  ],
+  'netinet/in.h': [],
+  'netinet/in6.h': [],
+  'netinet/tcp.h': [],
+  'netinet/udp.h': [],
+  'pem.h': [],
+  'poll.h': [],
+  'process.h': [],
+  'proto/bsdsocket.h': [],
+  'pthread.h': [],
+  'pwd.h': [
+    'getpwuid',
+    'getpwuid_r',
+  ],
+  'sched.h': [
+    'sched_yield',
+  ],
+  'setjmp.h': [
+    'sigsetjmp',
+  ],
+  'signal.h': [
+    'SIGALRM',
+    'sigaction',
+    'siginterrupt',
+    'signal',
+  ],
+  'sockio.h': [],
+  'stdatomic.h': [],
+  'stdbool.h': [],
+  'stddef.h': [],
+  'stdint.h': [],
+  'stdio.h': [
+    'snprintf',
+  ],
+  'stdlib.h': [
+    '_strtoi64',
+    'arc4random',
+    'strtoll',
+  ],
+  'string.h': [
+    'strcmpi',
+    'strdup',
+    'strerror_r',
+    'stricmp',
+    'strtok_r',
+  ],
+  'strings.h': [
+    'strcasecmp',
+  ],
+  'stropts.h': [],
+  'sys/filio.h': [],
+  'sys/ioctl.h': [],
+  'sys/param.h': [],
+  'sys/poll.h': [],
+  'sys/resource.h': [
+    'getrlimit',
+    'setrlimit',
+  ],
+  'sys/select.h': [
+    'select',
+  ],
+  'sys/socket.h': [
+    'sa_family_t',
+    'sendmsg',
+    'socket',
+    'socketpair',
+  ],
+  'sys/sockio.h': [],
+  'sys/stat.h': [
+    'fchmod',
+  ],
+  'sys/time.h': [
+    'gettimeofday',
+    'utimes',
+  ],
+  'sys/types.h': [],
+  'sys/uio.h': [],
+  'sys/un.h': [],
+  'sys/utime.h': [],
+  'sys/utsname.h': [
+    'uname',
+  ],
+  'sys/wait.h': [],
+  'sys/xattr.h': [
+    'fsetxattr',
+  ],
+  'termio.h': [],
+  'termios.h': [],
+  'time.h': [
+    'gmtime_r',
+    'strftime',
+  ],
+  'unistd.h': [
+    'alarm',
+    'ftruncate',
+    'geteuid',
+    'gethostname',
+    'getpass_r',
+    'getppid',
+    'pipe',
+    'setmode',
+  ],
+  'utime.h': [
+    'utime',
+  ],
+}
+
+if host_machine.system() == 'darwin'
+  _headerlist += {
+    'mach/mach_time.h': [
+      'mach_absolute_time',
+    ],
+  }
+elif host_machine.system() == 'windows'
+  _headerlist += {
+    'windows.h': [],
+    'winsock.h': [
+      'closesocket',
+      'gethostname',
+    ],
+    'winsock2.h': [
+      'ADDRESS_FAMILY',
+      'gethostname',
+      'select',
+      'socket',
+    ],
+    'ws2tcpip.h': [
+      'freeaddrinfo',
+      'getaddrinfo',
+      'inet_ntop',
+      'inet_pton',
+    ],
+  }
+endif
+
+foreach _header, _symlist : _headerlist
+  _var = 'HAVE_' + _header.underscorify().to_upper()
+  _has_header = cc.has_header(_header)
+  cdata.set(_var, _has_header)
+  if _has_header
+    check_args += '-D' + _var
+    check_headers += _header
+  endif
+  foreach _symbol : _symlist
+    _flag = 'HAVE_' + _symbol.underscorify().to_upper()
+    _available = (
+      cdata.get(_flag, false)
+      or (_has_header and cc.has_header_symbol(_header, _symbol))
+    )
+    cdata.set(_flag, _available)
+  endforeach
+endforeach
+
+check_prefix = {}
+foreach _name, _headerlist : {
+  'stdinc': [
+    'sys/types.h',
+    'stdint.h',
+    'stddef.h',
+  ],
+  'timeinc': [
+    'sys/time.h',
+    'time.h',
+  ],
+}
+  _prefix = []
+  foreach _header : _headerlist
+    if _header in check_headers
+      _prefix += '#include<@0@>'.format(_header)
+    endif
+  endforeach
+  check_prefix += {_name: '\n'.join(_prefix)}
+endforeach
+
+cdata.set('HAVE_LONGLONG', cc.has_type('long long'))
+
+foreach _type, _prefix : {
+  'int'        : check_prefix['stdinc'],
+  'short'      : check_prefix['stdinc'],
+  'long'       : check_prefix['stdinc'],
+  'long double': check_prefix['stdinc'],
+  '__int64'    : check_prefix['stdinc'],
+  'off_t'      : check_prefix['stdinc'],
+  'size_t'     : check_prefix['stdinc'],
+  'ssize_t'    : check_prefix['stdinc'],
+  'time_t'     : check_prefix['stdinc'],
+  'curl_off_t' : '#include"curl/system.h"',
+}
+  cdata.set(
+    'SIZEOF_' + _type.underscorify().to_upper(),
+    cc.sizeof(
+      _type,
+      args: check_args,
+      include_directories: CURL_PUBLIC_INC,
+      prefix: _prefix,
+    ),
+  )
+endforeach
+
+if cdata.get('SIZEOF_SIZE_T') <= 0
+  cdata.set('size_t', 'unsigned int')
+  cdata.set('SIZEOF_SIZE_T', 'SIZEOF_INT')
+endif
+
+if cdata.get('SIZEOF_SSIZE_T') <= 0
+  foreach _type : ['long', '__int64']
+    _size = cdata.get('SIZEOF_' + _type.to_upper())
+    if _size == cdata.get('SIZEOF_SIZE_T')
+      cdata.set('ssize_t', _type)
+      cdata.set('SIZEOF_SSIZE_T', _size)
+      break
+    endif
+  endforeach
+endif
+
+cdata.set(
+  'HAVE_GETIFADDRS',
+  cc.has_function(
+    'getifaddrs',
+    prefix: '''
+      #include <sys/types.h>
+      #include <ifaddrs.h>
+      ''',
+  ),
+)
+
+if not cdata.get('HAVE_GETPWUID_R') and cc.has_function('getpwuid_r')
+  cdata.set('HAVE_GETPWUID_R', true)
+  cdata.set('HAVE_DECL_GETPWUID_R_MISSING', true)
+endif
+
+cdata.set('HAVE_SIGNAL', cdata.get('HAVE_SIGALRM') and cdata.get('HAVE_SIGNAL'))
+
+cdata.set(
+  'HAVE_SUSECONDS_T',
+  cc.has_type('suseconds_t', prefix: '#include<sys/time.h>'),
+)
+
+# }}}
+
+# Features & protocols. {{{
+
+# Windows. {{{
+
+host_vista_or_newer = (
+  host_machine.system() == 'windows'
+  and cc.compiles(
+    '''
+    #include <windows.h>
+    #if (WINVER < 0x600) && (_WIN32_WINNT < 0x600)
+    #error
+    #endif
+    ''',
+    name: 'Windows >= Vista',
+  )
+)
+
+use_win32_crypto = (
+  host_machine.system() == 'windows'
+  and cc.has_header_symbol(
+    'wincrypt.h',
+    'CryptAcquireContext',
+    prefix: '#include<windows.h>',
+  )
+)
+
+if use_win32_crypto
+  lib_deps += [
+    cc.find_library('advapi32'),
+    cc.find_library('crypt32'),
+  ]
+endif
+
+sspi_opt = get_option(
+  'sspi',
+).disable_auto_if(
+  get_option('gss-api').enabled(),
+).require(
+  host_machine.system() == 'windows',
+  error_message: WINDOWS_ONLY_ERROR,
+)
+cdata.set('USE_WINDOWS_SSPI', sspi_opt.allowed())
+
+# }}}
+
+# DNS. {{{
+
+asynchdns_opt = get_option('asynchdns')
+asynchdns_resolver = ''
+
+_required = asynchdns_opt.disabled() ? asynchdns_opt : false
+foreach _resolver : get_option('asynchdns-resolver')
+  if _resolver == 'pthread'
+    # Posix threaded resolver.
+    _dep = (
+      asynchdns_opt.allowed()
+      and cdata.get('HAVE_PTHREAD_H') ? threads_dep : disabler()
+    )
+    _flag = 'USE_THREADS_POSIX'
+  elif _resolver == 'win32'
+    # Win32 threaded resolver.
+    _dep = (
+      asynchdns_opt.allowed()
+      and host_machine.system() == 'windows' ? threads_dep : disabler()
+    )
+    _flag = 'USE_THREADS_WIN32'
+  elif _resolver == 'ares'
+    # Library: c-ares.
+    _dep = dependency('libcares', required: _required)
+    _flag = 'USE_ARES'
+  else
+    error('invalid Asynchronous DNS provider: ' + _provider)
+  endif
+  if _dep.found()
+    asynchdns_resolver = _resolver
+    cdata.set(_flag, true)
+    lib_deps += _dep
+    break
+  endif
+endforeach
+
+asynchdns_opt = asynchdns_opt.require(
+  asynchdns_resolver != '',
+  error_message: 'no supported resolver',
+)
+
+# }}}
+
+# Brotli. {{{
+
+brotli_opt = get_option('brotli')
+lib_deps += dependency('libbrotlidec', required: brotli_opt)
+brotli_opt = brotli_opt.require(lib_deps[-1].found())
+cdata.set('HAVE_BROTLI', brotli_opt.allowed())
+
+# }}}
+
+# IPv6. {{{
+
+ipv6_opt = get_option('ipv6').require(
+  host_machine.system() == 'windows'
+  or cc.has_members(
+    'struct sockaddr_in6',
+    'sin6_addr',
+    'sin6_scope_id',
+    prefix: '#include<netinet/in.h>',
+  ),
+  error_message: 'struct sockaddr_in6 not available',
+)
+cdata.set('ENABLE_IPV6', ipv6_opt.allowed())
+
+# }}}
+
+# Large file. {{{
+
+cdata.set('USE_WIN32_LARGE_FILES', host_machine.system() == 'windows')
+largefile_opt = (
+  cdata.get('USE_WIN32_LARGE_FILES')
+  or (cdata.get('SIZEOF_CURL_OFF_T') > 4
+  and cdata.get('SIZEOF_OFF_T') > 4)
+  ? ENABLED_OPT : DISABLED_OPT
+)
+
+# }}}
+
+# SSH. {{{
+
+ssh_opt = get_option('ssh')
+ssh_provider = ''
+
+_required = ssh_opt.disabled() ? ssh_opt : false
+foreach _provider : get_option('ssh-provider')
+  _dep = dependency(_provider, required: _required)
+  if _dep.found()
+    cdata.set('USE_' + _provider.to_upper(), true)
+    ssh_provider = _provider
+    lib_deps += _dep
+    break
+  endif
+endforeach
+
+ssh_opt = ssh_opt.require(
+  ssh_provider != '',
+  error_message: 'no supported provider',
+)
+
+scp_opt  = ssh_opt
+sftp_opt = ssh_opt
+
+# }}}
+
+# SSL. {{{
+
+ssl_backends = []
+ssl_opt = get_option('ssl')
+
+# Windows secure channel. {{{
+
+schannel_opt = get_option(
+  'schannel',
+).disable_auto_if(
+  ssl_backends.length() > 0,
+).require(
+  host_machine.system() == 'windows',
+  error_message: WINDOWS_ONLY_ERROR,
+).require(
+  ssl_opt.allowed(),
+  error_message: SSL_DISABLED_ERROR,
+).require(
+  sspi_opt.allowed(),
+  error_message: 'feature sspi is disabled',
+).require(
+  use_win32_crypto,
+  error_message: MISSING_LIBS_ERROR,
+)
+
+cdata.set('USE_SCHANNEL', schannel_opt.allowed())
+
+ssl_backends += schannel_opt.allowed() ? 'schannel' : []
+
+# }}}
+
+# Secure transport (macOS). {{{
+
+secure_transport_opt = get_option(
+  'secure-transport',
+).disable_auto_if(
+  ssl_backends.length() > 0,
+).require(
+  ssl_opt.allowed(),
+  error_message: SSL_DISABLED_ERROR,
+).require(
+  host_machine.system() == 'darwin',
+  error_message: MACOS_ONLY_ERROR,
+)
+
+lib_deps += dependency(
+  'appleframeworks',
+  modules: 'Security',
+  required: secure_transport_opt,
+)
+secure_transport_opt.require(lib_deps[-1].found())
+
+cdata.set('USE_SECTRANSP', secure_transport_opt.allowed())
+
+ssl_backends += secure_transport_opt.allowed() ? 'secure-transport' : []
+
+# }}}
+
+# OpenSSL. {{{
+
+openssl_opt = get_option(
+  'openssl',
+).disable_auto_if(
+  ssl_backends.length() > 0,
+).require(
+  ssl_opt.allowed(),
+  error_message: SSL_DISABLED_ERROR,
+)
+
+lib_deps += dependency('openssl', required: openssl_opt)
+openssl_opt = openssl_opt.require(lib_deps[-1].found())
+openssl_auto_load_config_opt = openssl_opt
+
+cdata.set('USE_OPENSSL', openssl_opt.allowed())
+ssl_backends += openssl_opt.allowed() ? 'openssl_opt' : []
+
+_partial_dep = lib_deps[-1].partial_dependency(
+  compile_args: true,
+  includes: true,
+)
+_required = openssl_opt.disabled() ? openssl_opt : false
+
+cdata.set(
+  'HAVE_RAND_EGD',
+  cc.has_header_symbol(
+    'openssl/rand.h',
+    'RAND_egd',
+    dependencies: _partial_dep,
+    required: _required,
+  ),
+)
+cdata.set(
+  'HAVE_OPENSSL_SRP',
+  cc.has_header_symbol(
+    'openssl/ssl.h',
+    'SSL_CTX_set_srp_password',
+    dependencies: _partial_dep,
+    required: _required,
+  )
+  and cc.has_header_symbol(
+    'openssl/ssl.h',
+    'SSL_CTX_set_srp_username',
+    dependencies: _partial_dep,
+    required: _required,
+  ),
+)
+cdata.set(
+  'HAVE_SSL_SET0_WBIO',
+  cc.has_header_symbol(
+    'openssl/ssl.h',
+    'SSL_set0_wbio',
+    dependencies: _partial_dep,
+    required: _required,
+  ),
+)
+
+# }}}
+
+ssl_opt = ssl_opt.require(
+  ssl_backends.length() > 0,
+  error_message: 'no supported backend',
+)
+
+tls_srp_opt = get_option(
+  'tls-srp',
+).require(cdata.get('HAVE_OPENSSL_SRP', false))
+cdata.set('USE_TLS_SRP', tls_srp_opt.allowed())
+
+ssl_default_backend = get_option('ssl-default-backend')
+if ssl_default_backend == 'implicit'
+  cdata.set('CURL_DEFAULT_SSL_BACKEND', false)
+elif ssl_default_backend in ssl_backends
+  cdata.set_quoted('CURL_DEFAULT_SSL_BACKEND', ssl_default_backend)
+else
+  error(
+    'invalid default SSL backend: @0@ (available: @1@)'.format(
+      ssl_default_backend, ', '.join(ssl_backends),
+    ),
+  )
+endif
+
+multissl_opt = ssl_backends.length() > 1 ? ENABLED_OPT : DISABLED_OPT
+
+# }}}
+
+# GSASL. {{{
+
+gsasl_opt = get_option('gsasl')
+lib_deps += dependency('libgsasl', required: gsasl_opt)
+gsasl_opt = gsasl_opt.require(lib_deps[-1].found())
+cdata.set('USE_GSASL', gsasl_opt.allowed())
+
+# }}}
+
+# GSS API. {{{
+
+gss_api_opt = get_option(
+  'gss-api',
+).require(
+  not sspi_opt.allowed(),
+  error_message: 'feature sspi is enabled',
+)
+gss_api_provider = ''
+
+_required = gss_api_opt.disabled() ? gss_api_opt : false
+foreach _provider : get_option('gss-api-provider')
+  if _provider == 'gnu'
+    # GNU GSS.
+    _dep = dependency('gss', disabler: true, required: _required)
+    cdata.set('HAVE_GSSGNU', _dep.found())
+  elif _provider == 'mit'
+    # MIT Kerberos.
+    _dep = dependency('mit-krb5-gssapi', disabler: true, required: _required)
+    _partial_dep = _dep.partial_dependency(
+      compile_args: true,
+      includes: true,
+    )
+    foreach _header : [
+      'gssapi/gssapi.h',
+      'gssapi/gssapi_generic.h',
+    ]
+      cdata.set(
+        'HAVE_' + _header.underscorify().to_upper(),
+        cc.has_header(_header, dependencies: _partial_dep),
+      )
+    endforeach
+    # Need at least <gssapi/gssapi.h>.
+    if not cdata.get('HAVE_GSSAPI_GSSAPI_H', false)
+      _dep = disabler()
+    endif
+  elif _provider == 'heimdal'
+    # Heimdal.
+    _dep = dependency('heimdal-gssapi', disabler: true, required: _required)
+    _partial_dep = _dep.partial_dependency(
+      compile_args: true,
+      includes: true,
+    )
+    if not cc.has_header('gssapi.h', dependencies: _partial_dep)
+      _dep = disabler()
+    endif
+  else
+    error('invalid GSS-API provider: ' + _provider)
+  endif
+  if _dep.found()
+    gss_api_provider = _provider
+    lib_deps += _dep
+    break
+  endif
+endforeach
+
+gss_api_opt = gss_api_opt.require(
+  gss_api_provider != '',
+  error_message: 'no supported provider',
+)
+cdata.set('HAVE_GSSAPI', gss_api_opt.allowed())
+
+# }}}
+
+# HTTP. {{{
+
+http_opt = get_option('http')
+
+foreach _feat : [
+  'alt-svc',
+  'headers-api',
+  'hsts',
+  'http2',
+  'http-auth',
+]
+  set_variable(
+    _feat.underscorify() + '_opt',
+    get_option(
+      _feat,
+    ).require(
+      http_opt.allowed(),
+      error_message: HTTP_DISABLED_ERROR,
+    ),
+  )
+endforeach
+
+# HTTP2.
+lib_deps += dependency('libnghttp2', required: http2_opt)
+http2_opt = http2_opt.require(lib_deps[-1].found())
+cdata.set('USE_NGHTTP2', http2_opt.allowed())
+
+# HTTP3.
+http3_opt = DISABLED_OPT
+
+# HTTPS proxy.
+https_proxy_opt = ssl_opt.allowed() ? proxy_opt : DISABLED_OPT
+
+# }}}
+
+# LDAP. {{{
+
+ldap_opt = get_option('ldap')
+ldap_provider = ''
+have_ldap_ssl = false
+
+_required = ldap_opt.disabled() ? ldap_opt : false
+foreach _provider : get_option('ldap-provider')
+  if _provider == 'openldap'
+    _dep = dependency(
+      'ldap',
+      required: _required,
+      version: '>= 2.4.48',
+    )
+    _flag = 'OPENLDAP'
+  elif _provider == 'win32'
+    _dep = (
+      host_machine.system() == 'windows' ? cc.find_library(
+        'wldap32',
+        has_headers: 'winldap.h',
+        required: _required,
+      ) : disabler()
+    )
+    _flag = 'WIN32_LDAP'
+  else
+    error('invalid LDAP provider: ' + _provider)
+  endif
+  if _dep.found()
+    cdata.set('USE_' + _flag, true)
+    ldap_provider = _provider
+    lib_deps += _dep
+    break
+  endif
+endforeach
+
+ldap_opt = ldap_opt.require(
+  ldap_provider != '',
+  error_message: 'no supported provider',
+)
+
+ldaps_opt = get_option(
+  'ldaps',
+).require(
+  ldap_opt.allowed(),
+  error_message: 'feature ldap is disabled',
+).require(
+  ldap_provider == 'win32' or ssl_opt.allowed(),
+  error_message: 'no ssl support',
+)
+cdata.set('HAVE_LDAP_SSL', ldaps_opt.allowed())
+
+# }}}
+
+# NTLM. {{{
+
+ntlm_opt = get_option(
+  'ntlm',
+).require(
+  crypto_auth_opt.allowed(),
+  error_message: 'feature crypto-auth is disabled',
+).require(
+  use_win32_crypto or ssl_backends.length() > 0,
+  error_message: MISSING_LIBS_ERROR,
+)
+
+ntlm_wb_opt = get_option(
+  'ntlm-wb',
+).disable_auto_if(
+  host_machine.system() == 'windows',
+).require(
+  ntlm_opt.allowed(),
+  error_message: 'feature ntml is disabled',
+).require(
+  http_opt.allowed(),
+  error_message: HTTP_DISABLED_ERROR,
+)
+
+ntlm_wb_file = find_program(get_option('ntlm-wb-file'), required: ntlm_wb_opt)
+ntlm_wb_opt = ntlm_wb_opt.require(ntlm_wb_file.found())
+
+if ntlm_wb_opt.allowed()
+  cdata.set('NTLM_WB_ENABLED', true)
+  cdata.set_quoted('NTLM_WB_FILE', ntlm_wb_file.full_path())
+else
+  cdata.set('NTLM_WB_ENABLED', false)
+  cdata.set('NTLM_WB_FILE', false)
+endif
+
+# }}}
+
+# Public Suffix List. {{{
+
+psl_opt = get_option('psl')
+lib_deps += dependency('libpsl', required: psl_opt)
+psl_opt = psl_opt.require(lib_deps[-1].found())
+cdata.set('USE_LIBPSL', psl_opt.allowed())
+
+# }}}
+
+# RTMP. {{{
+
+rtmp_opt = get_option('rtmp')
+lib_deps += dependency('librtmp', required: rtmp_opt)
+rtmp_opt = rtmp_opt.require(lib_deps[-1].found())
+cdata.set('USE_LIBRTMP', rtmp_opt.allowed())
+
+# }}}
+
+# Samba. {{{
+
+smb_opt = get_option(
+  'smb',
+).require(
+  ntlm_opt.allowed(),
+  error_message: 'feature ntlm is disabled',
+).require(
+  cdata.get('SIZEOF_CURL_OFF_T') > 4,
+  error_message: 'sizeof (curl_off_t) <= 4',
+)
+
+smbs_opt = ssl_opt.allowed() ? smb_opt : DISABLED_OPT
+
+# }}}
+
+# Unix sockets. {{{
+
+unixsockets_opt = get_option(
+  'unixsockets',
+).require(
+  host_machine.system() == 'windows'
+  or cc.has_member(
+    'struct sockaddr_un',
+    'sun_path',
+    prefix: '#include<sys/un.h>',
+  ),
+  error_message: 'struct sockaddr_un not available',
+)
+
+cdata.set('USE_UNIX_SOCKETS', unixsockets_opt.allowed())
+
+# }}}
+
+# IDN. {{{
+
+idn_opt = get_option('idn')
+idn_provider = ''
+
+_required = idn_opt.disabled() ? idn_opt : false
+foreach _provider : get_option('idn-provider')
+  if _provider == 'libidn2'
+    # Library: libdn2.
+    _dep = dependency('libidn2', required: _required)
+    cdata.set('HAVE_LIBIDN2', _dep.found())
+    cdata.set('HAVE_IDN2_H', _dep.found())
+    if _dep.found()
+      idn_provider = _provider
+      lib_deps += _dep
+      break
+    endif
+  elif _provider == 'winidn'
+    # Windows IDN.
+    _dep = (
+      host_vista_or_newer ? cc.find_library(
+        'normaliz',
+        disabler: true,
+        required: _required,
+      ) : disabler()
+    )
+    if cc.has_function(
+      'IdnToUnicode',
+      dependencies: _dep,
+    )
+      cdata.set('USE_WIN32_IDN', true)
+      idn_provider = 'winidn'
+      lib_deps += _dep
+      break
+    endif
+  else
+    error('invalid IDN provider: ' + _provider)
+  endif
+endforeach
+
+idn_opt = idn_opt.require(
+  idn_provider != '',
+  error_message: 'no supported provider',
+)
+
+# }}}
+
+# ZLIB. {{{
+
+libz_opt = get_option('libz')
+lib_deps += dependency('zlib', required: libz_opt)
+libz_opt = libz_opt.require(lib_deps[-1].found())
+cdata.set('HAVE_LIBZ', libz_opt.allowed())
+
+# }}}
+
+# ZSTD. {{{
+
+zstd_opt = get_option('zstd')
+lib_deps += dependency('libzstd', required: zstd_opt)
+zstd_opt = zstd_opt.require(lib_deps[-1].found())
+cdata.set('HAVE_ZSTD', zstd_opt.allowed())
+
+# }}}
+
+# }}}
+
+# Advanced checks. {{{
+
+_has_fcntl = cdata.get('HAVE_FCNTL')
+_has_fsetxattr = cdata.get('HAVE_FSETXATTR')
+_has_gethostbyname_r = cdata.get('HAVE_GETHOSTBYNAME_R')
+
+# TODO: replace some of those with simpler checks.
+foreach _spec : [
+  ['HAVE_ATOMIC'],
+  ['HAVE_BOOL_T'],
+  ['HAVE_BUILTIN_AVAILABLE'],
+  ['HAVE_CLOCK_GETTIME_MONOTONIC'],
+  ['HAVE_FCNTL_O_NONBLOCK', _has_fcntl],
+  ['HAVE_FSETXATTR_5', _has_fsetxattr],
+  ['HAVE_FSETXATTR_6', _has_fsetxattr],
+  ['HAVE_GETHOSTBYNAME_R_3', _has_gethostbyname_r],
+  ['HAVE_GETHOSTBYNAME_R_3', _has_gethostbyname_r],
+  ['HAVE_GETHOSTBYNAME_R_3_REENTRANT', _has_gethostbyname_r],
+  ['HAVE_GETHOSTBYNAME_R_3_REENTRANT', _has_gethostbyname_r],
+  ['HAVE_GETHOSTBYNAME_R_5', _has_gethostbyname_r],
+  ['HAVE_GETHOSTBYNAME_R_5', _has_gethostbyname_r],
+  ['HAVE_GETHOSTBYNAME_R_5_REENTRANT', _has_gethostbyname_r],
+  ['HAVE_GETHOSTBYNAME_R_5_REENTRANT', _has_gethostbyname_r],
+  ['HAVE_GETHOSTBYNAME_R_6', _has_gethostbyname_r],
+  ['HAVE_GETHOSTBYNAME_R_6', _has_gethostbyname_r],
+  ['HAVE_GETHOSTBYNAME_R_6_REENTRANT', _has_gethostbyname_r],
+  ['HAVE_GETHOSTBYNAME_R_6_REENTRANT', _has_gethostbyname_r],
+  ['HAVE_GLIBC_STRERROR_R'],
+  ['HAVE_IN_ADDR_T'],
+  ['HAVE_IOCTLSOCKET'],
+  ['HAVE_IOCTLSOCKET_CAMEL'],
+  ['HAVE_IOCTLSOCKET_CAMEL_FIONBIO'],
+  ['HAVE_IOCTLSOCKET_FIONBIO'],
+  ['HAVE_IOCTL_FIONBIO'],
+  ['HAVE_IOCTL_SIOCGIFADDR'],
+  ['HAVE_O_NONBLOCK'],
+  ['HAVE_POSIX_STRERROR_R'],
+  ['HAVE_SETSOCKOPT_SO_NONBLOCK'],
+  ['HAVE_VARIADIC_MACROS_C99'],
+  ['HAVE_VARIADIC_MACROS_GCC'],
+  ['STDC_HEADERS'],
+]
+  _test = _spec[0]
+  _enabled = _spec.get(1, true)
+  cdata.set(
+    _test,
+    _enabled
+    and cc.links(
+      files('CMake/CurlTests.c'),
+      args: [check_args, '-D' + _test],
+      dependencies: sys_deps,
+      name: _test + ' test',
+    ),
+  )
+endforeach
+
+_source_epilogue = '#undef inline'
+
+if host_machine.system() == 'windows'
+  foreach _header : [
+    # NOTE: do not reorder (`winsock2.h` must be included before `windows.h`).
+    'winsock2.h',
+    'windows.h',
+  ]
+    if _header in check_headers
+      _source_epilogue += '\n#include<@0@>'.format(_header)
+    endif
+  endforeach
+  _source_epilogue += '\n#ifndef WIN32_LEAN_AND_MEAN\n#define WIN32_LEAN_AND_MEAN\n#endif'
+else
+  foreach _header : [
+    'proto/bsdsocket.h',
+    'sys/types.h',
+    'sys/socket.h',
+    'sys/time.h',
+    'time.h',
+  ]
+    if _header in check_headers
+      _source_epilogue += '\n#include<@0@>'.format(_header)
+    endif
+  endforeach
+endif
+
+threadsafe_opt = (
+  host_vista_or_newer
+  or cdata.get('HAVE_STDATOMIC_H')
+  ? ENABLED_OPT : DISABLED_OPT
+)
+
+cdata.set(
+  'HAVE_GETADDRINFO_THREADSAFE',
+  host_machine.system() == 'windows'
+  or cc.compiles(
+    '''
+    #ifdef HAVE_SYS_SOCKET_H
+    #  include<sys/socket.h>
+    #endif
+    #ifdef HAVE_NETDB_H
+    #  include<netdb.h>
+    #endif
+    int main(void) {
+      #ifndef h_errno
+        force compilation error
+      #endif
+      #if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200809L)
+      #elif defined(_XOPEN_SOURCE) && (_XOPEN_SOURCE >= 700)
+      #else
+        force compilation error
+      #endif
+      h_errno = 2;
+      if(0 != h_errno)
+        return 1;
+      return 0;
+    }
+    ''',
+    args: check_args,
+    dependencies: sys_deps,
+    name: 'HAVE_GETADDRINFO_THREADSAFE test',
+  ),
+)
+
+cdata.set(
+  'HAVE_RECV',
+  cc.links(
+    _source_epilogue + '''
+    int main(void) {
+      recv(0, 0, 0, 0);
+      return 0;
+    }
+    ''',
+    args: check_args,
+    dependencies: sys_deps,
+    name: 'HAVE_RECV test',
+  ),
+)
+
+cdata.set(
+  'HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID',
+  cc.compiles(
+    '''
+    #include <sys/types.h>
+    #ifdef HAVE_WINSOCK2_H
+    #include <winsock2.h>
+    #include <ws2tcpip.h>
+    #else
+    #include <netinet/in.h>
+    #if defined (__TANDEM)
+    # include <netinet/in6.h>
+    #endif
+    #endif
+    int main(void) {
+      struct sockaddr_in6 s;
+      s.sin6_scope_id = 0;
+      return 0;
+    }
+    ''',
+    args: check_args,
+    dependencies: sys_deps,
+    name: 'HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID test',
+  ),
+)
+
+cdata.set(
+  'HAVE_SEND',
+  cc.links(
+    _source_epilogue + '''
+    int main(void) {
+      send(0, 0, 0, 0);
+      return 0;
+    }
+    ''',
+    args: check_args,
+    dependencies: sys_deps,
+    name: 'HAVE_SEND test',
+  ),
+)
+
+cdata.set(
+  'HAVE_MSG_NOSIGNAL',
+  cc.links(
+    _source_epilogue + '''
+    int main(void) {
+      int flag = MSG_NOSIGNAL;
+      (void)flag;
+      return 0;
+    }
+    ''',
+    name: 'HAVE_MSG_NOSIGNAL test',
+  ),
+)
+
+cdata.set(
+  'HAVE_STRUCT_TIMEVAL',
+  cc.links(
+    _source_epilogue + '''
+    int main(void) {
+      struct timeval ts;
+      ts.tv_sec  = 0;
+      ts.tv_usec = 0;
+      (void)ts;
+      return 0;
+    }
+    ''',
+    name: 'HAVE_STRUCT_TIMEVAL test',
+  ),
+)
+
+cdata.set(
+  'HAVE_STRUCT_SOCKADDR_STORAGE',
+  cc.sizeof(
+    'struct sockaddr_storage',
+    prefix: _source_epilogue,
+  ) > 0,
+)
+
+cdata.set(
+  'HAVE_POLL_FINE',
+  meson.can_run_host_binaries()
+  and cc.run(
+    '''
+    #include <stdlib.h>
+    #include <sys/time.h>
+    #ifdef HAVE_SYS_POLL_H
+    #  include <sys/poll.h>
+    #elif  HAVE_POLL_H
+    #  include <poll.h>
+    #endif
+    int main(void)
+    {
+        if (0 != poll(0, 0, 10)) {
+          return 1; /* fail */
+        }
+        else {
+          /* detect the 10.12 poll() breakage */
+          struct timeval before, after;
+          int rc;
+          size_t us;
+          gettimeofday(&before, NULL);
+          rc = poll(NULL, 0, 500);
+          gettimeofday(&after, NULL);
+          us = (after.tv_sec - before.tv_sec) * 1000000 +
+            (after.tv_usec - before.tv_usec);
+          if (us < 400000) {
+            return 1;
+          }
+        }
+        return 0;
+    }
+    ''',
+    args: check_args,
+    dependencies: sys_deps,
+    name: 'HAVE_POLL_FINE test',
+  ).returncode() == 0,
+)
+
+cdata.set(
+  'HAVE_TIME_T_UNSIGNED',
+  meson.can_run_host_binaries()
+  and cc.run(
+    '''
+    #include <time.h>
+    #include <limits.h>
+    int main(void) {
+      time_t t = -1;
+      return (t < 0);
+    }
+    ''',
+    name: 'HAVE_TIME_T_UNSIGNED test',
+  ).returncode() == 0,
+)
+
+cdata.set(
+  'HAVE_WRITABLE_ARGV',
+  meson.can_run_host_binaries()
+  and cc.run(
+    '''
+    int main(int argc, char **argv)
+    {
+      (void)argc;
+      argv[0][0] = ' ';
+      return (argv[0][0] == ' ')?0:1;
+    }
+    ''',
+    name: 'HAVE_WRITABLE_ARGV test',
+  ).returncode() == 0,
+)
+
+_required = cdata.get('HAVE_GETHOSTNAME') ? true : disabler()
+foreach _arg1 : ['char *', 'unsigned char *', 'void *']
+  foreach _arg2 : ['int', 'unsigned int', 'size_t']
+    if (
+      _required
+      and cc.compiles(
+        _source_epilogue + '''
+        #ifdef HAVE_WINDOWS_H
+        #  ifndef WIN32_LEAN_AND_MEAN
+        #    define WIN32_LEAN_AND_MEAN
+        #  endif
+        #  include <windows.h>
+        #  if defined(HAVE_WINSOCK2_H)
+        #    include <winsock2.h>
+        #  elif defined(HAVE_WINSOCK_H)
+        #    include <winsock.h>
+        #  endif
+        #endif
+        #ifdef HAVE_SYS_TYPES_H
+        #  include <sys/types.h>
+        #endif
+        #ifdef HAVE_UNISTD_H
+        #  include <unistd.h>
+        #endif
+        #ifdef HAVE_WINDOWS_H
+        #  define FUNCALLCONV __stdcall
+        #else
+        #  define FUNCALLCONV
+        #endif
+        extern int FUNCALLCONV gethostname(@0@, @1@);
+        int main(void) {
+          if(0 != gethostname(0, 0))
+            return 1;
+          return 0;
+        }
+        '''.format(_arg1, _arg2),
+        args: check_args,
+        name: 'gethostname(@0@, @1@)'.format(_arg1, _arg2),
+      )
+    )
+      cdata.set('GETHOSTNAME_TYPE_ARG2', _arg2)
+      _required = disabler()
+    endif
+  endforeach
+endforeach
+
+# NEED_REENTRANT. {{{
+
+_need_reentrant = false
+
+_flaglist = [
+  'HAVE_GETHOSTBYNAME_R_3',
+  'HAVE_GETHOSTBYNAME_R_5',
+  'HAVE_GETHOSTBYNAME_R_6',
+]
+
+foreach _flag : _flaglist
+  if not cdata.get(_flag) and cdata.get(_flag + '_REENTRANT')
+    _need_reentrant = true
+  endif
+endforeach
+
+cdata.set('NEED_REENTRANT', _need_reentrant)
+
+if _need_reentrant
+  foreach _flag : _flaglist
+    cdata.set(_flag, cdata.get(_flag + '_REENTRANT'))
+  endforeach
+endif
+
+# }}}
+
+# }}}.
+
+# Finalize config. {{{
+
+# OS {{{
+
+# Some parts of the testsuite rely on a particular
+# formatting, e.g. for detecting the Windows build.
+if cc.get_argument_syntax() == 'gcc'
+  _os = run_command(cc.cmd_array(), '-dumpmachine', check: true).stdout().strip()
+else
+  _os = '-'.join(host_machine.cpu(), host_machine.system())
+endif
+
+cdata.set_quoted('OS', _os)
+
+# }}}
+
+# Compile flags. {{{
+
+# Symbols visibility.
+if (
+  cc.has_argument('-fvisibility=hidden')
+  and cc.has_function_attribute('visibility:default')
+)
+  cdata.set(
+    'CURL_EXTERN_SYMBOL',
+    '__attribute__ ((__visibility__ ("default")))',
+  )
+  curl_symbols_hiding_flags      = ['-DCURL_HIDDEN_SYMBOLS']
+  curl_symbols_hiding_visibility = 'hidden'
+else
+  cdata.set('CURL_EXTERN_SYMBOL', '')
+  curl_symbols_hiding_flags      = []
+  curl_symbols_hiding_visibility = 'default'
+endif
+
+# Turn off Visual Studio CRT deprecation warnings.
+if cc.get_id() == 'clang-cl'
+  add_project_arguments(
+    [
+      '-D_CRT_NONSTDC_NO_DEPRECATE',
+      '-D_CRT_SECURE_NO_DEPRECATE',
+      '-D_CRT_SECURE_NO_WARNINGS',
+    ],
+    language: 'c',
+  )
+endif
+
+# }}}
+
+# CA. {{{
+
+ca_bundle = get_option('ca_bundle')
+if ca_bundle == 'auto'
+  foreach _path : [
+    '/etc/ssl/certs/ca-certificates.crt',
+    '/etc/pki/tls/certs/ca-bundle.crt',
+    '/usr/share/ssl/certs/ca-bundle.crt',
+    '/usr/local/share/certs/ca-root-nss.crt',
+    '/etc/ssl/cert.pem',
+  ]
+    if fs.is_file(_path)
+      ca_bundle = _path
+      break
+    endif
+  endforeach
+  if ca_bundle == 'auto'
+    message('CA bundle auto-detection failed')
+    ca_bundle = ''
+  endif
+endif
+if ca_bundle == ''
+  cdata.set('CURL_CA_BUNDLE', false)
+else
+  cdata.set_quoted('CURL_CA_BUNDLE', ca_bundle)
+endif
+
+ca_path = get_option('ca_path')
+if ca_path == 'auto'
+  foreach _path : [
+    '/etc/ssl/certs',
+  ]
+    if fs.is_dir(_path)
+      ca_path = _path
+      break
+    endif
+  endforeach
+  if ca_path == 'auto'
+    message('CA path auto-detection failed')
+    ca_path = ''
+  endif
+endif
+if ca_path == ''
+  cdata.set('CURL_CA_PATH', false)
+else
+  cdata.set_quoted('CURL_CA_PATH', ca_path)
+endif
+
+cdata.set('CURL_CA_FALLBACK', get_option('ca_fallback'))
+
+# }}}
+
+# Protocols. {{{
+
+# SSL variants.
+foreach _proto : [
+  'ftp',
+  'gopher',
+  'http',
+  'imap',
+  'pop3',
+  'smtp',
+]
+  set_variable(
+    _proto + 's_opt',
+    ssl_opt.allowed()
+    and get_variable(_proto + '_opt').allowed()
+    ? ENABLED_OPT : DISABLED_OPT,
+  )
+endforeach
+
+foreach _proto : [
+  'dict',
+  'file',
+  'ftp',
+  'gopher',
+  'http',
+  'imap',
+  'ldap',
+  'ldaps',
+  'mqtt',
+  'pop3',
+  'rtsp',
+  'smb',
+  'smtp',
+  'telnet',
+  'tftp',
+]
+  cdata.set(
+    'CURL_DISABLE_' + _proto.to_upper(),
+    get_variable(_proto + '_opt').disabled(),
+  )
+endforeach
+
+# }}}
+
+# Features. {{{
+
+kerberos_opt = (
+  crypto_auth_opt.allowed()
+  and (gss_api_opt.allowed() or sspi_opt.allowed())
+  ? ENABLED_OPT : DISABLED_OPT
+)
+spnego_opt = kerberos_opt
+
+# `CURL_DISABLE_ALTSVC` is used instead of `CURL_DISABLE_ALT_SVC`…
+altsvc_opt = alt_svc_opt
+
+foreach _feat : [
+  'altsvc',
+  'cookies',
+  'crypto-auth',
+  'doh',
+  'getoptions',
+  'headers-api',
+  'hsts',
+  'http-auth',
+  'libcurl-option',
+  'mime',
+  'netrc',
+  'ntlm',
+  'openssl-auto-load-config',
+  'parsedate',
+  'progress-meter',
+  'proxy',
+  'shuffle-dns',
+  'socketpair',
+  'verbose-strings',
+]
+  cdata.set(
+    'CURL_DISABLE_' + _feat.underscorify().to_upper(),
+    get_variable(_feat.underscorify() + '_opt').disabled(),
+  )
+endforeach
+
+# }}}.
+
+# Reported features, protocols, and SSL backends. {{{
+
+foreach _section, _optlist : {
+  'features': [
+    ['Alt-Svc'],
+    ['AsynchDNS', asynchdns_resolver != '' ? asynchdns_resolver : false],
+    ['Brotli'],
+    ['GSASL'],
+    ['GSS-API', gss_api_provider != '' ? gss_api_provider : false],
+    ['HTTP2'],
+    ['HTTP3'],
+    ['HTTPS-proxy'],
+    ['HSTS'],
+    ['IDN', idn_provider != '' ? idn_provider : false],
+    ['IPv6'],
+    ['Kerberos'],
+    ['Largefile'],
+    ['LibZ'],
+    ['MultiSSL'],
+    ['NTLM'],
+    ['NTLM_WB'],
+    ['PSL'],
+    ['SPNEGO'],
+    ['SSL'],
+    ['SSPI'],
+    ['TLS-SRP'],
+    ['ThreadSafe'],
+    ['UnixSockets'],
+    ['ZSTD'],
+  ],
+  'protocols': [
+    ['DICT'],
+    ['FILE'],
+    ['FTP'],
+    ['FTPS'],
+    ['GOPHER'],
+    ['GOPHERS'],
+    ['HTTP'],
+    ['HTTPS'],
+    ['IMAP'],
+    ['IMAPS'],
+    ['LDAP', ldap_provider != '' ? ldap_provider : false],
+    ['LDAPS'],
+    ['MQTT'],
+    ['POP3'],
+    ['POP3S'],
+    ['RTMP'],
+    ['RTSP'],
+    ['SCP', ssh_provider != '' ? ssh_provider : false],
+    ['SFTP', ssh_provider != '' ? ssh_provider : false],
+    ['SMB'],
+    ['SMBS'],
+    ['SMTP'],
+    ['SMTPS'],
+    ['TELNET'],
+    ['TFTP'],
+  ],
+  'ssl_backends': [
+    ['OpenSSL'],
+    ['Schannel'],
+    ['Secure Transport'],
+  ],
+}
+  _summary = {}
+  _enabled_list = []
+  _disabled_list = []
+  foreach _spec : _optlist
+    _name = _spec[0]
+    _opt = _name.underscorify().to_lower() + '_opt'
+    _enabled = get_variable(_opt).allowed()
+    _summary_value = _spec.get(1, _enabled)
+    if _enabled
+      _enabled_list += _name
+    else
+      _disabled_list += _name
+    endif
+    _summary += {_name: _summary_value}
+  endforeach
+  set_variable(_section + '_summary', _summary)
+  set_variable('enabled_' + _section, _enabled_list)
+  set_variable('disabled_' + _section, _disabled_list)
+endforeach
+
+ssl_backends_summary += {'Default backend': ssl_default_backend}
+
+# }}}
+
+# Sanitize boolean flags.
+_boolkeys = ['STDC_HEADERS']
+foreach _key : cdata.keys()
+  if (
+    _key.startswith('CURL_DISABLE_')
+    or _key.endswith('_ENABLED')
+    or _key.split('_')[0] in [
+      'ENABLE',
+      'HAVE',
+      'NEED',
+      'USE',
+    ]
+  )
+    _boolkeys += _key
+  endif
+endforeach
+foreach _key : _boolkeys
+  cdata.set(_key, cdata.get(_key) ? 1 : false)
+endforeach
+
+# }}}
+
+# Other. {{{
+
+cdata.set('CURL_WITH_MULTI_SSL', enabled_ssl_backends.length() > 1)
+
+if fs.exists('/dev/urandom')
+  cdata.set_quoted('RANDOM_FILE', '/dev/urandom')
+endif
+
+cdata.set('DEBUGBUILD', get_option('debug'))
+cdata.set('CURLDEBUG', get_option('curldebug'))
+
+# }}}
+
+# Generate `curl-config`. {{{
+
+cdata.set_quoted('CURLVERSION', CURL_VERSION)
+cdata.set_quoted('VERSIONNUM', CURL_VERSION_NUM.replace('0x', ''))
+
+_link_args = get_option('c_link_args')
+cdata.set('CC', ' '.join(cc.cmd_array()))
+cdata.set(
+  'LDFLAGS',
+  _link_args.length() > 0 ? ('\'' + '\' \''.join(_link_args) + '\'') : '',
+)
+cdata.set_quoted(
+  'CPPFLAG_CURL_STATICLIB',
+  get_option('default_library') == 'static' ? '-DCURL_STATICLIB' : '',
+)
+cdata.set_quoted(
+  'ENABLE_SHARED',
+  get_option('default_library') in ['both', 'shared'] ? 'yes' : 'no',
+)
+cdata.set_quoted(
+  'ENABLE_STATIC',
+  get_option('default_library') in ['both', 'static'] ? 'yes' : 'no',
+)
+# FIXME
+cdata.set('CONFIGURE_OPTIONS', '')
+cdata.set('LIBCURL_LIBS', '')
+
+cdata.set_quoted('prefix', get_option('prefix'))
+cdata.set_quoted('exec_prefix', '${prefix}')
+cdata.set_quoted('includedir', '${prefix}' / get_option('includedir'))
+cdata.set_quoted('libdir', '${prefix}' / get_option('libdir'))
+cdata.set_quoted('libext', 'a')
+
+cdata.set('SUPPORT_FEATURES', ' '.join(enabled_features))
+cdata.set('SUPPORT_PROTOCOLS', ' '.join(enabled_protocols))
+cdata.set('SSL_BACKENDS', ' '.join(enabled_ssl_backends))
+
+curl_config_script = configure_file(
+  configuration: cdata,
+  input: 'curl-config.in',
+  output: 'curl-config',
+  install: true,
+  install_dir: get_option('bindir'),
+  install_tag: 'devel',
+)
+
+# }}}
+
+# }}}
+
+# Tests. {{{
+
+# Don't automatically enable tests on Windows,
+# as the testsuite does not seem to support it.
+tests_opt = get_option(
+  'tests',
+).disable_auto_if(
+  host_machine.system() == 'windows',
+)
+
+# Absolute minimum for setting up & running the testsuite.
+bash_exe = find_program('bash', required: tests_opt)
+# NOTE: look for `gmake` first so on macOS we get the
+# brew version (>=4) and not the old system one (3.xx)…
+make_exe = find_program(['gmake', 'make', 'mingw32-make'], required: tests_opt)
+# Don't use `find_program('perl')`, as is it may yield a different perl
+# than the one that is going to be used by the testsuite through bash
+# (e.g. on Windows).
+if bash_exe.found()
+  _cmd = [bash_exe, '-c', 'perl -e ""']
+  _ret = run_command(_cmd, check: false)
+  # message(
+  #   '@0@ return @1@:\n@2@'.format(
+  #     _cmd,
+  #     _ret.returncode(),
+  #     _ret.stderr(),
+  #   ),
+  # )
+  perl_found = _ret.returncode() == 0
+else
+  perl_found = false
+endif
+
+tests_opt = tests_opt.require(
+  bash_exe.found() and make_exe.found() and perl_found,
+  error_message: 'running the testsuite requires a UNIX like system with bash, make and perl',
+)
+build_tests = tests_opt.allowed() ? declare_dependency() : disabler()
+
+unittests_opt = get_option(
+  'unittests',
+).require(
+  tests_opt.allowed(),
+  error_message: 'feature tests is disabled',
+).require(
+  get_option('debug'),
+  error_message: 'only support debug builds',
+)
+build_unittests = unittests_opt.allowed() ? declare_dependency() : disabler()
+
+# }}}
+
+# Install. {{{
+
+install_data(
+  'docs/libcurl/libcurl.m4',
+  install_dir: get_option('datadir') / 'aclocal',
+  install_tag: 'devel',
+)
+
+install_data(
+  'COPYING',
+  install_dir: get_option('datadir') / 'licences/curl',
+)
+
+install_headers(
+  [
+    'include/curl/curl.h',
+    'include/curl/curlver.h',
+    'include/curl/easy.h',
+    'include/curl/header.h',
+    'include/curl/mprintf.h',
+    'include/curl/multi.h',
+    'include/curl/options.h',
+    'include/curl/stdcheaders.h',
+    'include/curl/system.h',
+    'include/curl/typecheck-gcc.h',
+    'include/curl/urlapi.h',
+    'include/curl/websockets.h',
+  ],
+  subdir: 'curl',
+)
+
+# }}}
+
+# Subdirs. {{{
+
+subdir('lib')
+
+if get_option('tool').allowed() or build_tests.found()
+  subdir('src')
+endif
+
+if build_tests.found()
+  subdir('tests')
+endif
+
+# }}}
+
+# Summary. {{{
+
+summary(
+  {
+    'OS': cdata.get_unquoted('OS'),
+  },
+  bool_yn: true,
+  section: 'System',
+)
+
+summary(
+  {
+    'Path'    : cdata.get('CURL_CA_PATH'),
+    'Bundle'  : cdata.get('CURL_CA_BUNDLE'),
+    'Fallback': cdata.get('CURL_CA_FALLBACK'),
+  },
+  bool_yn: true,
+  section: 'CA',
+)
+
+summary(
+  features_summary,
+  bool_yn: true,
+  section: 'Features',
+)
+
+summary(
+  protocols_summary,
+  bool_yn: true,
+  section: 'Protocols',
+)
+
+summary(
+  ssl_backends_summary,
+  bool_yn: true,
+  section: 'SSL backends',
+)
+
+# }}}
+
+# vim: foldmethod=marker foldlevel=0

--- a/subprojects/packagefiles/curl/meson/curl_config.h.meson
+++ b/subprojects/packagefiles/curl/meson/curl_config.h.meson
@@ -1,0 +1,835 @@
+/* lib/curl_config.h.  Generated from meson/curl_config.h.meson by meson.  */
+
+/* to enable curl debug memory tracking */
+#mesondefine CURLDEBUG
+
+/* Location of default ca bundle */
+#mesondefine CURL_CA_BUNDLE
+
+/* define "1" to use built in CA store of SSL library */
+#mesondefine CURL_CA_FALLBACK
+
+/* Location of default ca path */
+#mesondefine CURL_CA_PATH
+
+/* Default SSL backend */
+#mesondefine CURL_DEFAULT_SSL_BACKEND
+
+/* disable alt-svc */
+#mesondefine CURL_DISABLE_ALTSVC
+
+/* to disable cookies support */
+#mesondefine CURL_DISABLE_COOKIES
+
+/* to disable cryptographic authentication */
+#mesondefine CURL_DISABLE_CRYPTO_AUTH
+
+/* to disable DICT */
+#mesondefine CURL_DISABLE_DICT
+
+/* disable DoH */
+#mesondefine CURL_DISABLE_DOH
+
+/* to disable FILE */
+#mesondefine CURL_DISABLE_FILE
+
+/* to disable FTP */
+#mesondefine CURL_DISABLE_FTP
+
+/* to disable curl_easy_options */
+#mesondefine CURL_DISABLE_GETOPTIONS
+
+/* to disable Gopher */
+#mesondefine CURL_DISABLE_GOPHER
+
+/* disable headers-api */
+#mesondefine CURL_DISABLE_HEADERS_API
+
+/* disable alt-svc */
+#mesondefine CURL_DISABLE_HSTS
+
+/* to disable HTTP */
+#mesondefine CURL_DISABLE_HTTP
+
+/* disable HTTP authentication */
+#mesondefine CURL_DISABLE_HTTP_AUTH
+
+/* to disable IMAP */
+#mesondefine CURL_DISABLE_IMAP
+
+/* to disable LDAP */
+#mesondefine CURL_DISABLE_LDAP
+
+/* to disable LDAPS */
+#mesondefine CURL_DISABLE_LDAPS
+
+/* to disable --libcurl C code generation option */
+#mesondefine CURL_DISABLE_LIBCURL_OPTION
+
+/* disable mime API */
+#mesondefine CURL_DISABLE_MIME
+
+/* to disable MQTT */
+#mesondefine CURL_DISABLE_MQTT
+
+/* disable netrc parsing */
+#mesondefine CURL_DISABLE_NETRC
+
+/* to disable NTLM support */
+#mesondefine CURL_DISABLE_NTLM
+
+/* if the OpenSSL configuration won't be loaded automatically */
+#mesondefine CURL_DISABLE_OPENSSL_AUTO_LOAD_CONFIG
+
+/* disable date parsing */
+#mesondefine CURL_DISABLE_PARSEDATE
+
+/* to disable POP3 */
+#mesondefine CURL_DISABLE_POP3
+
+/* disable progress-meter */
+#mesondefine CURL_DISABLE_PROGRESS_METER
+
+/* to disable proxies */
+#mesondefine CURL_DISABLE_PROXY
+
+/* to disable RTSP */
+#mesondefine CURL_DISABLE_RTSP
+
+/* disable DNS shuffling */
+#mesondefine CURL_DISABLE_SHUFFLE_DNS
+
+/* to disable SMB/CIFS */
+#mesondefine CURL_DISABLE_SMB
+
+/* to disable SMTP */
+#mesondefine CURL_DISABLE_SMTP
+
+/* to disable socketpair support */
+#mesondefine CURL_DISABLE_SOCKETPAIR
+
+/* to disable TELNET */
+#mesondefine CURL_DISABLE_TELNET
+
+/* to disable TFTP */
+#mesondefine CURL_DISABLE_TFTP
+
+/* to disable verbose strings */
+#mesondefine CURL_DISABLE_VERBOSE_STRINGS
+
+/* Definition to make a library symbol externally visible. */
+#mesondefine CURL_EXTERN_SYMBOL
+
+/* built with multiple SSL backends */
+#mesondefine CURL_WITH_MULTI_SSL
+
+/* enable debug build options */
+#mesondefine DEBUGBUILD
+
+/* your Entropy Gathering Daemon socket pathname */
+#mesondefine EGD_SOCKET
+
+/* Define if you want to enable IPv6 support */
+#mesondefine ENABLE_IPV6
+
+/* Define to the type of arg 2 for gethostname. */
+#mesondefine GETHOSTNAME_TYPE_ARG2
+
+/* Define to 1 if you have `ADDRESS_FAMILY' type. */
+#mesondefine HAVE_ADDRESS_FAMILY
+
+/* Define to 1 if you have the alarm function. */
+#mesondefine HAVE_ALARM
+
+/* Define to 1 if you have the `arc4random' function. */
+#mesondefine HAVE_ARC4RANDOM
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+#mesondefine HAVE_ARPA_INET_H
+
+/* Define to 1 if you have the <arpa/tftp.h> header file. */
+#mesondefine HAVE_ARPA_TFTP_H
+
+/* Define to 1 if you have _Atomic support. */
+#mesondefine HAVE_ATOMIC
+
+/* Define to 1 if you have the basename function. */
+#mesondefine HAVE_BASENAME
+
+/* Define to 1 if bool is an available type. */
+#mesondefine HAVE_BOOL_T
+
+/* Define to 1 if using BoringSSL. */
+#mesondefine HAVE_BORINGSSL
+
+/* if BROTLI is in use */
+#mesondefine HAVE_BROTLI
+
+/* Define to 1 if you have the __builtin_available function. */
+#mesondefine HAVE_BUILTIN_AVAILABLE
+
+/* Define to 1 if you have the clock_gettime function and monotonic timer. */
+#mesondefine HAVE_CLOCK_GETTIME_MONOTONIC
+
+/* Define to 1 if you have the closesocket function. */
+#mesondefine HAVE_CLOSESOCKET
+
+/* Define to 1 if you have the CloseSocket camel case function. */
+#mesondefine HAVE_CLOSESOCKET_CAMEL
+
+/* Define to 1 if you have the <crypto.h> header file. */
+#mesondefine HAVE_CRYPTO_H
+
+/* "Set if getpwuid_r() declaration is missing" */
+#mesondefine HAVE_DECL_GETPWUID_R_MISSING
+
+/* Define to 1 if you have the `fchmod' function. */
+#mesondefine HAVE_FCHMOD
+
+/* Define to 1 if you have the fcntl function. */
+#mesondefine HAVE_FCNTL
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#mesondefine HAVE_FCNTL_H
+
+/* Define to 1 if you have a working fcntl O_NONBLOCK function. */
+#mesondefine HAVE_FCNTL_O_NONBLOCK
+
+/* Define to 1 if you have the `fnmatch' function. */
+#mesondefine HAVE_FNMATCH
+
+/* Define to 1 if you have the freeaddrinfo function. */
+#mesondefine HAVE_FREEADDRINFO
+
+/* Define to 1 if you have the fsetxattr function. */
+#mesondefine HAVE_FSETXATTR
+
+/* fsetxattr() takes 5 args */
+#mesondefine HAVE_FSETXATTR_5
+
+/* fsetxattr() takes 6 args */
+#mesondefine HAVE_FSETXATTR_6
+
+/* Define to 1 if you have the ftruncate function. */
+#mesondefine HAVE_FTRUNCATE
+
+/* Define to 1 if you have a working getaddrinfo function. */
+#mesondefine HAVE_GETADDRINFO
+
+/* Define to 1 if the getaddrinfo function is threadsafe. */
+#mesondefine HAVE_GETADDRINFO_THREADSAFE
+
+/* Define to 1 if you have the `geteuid' function. */
+#mesondefine HAVE_GETEUID
+
+/* Define to 1 if you have the gethostbyname_r function. */
+#mesondefine HAVE_GETHOSTBYNAME_R
+
+/* gethostbyname_r() takes 3 args */
+#mesondefine HAVE_GETHOSTBYNAME_R_3
+
+/* gethostbyname_r() takes 5 args */
+#mesondefine HAVE_GETHOSTBYNAME_R_5
+
+/* gethostbyname_r() takes 6 args */
+#mesondefine HAVE_GETHOSTBYNAME_R_6
+
+/* Define to 1 if you have the gethostname function. */
+#mesondefine HAVE_GETHOSTNAME
+
+/* Define to 1 if you have a working getifaddrs function. */
+#mesondefine HAVE_GETIFADDRS
+
+/* Define to 1 if you have the `getpass_r' function. */
+#mesondefine HAVE_GETPASS_R
+
+/* Define to 1 if you have the getpeername function. */
+#mesondefine HAVE_GETPEERNAME
+
+/* Define to 1 if you have the `getppid' function. */
+#mesondefine HAVE_GETPPID
+
+/* Define to 1 if you have the `getpwuid' function. */
+#mesondefine HAVE_GETPWUID
+
+/* Define to 1 if you have the `getpwuid_r' function. */
+#mesondefine HAVE_GETPWUID_R
+
+/* Define to 1 if you have the `getrlimit' function. */
+#mesondefine HAVE_GETRLIMIT
+
+/* Define to 1 if you have the getsockname function. */
+#mesondefine HAVE_GETSOCKNAME
+
+/* Define to 1 if you have the `gettimeofday' function. */
+#mesondefine HAVE_GETTIMEOFDAY
+
+/* Define to 1 if you have a working glibc-style strerror_r function. */
+#mesondefine HAVE_GLIBC_STRERROR_R
+
+/* Define to 1 if you have a working gmtime_r function. */
+#mesondefine HAVE_GMTIME_R
+
+/* if you have the function gnutls_srp_verifier */
+#mesondefine HAVE_GNUTLS_SRP
+
+/* if you have GSS-API libraries */
+#mesondefine HAVE_GSSAPI
+
+/* Define to 1 if you have the <gssapi/gssapi_generic.h> header file. */
+#mesondefine HAVE_GSSAPI_GSSAPI_GENERIC_H
+
+/* Define to 1 if you have the <gssapi/gssapi.h> header file. */
+#mesondefine HAVE_GSSAPI_GSSAPI_H
+
+/* if you have GNU GSS */
+#mesondefine HAVE_GSSGNU
+
+/* Define to 1 if you have the <idn2.h> header file. */
+#mesondefine HAVE_IDN2_H
+
+/* Define to 1 if you have the <ifaddrs.h> header file. */
+#mesondefine HAVE_IFADDRS_H
+
+/* Define to 1 if you have the `if_nametoindex' function. */
+#mesondefine HAVE_IF_NAMETOINDEX
+
+/* Define to 1 if you have a IPv6 capable working inet_ntop function. */
+#mesondefine HAVE_INET_NTOP
+
+/* Define to 1 if you have a IPv6 capable working inet_pton function. */
+#mesondefine HAVE_INET_PTON
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#mesondefine HAVE_INTTYPES_H
+
+/* Define to 1 if you have the ioctlsocket function. */
+#mesondefine HAVE_IOCTLSOCKET
+
+/* Define to 1 if you have the IoctlSocket camel case function. */
+#mesondefine HAVE_IOCTLSOCKET_CAMEL
+
+/* Define to 1 if you have a working IoctlSocket camel case FIONBIO function.
+   */
+#mesondefine HAVE_IOCTLSOCKET_CAMEL_FIONBIO
+
+/* Define to 1 if you have a working ioctlsocket FIONBIO function. */
+#mesondefine HAVE_IOCTLSOCKET_FIONBIO
+
+/* Define to 1 if you have a working ioctl FIONBIO function. */
+#mesondefine HAVE_IOCTL_FIONBIO
+
+/* Define to 1 if you have a working ioctl SIOCGIFADDR function. */
+#mesondefine HAVE_IOCTL_SIOCGIFADDR
+
+/* Define to 1 if you have the <io.h> header file. */
+#mesondefine HAVE_IO_H
+
+/* Define to 1 if you have the lber.h header file. */
+#mesondefine HAVE_LBER_H
+
+/* Use LDAPS implementation */
+#mesondefine HAVE_LDAP_SSL
+
+/* Define to 1 if you have the ldap_ssl.h header file. */
+#mesondefine HAVE_LDAP_SSL_H
+
+/* Define to 1 if you have the `ldap_url_parse' function. */
+#mesondefine HAVE_LDAP_URL_PARSE
+
+/* Define to 1 if you have the <libgen.h> header file. */
+#mesondefine HAVE_LIBGEN_H
+
+/* Define to 1 if you have the `idn2' library (-lidn2). */
+#mesondefine HAVE_LIBIDN2
+
+/* if zlib is available */
+#mesondefine HAVE_LIBZ
+
+/* Define to 1 if you have the <linux/tcp.h> header file. */
+#mesondefine HAVE_LINUX_TCP_H
+
+/* Define to 1 if you have the <locale.h> header file. */
+#mesondefine HAVE_LOCALE_H
+
+/* Define to 1 if the compiler supports the 'long long' data type. */
+#mesondefine HAVE_LONGLONG
+
+/* Define to 1 if you have the `mach_absolute_time' function. */
+#mesondefine HAVE_MACH_ABSOLUTE_TIME
+
+/* Define to 1 if you have the memrchr function or macro. */
+#mesondefine HAVE_MEMRCHR
+
+/* Define to 1 if you have the MSG_NOSIGNAL flag. */
+#mesondefine HAVE_MSG_NOSIGNAL
+
+/* Define to 1 if you have the <netdb.h> header file. */
+#mesondefine HAVE_NETDB_H
+
+/* Define to 1 if you have the <netinet/in6.h> header file. */
+#mesondefine HAVE_NETINET_IN6_H
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+#mesondefine HAVE_NETINET_IN_H
+
+/* Define to 1 if you have the <netinet/tcp.h> header file. */
+#mesondefine HAVE_NETINET_TCP_H
+
+/* Define to 1 if you have the <netinet/udp.h> header file. */
+#mesondefine HAVE_NETINET_UDP_H
+
+/* Define to 1 if you have the <net/if.h> header file. */
+#mesondefine HAVE_NET_IF_H
+
+/* if you have an old MIT Kerberos version, lacking GSS_C_NT_HOSTBASED_SERVICE
+   */
+#mesondefine HAVE_OLD_GSSMIT
+
+/* if you have the functions SSL_CTX_set_srp_username and
+   SSL_CTX_set_srp_password */
+#mesondefine HAVE_OPENSSL_SRP
+
+/* Define to 1 if you have the <pem.h> header file. */
+#mesondefine HAVE_PEM_H
+
+/* Define to 1 if you have the `pipe' function. */
+#mesondefine HAVE_PIPE
+
+/* if you have the PK11_CreateManagedGenericObject function */
+#mesondefine HAVE_PK11_CREATEMANAGEDGENERICOBJECT
+
+/* If you have a fine poll */
+#mesondefine HAVE_POLL_FINE
+
+/* Define to 1 if you have the <poll.h> header file. */
+#mesondefine HAVE_POLL_H
+
+/* Define to 1 if you have a working POSIX-style strerror_r function. */
+#mesondefine HAVE_POSIX_STRERROR_R
+
+/* Define to 1 if you have the <proto/bsdsocket.h> header file. */
+#mesondefine HAVE_PROTO_BSDSOCKET_H
+
+/* if you have <pthread.h> */
+#mesondefine HAVE_PTHREAD_H
+
+/* Define to 1 if you have the <pwd.h> header file. */
+#mesondefine HAVE_PWD_H
+
+/* Define to 1 if you have the `quiche_conn_set_qlog_fd' function. */
+#mesondefine HAVE_QUICHE_CONN_SET_QLOG_FD
+
+/* Define to 1 if you have the <quiche.h> header file. */
+#mesondefine HAVE_QUICHE_H
+
+/* Define to 1 if you have the `RAND_egd' function. */
+#mesondefine HAVE_RAND_EGD
+
+/* Define to 1 if you have the recv function. */
+#mesondefine HAVE_RECV
+
+/* Define to 1 if you have the <rsa.h> header file. */
+#mesondefine HAVE_RSA_H
+
+/* Define to 1 if you have the sa_family_t type. */
+#mesondefine HAVE_SA_FAMILY_T
+
+/* Define to 1 if you have the `sched_yield' function. */
+#mesondefine HAVE_SCHED_YIELD
+
+/* Define to 1 if you have the select function. */
+#mesondefine HAVE_SELECT
+
+/* Define to 1 if you have the send function. */
+#mesondefine HAVE_SEND
+
+/* Define to 1 if you have the `sendmsg' function. */
+#mesondefine HAVE_SENDMSG
+
+/* Define to 1 if you have the <setjmp.h> header file. */
+#mesondefine HAVE_SETJMP_H
+
+/* Define to 1 if you have the `setlocale' function. */
+#mesondefine HAVE_SETLOCALE
+
+/* Define to 1 if you have the `setmode' function. */
+#mesondefine HAVE_SETMODE
+
+/* Define to 1 if you have the `setrlimit' function. */
+#mesondefine HAVE_SETRLIMIT
+
+/* Define to 1 if you have a working setsockopt SO_NONBLOCK function. */
+#mesondefine HAVE_SETSOCKOPT_SO_NONBLOCK
+
+/* Define to 1 if you have the sigaction function. */
+#mesondefine HAVE_SIGACTION
+
+/* Define to 1 if you have the siginterrupt function. */
+#mesondefine HAVE_SIGINTERRUPT
+
+/* Define to 1 if you have the signal function. */
+#mesondefine HAVE_SIGNAL
+
+/* Define to 1 if you have the <signal.h> header file. */
+#mesondefine HAVE_SIGNAL_H
+
+/* Define to 1 if you have the sigsetjmp function or macro. */
+#mesondefine HAVE_SIGSETJMP
+
+/* Define to 1 if you have the `snprintf' function. */
+#mesondefine HAVE_SNPRINTF
+
+/* Define to 1 if struct sockaddr_in6 has the sin6_scope_id member */
+#mesondefine HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID
+
+/* Define to 1 if you have the socket function. */
+#mesondefine HAVE_SOCKET
+
+/* Define to 1 if you have the socketpair function. */
+#mesondefine HAVE_SOCKETPAIR
+
+/* Define to 1 if you have the `SSL_set0_wbio' function. */
+#mesondefine HAVE_SSL_SET0_WBIO
+
+/* Define to 1 if you have the <stdatomic.h> header file. */
+#mesondefine HAVE_STDATOMIC_H
+
+/* Define to 1 if you have the <stdbool.h> header file. */
+#mesondefine HAVE_STDBOOL_H
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#mesondefine HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#mesondefine HAVE_STDIO_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#mesondefine HAVE_STDLIB_H
+
+/* Define to 1 if you have the strcasecmp function. */
+#mesondefine HAVE_STRCASECMP
+
+/* Define to 1 if you have the strcmpi function. */
+#mesondefine HAVE_STRCMPI
+
+/* Define to 1 if you have the strdup function. */
+#mesondefine HAVE_STRDUP
+
+/* Define to 1 if you have the strerror_r function. */
+#mesondefine HAVE_STRERROR_R
+
+/* Define to 1 if you have the stricmp function. */
+#mesondefine HAVE_STRICMP
+
+/* Define to 1 if you have the <strings.h> header file. */
+#mesondefine HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#mesondefine HAVE_STRING_H
+
+/* Define to 1 if you have the <stropts.h> header file. */
+#mesondefine HAVE_STROPTS_H
+
+/* Define to 1 if you have the strtok_r function. */
+#mesondefine HAVE_STRTOK_R
+
+/* Define to 1 if you have the strtoll function. */
+#mesondefine HAVE_STRTOLL
+
+/* if struct sockaddr_storage is defined */
+#mesondefine HAVE_STRUCT_SOCKADDR_STORAGE
+
+/* Define to 1 if you have the timeval struct. */
+#mesondefine HAVE_STRUCT_TIMEVAL
+
+/* Define to 1 if suseconds_t is an available type. */
+#mesondefine HAVE_SUSECONDS_T
+
+/* Define to 1 if you have the <sys/filio.h> header file. */
+#mesondefine HAVE_SYS_FILIO_H
+
+/* Define to 1 if you have the <sys/ioctl.h> header file. */
+#mesondefine HAVE_SYS_IOCTL_H
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+#mesondefine HAVE_SYS_PARAM_H
+
+/* Define to 1 if you have the <sys/poll.h> header file. */
+#mesondefine HAVE_SYS_POLL_H
+
+/* Define to 1 if you have the <sys/resource.h> header file. */
+#mesondefine HAVE_SYS_RESOURCE_H
+
+/* Define to 1 if you have the <sys/select.h> header file. */
+#mesondefine HAVE_SYS_SELECT_H
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+#mesondefine HAVE_SYS_SOCKET_H
+
+/* Define to 1 if you have the <sys/sockio.h> header file. */
+#mesondefine HAVE_SYS_SOCKIO_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#mesondefine HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#mesondefine HAVE_SYS_TIME_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#mesondefine HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <sys/uio.h> header file. */
+#mesondefine HAVE_SYS_UIO_H
+
+/* Define to 1 if you have the <sys/un.h> header file. */
+#mesondefine HAVE_SYS_UN_H
+
+/* Define to 1 if you have the <sys/utime.h> header file. */
+#mesondefine HAVE_SYS_UTIME_H
+
+/* Define to 1 if you have the <sys/wait.h> header file. */
+#mesondefine HAVE_SYS_WAIT_H
+
+/* Define to 1 if you have the <termios.h> header file. */
+#mesondefine HAVE_TERMIOS_H
+
+/* Define to 1 if you have the <termio.h> header file. */
+#mesondefine HAVE_TERMIO_H
+
+/* Define this if time_t is unsigned */
+#mesondefine HAVE_TIME_T_UNSIGNED
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#mesondefine HAVE_UNISTD_H
+
+/* Define to 1 if you have the `utime' function. */
+#mesondefine HAVE_UTIME
+
+/* Define to 1 if you have the `utimes' function. */
+#mesondefine HAVE_UTIMES
+
+/* Define to 1 if you have the <utime.h> header file. */
+#mesondefine HAVE_UTIME_H
+
+/* Define to 1 if compiler supports C99 variadic macro style. */
+#mesondefine HAVE_VARIADIC_MACROS_C99
+
+/* Define to 1 if compiler supports old gcc variadic macro style. */
+#mesondefine HAVE_VARIADIC_MACROS_GCC
+
+/* Define to 1 if you have the windows.h header file. */
+#mesondefine HAVE_WINDOWS_H
+
+/* Define to 1 if you have the winsock2.h header file. */
+#mesondefine HAVE_WINSOCK2_H
+
+/* if you have wolfSSL_DES_ecb_encrypt */
+#mesondefine HAVE_WOLFSSL_DES_ECB_ENCRYPT
+
+/* if you have wolfSSL_BIO_set_shutdown */
+#mesondefine HAVE_WOLFSSL_FULL_BIO
+
+/* Define to 1 if you have the `wolfSSL_get_peer_certificate' function. */
+#mesondefine HAVE_WOLFSSL_GET_PEER_CERTIFICATE
+
+/* Define to 1 if you have the `wolfSSL_UseALPN' function. */
+#mesondefine HAVE_WOLFSSL_USEALPN
+
+/* Define this symbol if your OS supports changing the contents of argv */
+#mesondefine HAVE_WRITABLE_ARGV
+
+/* Define to 1 if you have the ws2tcpip.h header file. */
+#mesondefine HAVE_WS2TCPIP_H
+
+/* if libzstd is in use */
+#mesondefine HAVE_ZSTD
+
+/* Define to 1 if _REENTRANT preprocessor symbol must be defined. */
+#mesondefine NEED_REENTRANT
+
+/* Define to 1 if _THREAD_SAFE preprocessor symbol must be defined. */
+#mesondefine NEED_THREAD_SAFE
+
+/* Define to enable NTLM delegation to winbind's ntlm_auth helper. */
+#mesondefine NTLM_WB_ENABLED
+
+/* Define absolute filename for winbind's ntlm_auth helper. */
+#mesondefine NTLM_WB_FILE
+
+/* cpu-machine-OS */
+#mesondefine OS
+
+/* a suitable file to read random data from */
+#mesondefine RANDOM_FILE
+
+/* Size of curl_off_t in number of bytes */
+#mesondefine SIZEOF_CURL_OFF_T
+
+/* Size of int in number of bytes */
+#mesondefine SIZEOF_INT
+
+/* Size of long in number of bytes */
+#mesondefine SIZEOF_LONG
+
+/* Size of off_t in number of bytes */
+#mesondefine SIZEOF_OFF_T
+
+/* Size of size_t in number of bytes */
+#mesondefine SIZEOF_SIZE_T
+
+/* Size of time_t in number of bytes */
+#mesondefine SIZEOF_TIME_T
+
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+#mesondefine STDC_HEADERS
+
+/* if AmiSSL is in use */
+#mesondefine USE_AMISSL
+
+/* Define to enable c-ares support */
+#mesondefine USE_ARES
+
+/* if BearSSL is enabled */
+#mesondefine USE_BEARSSL
+
+/* if ECH support is available */
+#mesondefine USE_ECH
+
+/* if GnuTLS is enabled */
+#mesondefine USE_GNUTLS
+
+/* GSASL support enabled */
+#mesondefine USE_GSASL
+
+/* if hyper is in use */
+#mesondefine USE_HYPER
+
+/* PSL support enabled */
+#mesondefine USE_LIBPSL
+
+/* if librtmp is in use */
+#mesondefine USE_LIBRTMP
+
+/* if libSSH is in use */
+#mesondefine USE_LIBSSH
+
+/* if libSSH2 is in use */
+#mesondefine USE_LIBSSH2
+
+/* If you want to build curl with the built-in manual */
+#mesondefine USE_MANUAL
+
+/* if mbedTLS is enabled */
+#mesondefine USE_MBEDTLS
+
+/* if msh3 is in use */
+#mesondefine USE_MSH3
+
+/* if nghttp2 is in use */
+#mesondefine USE_NGHTTP2
+
+/* if nghttp3 is in use */
+#mesondefine USE_NGHTTP3
+
+/* if ngtcp2 is in use */
+#mesondefine USE_NGTCP2
+
+/* if ngtcp2_crypto_gnutls is in use */
+#mesondefine USE_NGTCP2_CRYPTO_GNUTLS
+
+/* if ngtcp2_crypto_openssl is in use */
+#mesondefine USE_NGTCP2_CRYPTO_OPENSSL
+
+/* if NSS is enabled */
+#mesondefine USE_NSS
+
+/* Use OpenLDAP-specific code */
+#mesondefine USE_OPENLDAP
+
+/* if OpenSSL is in use */
+#mesondefine USE_OPENSSL
+
+/* if quiche is in use */
+#mesondefine USE_QUICHE
+
+/* if rustls is enabled */
+#mesondefine USE_RUSTLS
+
+/* to enable Windows native SSL/TLS support */
+#mesondefine USE_SCHANNEL
+
+/* enable Secure Transport */
+#mesondefine USE_SECTRANSP
+
+/* if you want POSIX threaded DNS lookup */
+#mesondefine USE_THREADS_POSIX
+
+/* if you want Win32 threaded DNS lookup */
+#mesondefine USE_THREADS_WIN32
+
+/* Use TLS-SRP authentication */
+#mesondefine USE_TLS_SRP
+
+/* Use Unix domain sockets */
+#mesondefine USE_UNIX_SOCKETS
+
+/* enable websockets support */
+#mesondefine USE_WEBSOCKETS
+
+/* Define to 1 if you are building a Windows target with crypto API support.
+   */
+#mesondefine USE_WIN32_CRYPTO
+
+/* Define to 1 if you have the `normaliz' (WinIDN) library (-lnormaliz). */
+#mesondefine USE_WIN32_IDN
+
+/* Define to 1 if you are building a Windows target with large file support.
+   */
+#mesondefine USE_WIN32_LARGE_FILES
+
+/* Use Windows LDAP implementation */
+#mesondefine USE_WIN32_LDAP
+
+/* Define to 1 if you are building a Windows target without large file
+   support. */
+#mesondefine USE_WIN32_SMALL_FILES
+
+/* to enable SSPI support */
+#mesondefine USE_WINDOWS_SSPI
+
+/* if wolfSSH is in use */
+#mesondefine USE_WOLFSSH
+
+/* if wolfSSL is enabled */
+#mesondefine USE_WOLFSSL
+
+/* Define to 1 if OS is AIX. */
+#ifndef _ALL_SOURCE
+#mesondefine _ALL_SOURCE
+#endif
+
+/* Define for large files, on AIX-style hosts. */
+#mesondefine _LARGE_FILES
+
+/* Define to empty if `const' does not conform to ANSI C. */
+#mesondefine const
+
+/* Type to use in place of in_addr_t when system does not provide it. */
+#mesondefine in_addr_t
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+#mesondefine inline
+#endif
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+#mesondefine size_t
+
+/* the signed version of size_t */
+#mesondefine ssize_t
+
+/* vim: set ft=c: */

--- a/subprojects/packagefiles/curl/meson/extract.mk
+++ b/subprojects/packagefiles/curl/meson/extract.mk
@@ -1,0 +1,27 @@
+.PHONY: tests/libtest tests/server tests/unit
+
+define extract_noinst_progs
+$$(foreach prog,$$(noinst_PROGRAMS),
+   $$(info $$(prog)
+      $$(filter-out %.h,
+         $$(call nodist_$$(prog)_SOURCES)
+         $$(call $$(prog)_SOURCES)
+      )
+      $$(call $$(prog)_CPPFLAGS) $$(call $$(prog)_LDADD)
+))
+endef
+extract_noinst_progs := $(strip $(extract_noinst_progs))
+
+define extract_rule
+$(eval include $1/Makefile.inc)
+@$(eval $2)$(eval $3)
+endef
+
+tests/libtest:
+	$(call extract_rule,$@,TESTUTIL_LIBS = @TESTUTIL_LIBS@,$(extract_noinst_progs))
+
+tests/server:
+	$(call extract_rule,$@,,$(extract_noinst_progs))
+
+tests/unit:
+	$(call extract_rule,$@,,$$(foreach prog,$$(UNITPROGS),$$(info $$(prog) $$(prog).c $$(filter-out %.h,$$(UNITFILES)))))

--- a/subprojects/packagefiles/curl/meson/rewrite.mk
+++ b/subprojects/packagefiles/curl/meson/rewrite.mk
@@ -1,0 +1,15 @@
+.PHONY: curl_exe_src curl_lib_src
+
+define rewrite_rule
+$(eval include $2)
+$(eval old := $(shell meson rewrite target $1 info 2>&1 | jq -r '.target[].sources | join(" ")'))
+$(eval new := $3)
+meson rewrite target $1 add $(filter-out $(old),$(new))
+meson rewrite target $1 rm $(filter-out $(new),$(old))
+endef
+
+curl_exe_src:
+	$(call rewrite_rule,curl_exe,src/Makefile.inc,$$(filter-out tool_hugehelp.c %.h,$$(CURL_FILES)))
+
+curl_lib_src:
+	$(call rewrite_rule,curl_lib,lib/Makefile.inc,$$(filter-out %.h,$$(CSOURCES)))

--- a/subprojects/packagefiles/curl/meson_options.txt
+++ b/subprojects/packagefiles/curl/meson_options.txt
@@ -1,0 +1,114 @@
+# Build targets.
+option('tool'     , type: 'feature')
+option('tests'    , type: 'feature')
+option('unittests', type: 'feature')
+
+# Debugging.
+option('curldebug', type: 'boolean', value: false)
+
+# CA.
+option('ca_bundle'  , type: 'string' , value: 'auto')
+option('ca_path'    , type: 'string' , value: 'auto')
+option('ca_fallback', type: 'boolean', value: false)
+
+# NOTE: disabling some of those opt-out options can
+# break build and/or test suite, you've been warned!
+
+# Features. {{{
+
+option('brotli'         , type: 'feature')
+option('cookies'        , type: 'feature', value: 'enabled')
+option('crypto-auth'    , type: 'feature', value: 'enabled')
+option('doh'            , type: 'feature', value: 'enabled')
+option('getoptions'     , type: 'feature', value: 'enabled')
+option('gsasl'          , type: 'feature')
+option('http2'          , type: 'feature')
+option('ipv6'           , type: 'feature')
+option('libcurl-option' , type: 'feature', value: 'enabled')
+option('libz'           , type: 'feature')
+option('mime'           , type: 'feature', value: 'enabled')
+option('netrc'          , type: 'feature', value: 'enabled')
+option('parsedate'      , type: 'feature', value: 'enabled')
+option('progress-meter' , type: 'feature', value: 'enabled')
+option('proxy'          , type: 'feature', value: 'enabled')
+option('psl'            , type: 'feature')
+option('shuffle-dns'    , type: 'feature', value: 'enabled')
+option('socketpair'     , type: 'feature', value: 'enabled')
+option('sspi'           , type: 'feature')
+option('unixsockets'    , type: 'feature')
+option('verbose-strings', type: 'feature', value: 'enabled')
+option('zstd'           , type: 'feature')
+
+# Asynchronous DNS.
+option('asynchdns', type: 'feature')
+# Resolver, by order of preference (first available one is enabled).
+option('asynchdns-resolver', type: 'array', value: ['pthread', 'win32'], choices: ['pthread', 'win32', 'ares'])
+
+# GSS API.
+option('gss-api', type: 'feature')
+# Provider, by order of preference (first available one is enabled).
+option('gss-api-provider', type: 'array', choices: ['gnu', 'mit', 'heimdal'])
+
+# IDN.
+option('idn', type: 'feature')
+# Provider, by order of preference (first available one is enabled).
+option('idn-provider', type: 'array', choices: ['winidn', 'libidn2'])
+
+# HTTP.
+option('alt-svc'    , type: 'feature')
+option('headers-api', type: 'feature', value: 'enabled')
+option('hsts'       , type: 'feature')
+option('http-auth'  , type: 'feature', value: 'enabled')
+
+# LDAP.
+option('ldap-provider', type: 'array', choices: ['win32', 'openldap'])
+
+# NTLM.
+option('ntlm'        , type: 'feature')
+option('ntlm-wb'     , type: 'feature')
+option('ntlm-wb-file', type: 'string', value: 'ntlm_auth')
+
+# SSH support.
+option('ssh', type: 'feature')
+# Provider, by order of preference (first available one is enabled).
+option('ssh-provider', type: 'array', choices: ['libssh2', 'libssh'])
+
+# SSL support.
+option('ssl'                , type: 'feature')
+option('tls-srp'            , type: 'feature')
+option('ssl-default-backend', type: 'combo'  , choices: ['implicit', 'openssl', 'schannel', 'secure-transport'])
+# Backends.
+option('openssl'            , type: 'feature')
+# Windows only.
+option('schannel'           , type: 'feature')
+# macOS only.
+option('secure-transport'   , type: 'feature')
+
+# }}}
+
+# Protocols. {{{
+
+option('dict'  , type: 'feature')
+option('file'  , type: 'feature', value: 'enabled')
+option('ftp'   , type: 'feature')
+option('gopher', type: 'feature')
+option('http'  , type: 'feature', value: 'enabled')
+option('imap'  , type: 'feature')
+option('ldap'  , type: 'feature')
+option('ldaps' , type: 'feature')
+option('mqtt'  , type: 'feature')
+option('pop3'  , type: 'feature')
+option('rtmp'  , type: 'feature')
+option('rtsp'  , type: 'feature')
+option('smb'   , type: 'feature')
+option('smtp'  , type: 'feature')
+option('telnet', type: 'feature')
+option('tftp'  , type: 'feature')
+
+# }}}
+
+# Internal, disregard.
+option('_disabled', type: 'feature', value: 'disabled')
+option('_enabled' , type: 'feature', value: 'enabled')
+
+# vim: foldmethod=marker foldlevel=0

--- a/subprojects/packagefiles/curl/src/meson.build
+++ b/subprojects/packagefiles/curl/src/meson.build
@@ -1,0 +1,67 @@
+# To update this list: `make -f meson/rewrite.mk curl_exe_src`.
+curl_src = files(
+  '../lib/curl_multibyte.c',
+  '../lib/dynbuf.c',
+  '../lib/nonblock.c',
+  '../lib/strtoofft.c',
+  '../lib/timediff.c',
+  '../lib/version_win32.c',
+  '../lib/warnless.c',
+  'slist_wc.c',
+  'tool_binmode.c',
+  'tool_bname.c',
+  'tool_cb_dbg.c',
+  'tool_cb_hdr.c',
+  'tool_cb_prg.c',
+  'tool_cb_rea.c',
+  'tool_cb_see.c',
+  'tool_cb_wrt.c',
+  'tool_cfgable.c',
+  'tool_dirhie.c',
+  'tool_doswin.c',
+  'tool_easysrc.c',
+  'tool_filetime.c',
+  'tool_findfile.c',
+  'tool_formparse.c',
+  'tool_getparam.c',
+  'tool_getpass.c',
+  'tool_help.c',
+  'tool_helpers.c',
+  'tool_libinfo.c',
+  'tool_listhelp.c',
+  'tool_main.c',
+  'tool_msgs.c',
+  'tool_operate.c',
+  'tool_operhlp.c',
+  'tool_paramhlp.c',
+  'tool_parsecfg.c',
+  'tool_progress.c',
+  'tool_setopt.c',
+  'tool_sleep.c',
+  'tool_stderr.c',
+  'tool_strdup.c',
+  'tool_urlglob.c',
+  'tool_util.c',
+  'tool_vms.c',
+  'tool_writeout.c',
+  'tool_writeout_json.c',
+  'tool_xattr.c',
+)
+
+curl_exe = executable(
+  'curl',
+  curl_src,
+  dependencies: curl_ilib_dep,
+  install: get_option('tool').allowed(),
+)
+
+curltool_lib = static_library(
+  'curltool',
+  curl_src,
+  c_args: ['-DCURL_STATICLIB', '-DUNITTESTS'],
+  dependencies: [build_tests, curl_iflags_dep],
+)
+
+curltool_dep = declare_dependency(
+  link_with: curltool_lib,
+)

--- a/subprojects/packagefiles/curl/tests/libtest/.libs/meson.build
+++ b/subprojects/packagefiles/curl/tests/libtest/.libs/meson.build
@@ -1,0 +1,14 @@
+# `runtests.pl` expects `libhostname.so` and `libstubgss.so`
+# to be present in a `.libs` subdirectory of `tests/libtest`.
+
+libtest_targets += shared_library(
+  'hostname',
+  '../sethostname.c',
+  c_args: curl_symbols_hiding_flags,
+  dependencies: curl_iflags_dep,
+  gnu_symbol_visibility: curl_symbols_hiding_visibility,
+)
+
+if gss_api_opt.allowed()
+  libtest_targets += shared_library('stubgss', '../stub_gssapi.c')
+endif

--- a/subprojects/packagefiles/curl/tests/libtest/meson.build
+++ b/subprojects/packagefiles/curl/tests/libtest/meson.build
@@ -1,0 +1,57 @@
+subdir('.libs')
+
+_generated_srcs = {
+  'lib1521.c': custom_target(
+    'lib1521.c',
+    capture: true,
+    command: [
+      bash_exe,
+      '-c', 'exec perl "$@"',
+      '--', meson.current_source_dir() / 'mk-lib1521.pl',
+    ],
+    depend_files: 'mk-lib1521.pl',
+    feed: true,
+    input: meson.project_source_root() / 'include/curl/curl.h',
+    output: 'lib1521.c',
+  ),
+}
+
+_vars = {
+  'CURL_NETWORK_LIBS': ['deps', []],
+  'TESTUTIL_LIBS': ['deps', []],
+}
+
+foreach _spec : makefile_extractions['libtest']
+  _name = ''
+  _args = []
+  _deps = []
+  _incs = []
+  _srcs = []
+  foreach _part : _spec.strip().split()
+    if _name == ''
+      _name = _part
+      continue
+    endif
+    if _part.startswith('@') and _part.endswith('@')
+      _value = _vars.get(_part.substring(1, -1))
+      if _value[0] == 'deps'
+        _deps += _value[1]
+      endif
+    elif _part.startswith('-D')
+      _args += _part
+    elif _part.startswith('-I')
+      _incs += include_directories(_part.substring(2))
+    elif _part.endswith('.c')
+      _srcs += (
+        _part in _generated_srcs ? _generated_srcs.get(_part) : files(_part)
+      )
+    endif
+  endforeach
+  libtest_targets += executable(
+    _name,
+    c_args: _args,
+    dependencies: [_deps, curl_ilib_dep, threads_dep],
+    include_directories: _incs,
+    sources: _srcs,
+  )
+endforeach

--- a/subprojects/packagefiles/curl/tests/log/meson.build
+++ b/subprojects/packagefiles/curl/tests/log/meson.build
@@ -1,0 +1,1 @@
+# test1169 need this source directory to exists…

--- a/subprojects/packagefiles/curl/tests/meson.build
+++ b/subprojects/packagefiles/curl/tests/meson.build
@@ -1,0 +1,116 @@
+libtest_targets = []
+server_targets = []
+unit_targets = []
+
+subdir('log')
+
+# Extract test targets info.
+makefile_extractions = (
+  {
+    'libtest': '',
+    'server': '',
+  } + (
+    build_unittests.found() ? {
+      'unit': '',
+    } : {}
+  )
+)
+foreach _subdir : makefile_extractions.keys()
+  makefile_extractions += {
+    _subdir: run_command(
+      [
+        make_exe,
+        '--silent',
+        '-C', meson.project_source_root(),
+        '-f', files('../meson/extract.mk'),
+        'tests' / _subdir,
+      ],
+      check: true,
+      env: 'MAKEFLAGS=',
+    ).stdout().strip().split('\n'),
+  }
+  subdir(_subdir)
+endforeach
+
+_builddir = meson.current_build_dir()
+_srcdir = meson.current_source_dir()
+
+_env = environment()
+_env.set('srcdir', fs.as_posix(_srcdir))
+if host_machine.system() == 'windows'
+  foreach _component : [
+    'TOOL',
+    'SRV',
+  ]
+    _env.set('CURL_TEST_EXE_EXT_' + _component, '.exe')
+  endforeach
+  _libcurl_dir = meson.project_build_root() / 'lib'
+  _env.prepend('PATH', _libcurl_dir.replace('/', '\\'))
+endif
+
+_disabled_tests = []
+# Do not run flaky tests.
+_disabled_tests += '!flaky'
+if not fs.exists('../docs/curl.1')
+  # Not available in git checkout (and we don't build it).
+  _disabled_tests += '!1139'
+endif
+if host_machine.system() == 'darwin'
+  # Some preprocessor issue prevent those 2
+  # source analysis tests from succeeding.
+  _disabled_tests += ['!1119', '!1167']
+endif
+if not get_option('curldebug')
+  _disabled_tests += [
+    '!356',
+    '!358',
+    '!359',
+    '!412',
+    '!413',
+    '!446',
+    '!823',
+    '!869',
+    '!907',
+    '!1908',
+    '!1972',
+    '!2100',
+  ]
+endif
+if ipv6_opt.disabled()
+  _disabled_tests += '!1614'
+endif
+
+_kwargs = {}
+if meson.version().version_compare('>=0.62.0')
+  _kwargs += {'verbose': true}
+endif
+
+test(
+  'runtests',
+  bash_exe,
+  args: [
+    '-c',
+    'exec perl "$@"',
+    '--',
+    '-I' + fs.as_posix(_srcdir),
+    fs.as_posix(_srcdir / 'runtests.pl'),
+    # Continue even if a test fails.
+    '-a',
+    # Use this curl executable.
+    '-c',
+    fs.as_posix(curl_exe.full_path()),
+    # No valgrind.
+    '-n',
+    # Print log file contents on failure.
+    '-p',
+    # Verbose.
+    # '-v',
+    _disabled_tests,
+  ],
+  depends: [curl_exe, libtest_targets, server_targets, unit_targets],
+  env: _env,
+  is_parallel: false,
+  kwargs: _kwargs,
+  timeout: 0,
+  workdir: _builddir,
+)

--- a/subprojects/packagefiles/curl/tests/server/meson.build
+++ b/subprojects/packagefiles/curl/tests/server/meson.build
@@ -1,0 +1,42 @@
+_vars = {
+  'CURL_NETWORK_AND_TIME_LIBS': ['deps', sys_deps],
+}
+
+foreach _spec : makefile_extractions['server']
+  _name = ''
+  _args = []
+  _deps = []
+  _incs = []
+  _srcs = []
+  foreach _part : _spec.strip().split()
+    if _name == ''
+      _name = _part
+      continue
+    endif
+    if _part.startswith('@') and _part.endswith('@')
+      _value = _vars.get(_part.substring(1, -1))
+      if _value[0] == 'deps'
+        _deps += _value[1]
+      endif
+    elif _part.startswith('-D')
+      _args += _part
+    elif _part.startswith('-I')
+      _incs += include_directories(_part.substring(2))
+    elif _part.endswith('.c')
+      _srcs += _part
+    endif
+  endforeach
+  server_targets += executable(
+    _name,
+    _srcs,
+    c_args: [
+      '-DCURL_STATICLIB',
+      _args,
+    ],
+    dependencies: [
+      _deps,
+      curl_iflags_dep,
+    ],
+    include_directories: [include_directories('../../src'), _incs],
+  )
+endforeach

--- a/subprojects/packagefiles/curl/tests/unit/meson.build
+++ b/subprojects/packagefiles/curl/tests/unit/meson.build
@@ -1,0 +1,21 @@
+_deps = {
+  'unit1394': [curl_ilib_dep, curltool_dep],
+  'unit1621': [curl_ilib_dep, curltool_dep],
+}
+
+foreach _spec : makefile_extractions['unit']
+  _spec = _spec.split()
+  _name = _spec[0]
+  unit_targets += executable(
+    _spec,
+    c_args: curlu_flags,
+    dependencies: [
+      curl_iflags_dep,
+      _deps.get(_name, [curltool_dep, curlu_dep]),
+    ],
+    include_directories: include_directories(
+      '../../src',
+      '../libtest',
+    ),
+  )
+endforeach

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -32,6 +32,10 @@ PER_PROJECT_PERMITTED_FILES = {
     'box2d': [
         'doctest.h'
     ],
+    'curl': [
+        'extract.mk',
+        'rewrite.mk',
+    ],
     'glbinding': [
         'pch.h',
         'glbinding_api.h',


### PR DESCRIPTION
Note:
- not the latest version (8.0.1 is from 2023, latest is 8.2.1 released July 2023), because that's what I started with.
- advanced / experimental options are not supported: Unicode (Windows), HTTP/3, Hyper HTTP backend, WebSocket…
- not all SSL backends are supported: only OpenSSL, Secure Channel (Windows), and Secure Transport (Windows)
- not all LDAP providers are supported: only OpenLDAP `>= 2.4.48` (2019) and Windows.

Close #561.