### PR TITLE
Add libsass 3.6.4

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1437,6 +1437,14 @@
       "1.6.17-2"
     ]
   },
+  "libsass": {
+    "dependency_names": [
+      "libsass"
+    ],
+    "versions": [
+      "3.6.4-1"
+    ]
+  },
   "libsndfile": {
     "dependency_names": [
       "sndfile"

--- a/subprojects/libsass.wrap
+++ b/subprojects/libsass.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = libsass-3.6.4
+source_url = https://github.com/sass/libsass/archive/refs/tags/3.6.4.tar.gz
+source_filename = libsass-3.6.4.tar.gz
+source_hash = f9484d9a6df60576e791566eab2f757a97fd414fce01dd41fc0a693ea5db2889
+patch_directory = libsass
+
+[provide]
+libsass = libsass_dep

--- a/subprojects/packagefiles/libsass/include/meson.build
+++ b/subprojects/packagefiles/libsass/include/meson.build
@@ -1,0 +1,14 @@
+install_headers('sass.h', 'sass2scss.h')
+
+version_conf_data = configuration_data()
+version_conf_data.set('PACKAGE_VERSION', meson.project_version())
+
+version_h = configure_file(
+  input: 'sass/version.h.in',
+  output: 'version.h',
+  configuration: version_conf_data)
+
+install_headers(
+  'sass/base.h', 'sass/context.h', 'sass/functions.h', 'sass/values.h',
+  version_h,
+  subdir: 'sass')

--- a/subprojects/packagefiles/libsass/meson.build
+++ b/subprojects/packagefiles/libsass/meson.build
@@ -12,11 +12,9 @@ add_project_arguments(
   language: ['cpp'])
 
 cpp = meson.get_compiler('cpp')
-if cpp.get_id() != 'msvc'
-  add_project_arguments(
-    cpp.get_supported_arguments(['-Wno-non-virtual-dtor']),
-    language: ['cpp'])
-endif
+add_project_arguments(
+  cpp.get_supported_arguments('-Wno-non-virtual-dtor'),
+  language: ['cpp'])
 
 inc = include_directories('include')
 winres_path = files(join_paths('res', 'resource.rc'))

--- a/subprojects/packagefiles/libsass/meson.build
+++ b/subprojects/packagefiles/libsass/meson.build
@@ -11,11 +11,6 @@ add_project_arguments(
   '-DLIBSASS_VERSION="@0@"'.format(meson.project_version()),
   language: ['cpp'])
 
-cpp = meson.get_compiler('cpp')
-add_project_arguments(
-  cpp.get_supported_arguments('-Wno-non-virtual-dtor'),
-  language: ['cpp'])
-
 inc = include_directories('include')
 winres_path = files(join_paths('res', 'resource.rc'))
 

--- a/subprojects/packagefiles/libsass/meson.build
+++ b/subprojects/packagefiles/libsass/meson.build
@@ -1,0 +1,25 @@
+project('libsass', 'c', 'cpp',
+        version: '3.6.4',
+        meson_version : '>= 0.48.0',
+        default_options: [
+            'c_std=c99',
+            'cpp_std=c++11',
+            'buildtype=debugoptimized',
+        ])
+
+add_project_arguments(
+  '-DLIBSASS_VERSION="@0@"'.format(meson.project_version()),
+  language: ['cpp'])
+
+cpp = meson.get_compiler('cpp')
+if cpp.get_id() != 'msvc'
+  add_project_arguments(
+    cpp.get_supported_arguments(['-Wno-non-virtual-dtor']),
+    language: ['cpp'])
+endif
+
+inc = include_directories('include')
+winres_path = files(join_paths('res', 'resource.rc'))
+
+subdir('include')
+subdir('src')

--- a/subprojects/packagefiles/libsass/src/meson.build
+++ b/subprojects/packagefiles/libsass/src/meson.build
@@ -1,0 +1,107 @@
+cpp_sources = [
+  'ast.cpp',
+  'ast_values.cpp',
+  'ast_supports.cpp',
+  'ast_sel_cmp.cpp',
+  'ast_sel_unify.cpp',
+  'ast_sel_super.cpp',
+  'ast_sel_weave.cpp',
+  'ast_selectors.cpp',
+  'context.cpp',
+  'constants.cpp',
+  'fn_utils.cpp',
+  'fn_miscs.cpp',
+  'fn_maps.cpp',
+  'fn_lists.cpp',
+  'fn_colors.cpp',
+  'fn_numbers.cpp',
+  'fn_strings.cpp',
+  'fn_selectors.cpp',
+  'color_maps.cpp',
+  'environment.cpp',
+  'ast_fwd_decl.cpp',
+  'bind.cpp',
+  'file.cpp',
+  'util.cpp',
+  'util_string.cpp',
+  'json.cpp',
+  'units.cpp',
+  'values.cpp',
+  'plugins.cpp',
+  'source.cpp',
+  'position.cpp',
+  'lexer.cpp',
+  'parser.cpp',
+  'parser_selectors.cpp',
+  'prelexer.cpp',
+  'eval.cpp',
+  'eval_selectors.cpp',
+  'expand.cpp',
+  'listize.cpp',
+  'cssize.cpp',
+  'extender.cpp',
+  'extension.cpp',
+  'stylesheet.cpp',
+  'output.cpp',
+  'inspect.cpp',
+  'emitter.cpp',
+  'check_nesting.cpp',
+  'remove_placeholders.cpp',
+  'sass.cpp',
+  'sass_values.cpp',
+  'sass_context.cpp',
+  'sass_functions.cpp',
+  'sass2scss.cpp',
+  'backtrace.cpp',
+  'operators.cpp',
+  'ast2c.cpp',
+  'c2ast.cpp',
+  'to_value.cpp',
+  'source_map.cpp',
+  'error_handling.cpp',
+  'memory/allocator.cpp',
+  'memory/shared_ptr.cpp',
+  'utf8_string.cpp',
+  'base64vlq.cpp',
+]
+
+c_sources = [
+  'cencode.c',
+]
+
+sass_sources = cpp_sources + c_sources
+
+if host_machine.system() == 'windows'
+  windows = import('windows')
+  sass_sources += [windows.compile_resources(winres_path)]
+endif
+
+dl_dep = cpp.find_library('dl', required : false)
+
+libsass = shared_library(
+  'sass',
+   sass_sources,
+   dependencies: [dl_dep],
+   c_args: ['-DADD_EXPORTS'],
+   cpp_args: ['-DADD_EXPORTS'],
+   include_directories: inc,
+   install: true)
+
+libsass_dep = declare_dependency(
+  link_with: libsass,
+  include_directories: [inc])
+
+conf_data = configuration_data()
+conf_data.set('prefix', get_option('prefix'))
+conf_data.set('exec_prefix', '${prefix}')
+conf_data.set('libdir', join_paths('${exec_prefix}', get_option('libdir')))
+conf_data.set('includedir', join_paths('${prefix}', get_option('includedir')))
+conf_data.set('VERSION', meson.project_version())
+
+pkg_install_dir = join_paths(get_option('libdir'), 'pkgconfig')
+
+configure_file(
+  input: 'support/libsass.pc.in',
+  output: 'libsass.pc',
+  configuration: conf_data,
+  install_dir: pkg_install_dir)

--- a/subprojects/packagefiles/libsass/src/meson.build
+++ b/subprojects/packagefiles/libsass/src/meson.build
@@ -82,12 +82,17 @@ else
   dl_dep = cc.find_library('dl', required : false)
 endif
 
-libsass = shared_library(
+lib_args = []
+if get_option('default_library') != 'static'
+  lib_args += ['-DADD_EXPORTS']
+endif
+
+libsass = library(
   'sass',
    sass_sources,
    dependencies: [dl_dep],
-   c_args: ['-DADD_EXPORTS'],
-   cpp_args: ['-DADD_EXPORTS'],
+   c_args: lib_args,
+   cpp_args: lib_args,
    include_directories: inc,
    install: true)
 

--- a/subprojects/packagefiles/libsass/src/meson.build
+++ b/subprojects/packagefiles/libsass/src/meson.build
@@ -98,6 +98,7 @@ libsass = library(
    c_args: lib_args,
    cpp_args: lib_args,
    include_directories: inc,
+   soversion: '1',
    install: true)
 
 libsass_dep = declare_dependency(

--- a/subprojects/packagefiles/libsass/src/meson.build
+++ b/subprojects/packagefiles/libsass/src/meson.build
@@ -87,7 +87,7 @@ else
 endif
 
 lib_args = []
-if get_option('default_library') != 'static'
+if host_machine.system() == 'windows' and get_option('default_library') != 'static'
   lib_args += ['-DADD_EXPORTS']
 endif
 

--- a/subprojects/packagefiles/libsass/src/meson.build
+++ b/subprojects/packagefiles/libsass/src/meson.build
@@ -83,7 +83,7 @@ if host_machine.system() != 'windows'
     dl_dep = cc.find_library('dl', required : false)
   endif
 else
-  dl_dep = declare_dependency()
+  dl_dep = dependency('', required: false)
 endif
 
 lib_args = []

--- a/subprojects/packagefiles/libsass/src/meson.build
+++ b/subprojects/packagefiles/libsass/src/meson.build
@@ -76,10 +76,14 @@ if host_machine.system() == 'windows'
   sass_sources += [windows.compile_resources(winres_path)]
 endif
 
-if meson.version().version_compare('>= 0.62')
-  dl_dep = dependency('dl', required : false)
+if host_machine.system() != 'windows'
+  if meson.version().version_compare('>= 0.62')
+    dl_dep = dependency('dl')
+  else
+    dl_dep = cc.find_library('dl', required : false)
+  endif
 else
-  dl_dep = cc.find_library('dl', required : false)
+  dl_dep = declare_dependency()
 endif
 
 lib_args = []

--- a/subprojects/packagefiles/libsass/src/meson.build
+++ b/subprojects/packagefiles/libsass/src/meson.build
@@ -104,17 +104,10 @@ libsass_dep = declare_dependency(
   link_with: libsass,
   include_directories: [inc])
 
-conf_data = configuration_data()
-conf_data.set('prefix', get_option('prefix'))
-conf_data.set('exec_prefix', '${prefix}')
-conf_data.set('libdir', join_paths('${exec_prefix}', get_option('libdir')))
-conf_data.set('includedir', join_paths('${prefix}', get_option('includedir')))
-conf_data.set('VERSION', meson.project_version())
-
-pkg_install_dir = join_paths(get_option('libdir'), 'pkgconfig')
-
-configure_file(
-  input: 'support/libsass.pc.in',
-  output: 'libsass.pc',
-  configuration: conf_data,
-  install_dir: pkg_install_dir)
+pkg = import('pkgconfig')
+pkg.generate(
+  libsass,
+  name: 'libsass',
+  description: 'A C implementation of a Sass compiler',
+  url: 'https://github.com/sass/libsass',
+)

--- a/subprojects/packagefiles/libsass/src/meson.build
+++ b/subprojects/packagefiles/libsass/src/meson.build
@@ -76,7 +76,11 @@ if host_machine.system() == 'windows'
   sass_sources += [windows.compile_resources(winres_path)]
 endif
 
-dl_dep = cpp.find_library('dl', required : false)
+if meson.version().version_compare('>= 0.62')
+  dl_dep = dependency('dl', required : false)
+else
+  dl_dep = cc.find_library('dl', required : false)
+endif
 
 libsass = shared_library(
   'sass',


### PR DESCRIPTION
This is a direct copy of https://github.com/lazka/libsass/tree/meson which I've created for gtk back in the days.

There is an open PR for adding meson support upstream in https://github.com/sass/libsass/pull/3073 but the project is considered deprecated and hasn't seen a commit in over a year, so there is not much hope for progress there.

There is a newer 3.6.5 release out, but I wanted to copy things as is from my fork first and look at updating it later.