### PR TITLE
github CI: enable case sensitivity on Windows

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -39,6 +39,9 @@ jobs:
       TEST_BUILD_ALL: 1
       TEST_FATAL_WARNINGS: ${{ github.event.inputs.fatal_warnings }}
     steps:
+      - name: Enable case sensitivity
+        run: |
+          fsutil file setCaseSensitiveInfo .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -61,6 +64,9 @@ jobs:
       TEST_BUILD_ALL: 1
       TEST_FATAL_WARNINGS: ${{ github.event.inputs.fatal_warnings }}
     steps:
+      - name: Enable case sensitivity
+        run: |
+          fsutil file setCaseSensitiveInfo .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -85,6 +91,9 @@ jobs:
       matrix:
         platform: ['UCRT64', 'CLANG32', 'CLANG64']
     steps:
+      - name: Enable case sensitivity
+        run: |
+          fsutil file setCaseSensitiveInfo .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -27,6 +27,9 @@ jobs:
   VisualStudio:
     runs-on: windows-latest
     steps:
+      - name: Enable case sensitivity
+        run: |
+          fsutil file setCaseSensitiveInfo .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -47,6 +50,9 @@ jobs:
   VisualStudio-clang-cl:
     runs-on: windows-latest
     steps:
+      - name: Enable case sensitivity
+        run: |
+          fsutil file setCaseSensitiveInfo .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -75,6 +81,9 @@ jobs:
       matrix:
         platform: ['UCRT64', 'CLANG32', 'CLANG64']
     steps:
+      - name: Enable case sensitivity
+        run: |
+          fsutil file setCaseSensitiveInfo .
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
Allows packages that use the same filename with different cases to build.