### PR TITLE
ci: fix `sanity_checks.py` package installs on alpine

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Create non privileged user
         run: |
           adduser wrapdb --disabled-password
+          echo 'wrapdb ALL=(ALL:ALL) NOPASSWD: ALL' >/etc/sudoers.d/wrapdb
           chown -R wrapdb:wrapdb .
 
       - name: Sanity Checks

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Create non privileged user
         run: |
           adduser wrapdb --disabled-password
+          echo 'wrapdb ALL=(ALL:ALL) NOPASSWD: ALL' >/etc/sudoers.d/wrapdb
           chown -R wrapdb:wrapdb .
 
       - name: Sanity Checks


### PR DESCRIPTION
The `wrapdb` user need to be allowed to run sudo without a password for `sanity_checks.py` to be able to install additional packages.