### PR TITLE
Update glm.wrap to point to the right url

### DIFF
--- a/subprojects/glm.wrap
+++ b/subprojects/glm.wrap
@@ -1,6 +1,6 @@
 [wrap-file]
 directory = glm-0.9.9.8
-source_url = https://github.com/g-truc/glm/archive/0.9.9.8.tar.gz
+source_url = https://github.com/g-truc/glm/archive/refs/tags/0.9.9.8.tar.gz
 source_filename = 0.9.9.8.tar.gz
 source_hash = 7d508ab72cb5d43227a3711420f06ff99b0a0cb63ee2f93631b162bfe1fe9592
 patch_directory = glm


### PR DESCRIPTION
The link seems to be outdated.