### PR TITLE
sdl2: disable unity builds

### DIFF
--- a/subprojects/packagefiles/sdl2/meson.build
+++ b/subprojects/packagefiles/sdl2/meson.build
@@ -1207,7 +1207,7 @@ sdl2_test = static_library('sdl2_test',
     c_args : core_args,
     link_args : core_ldflags,
     dependencies : [sdl2_dep, test_deps],
-    override_options : ['c_std=none', 'unity=off'],
+    override_options : ['c_std=none'],
     build_by_default : false,
 )
 

--- a/subprojects/packagefiles/sdl2/meson.build
+++ b/subprojects/packagefiles/sdl2/meson.build
@@ -1177,7 +1177,7 @@ sdl2 = library('sdl2',
     c_args : core_args,
     link_args : core_ldflags,
     dependencies : deps,
-    override_options : ['c_std=none'],
+    override_options : ['c_std=none', 'unity=off'],
     install : do_install,
     gnu_symbol_visibility: 'hidden',
 )
@@ -1207,7 +1207,7 @@ sdl2_test = static_library('sdl2_test',
     c_args : core_args,
     link_args : core_ldflags,
     dependencies : [sdl2_dep, test_deps],
-    override_options : ['c_std=none'],
+    override_options : ['c_std=none', 'unity=off'],
     build_by_default : false,
 )
 


### PR DESCRIPTION
Unity builds doesn't seem to work with SDL2, it throws a bunch of build errors.
Please advise if this isn't the correct way to disable it, and I should disable it when including SDL2 as a dependency, etc.