### PR TITLE
elfutils: create wrap

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -553,6 +553,16 @@
       "3.3.4-1"
     ]
   },
+  "elfutils": {
+    "dependency_names": [
+      "asm",
+      "dw",
+      "elf"
+    ],
+    "versions": [
+      "0.190-1"
+    ]
+  },
   "emilk-loguru": {
     "dependency_names": [
       "loguru"

--- a/subprojects/elfutils.wrap
+++ b/subprojects/elfutils.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = elfutils-0.190
+source_url = https://sourceware.org/elfutils/ftp/0.190/elfutils-0.190.tar.bz2
+source_filename = elfutils-0.190.tar.bz2
+source_hash = 8e00a3a9b5f04bc1dc273ae86281d2d26ed412020b391ffcc23198f10231d692
+patch_directory = elfutils
+
+[provide]
+asm = asm
+dw = dw
+elf = elf
+elfutils = asm dw elf

--- a/subprojects/packagefiles/elfutils/meson.build
+++ b/subprojects/packagefiles/elfutils/meson.build
@@ -1,0 +1,21 @@
+project('elfutils', 'c', meson_version: '>=0.56.0')
+
+# elfutils generates definition files using `m4`
+# TODO: we could be smarter here and handle cases where the `m4`
+# binary is setup as a subproject
+m4 = find_program('m4', required: true)
+
+mod = import('unstable-external_project')
+
+proj = mod.add_project('configure',
+  configure_options: [
+    '--prefix=@PREFIX@',
+    '--libdir=@PREFIX@/@LIBDIR@',
+    '--includedir=@PREFIX@/@INCLUDEDIR@',
+    '--disable-debuginfod',
+  ],
+)
+
+asm = proj.dependency('asm')
+dw = proj.dependency('dw')
+elf = proj.dependency('elf')


### PR DESCRIPTION
`elfutils` (https://sourceware.org/elfutils/) is a set of libraries and tools to inspect ELF, DWARF, etc.

> **libelf**
> elf32, elf64 and gelf functions to read, modify and create ELF files.

> **ibdw**
> dwarf, dwfl and dwelf functions to read DWARF, find separate debuginfo, symbols and inspect process state.

> **libasm**
> asm and disasm functions to assemble and disassamble instructions (partial support for i686 and BPF instructions only).

Apart from its direct use, `elfutils` can be linked to `backward-cpp` (an already existing wrap) to allow the display of demangled stack traces with inline source code.

Some notes:

- `elfutils` requires the `m4` binary to generate some definition files. Currently we directly check for `m4` using `find_program`, though we could be smarter in the future and fallback to using the `m4` wrap. I am not litterate enough in meson to do that properly for now, but that could be a welcomed addition in the future.

- Wrapping autotools projects requires using the `unstable-external_project` feature, or I may be mistaken.  