### PR TITLE
type_safe: new wrap

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -3220,6 +3220,14 @@
       "1.3.1-1"
     ]
   },
+  "type_safe": {
+    "dependency_names": [
+      "type_safe"
+    ],
+    "versions": [
+      "0.2.3-1"
+    ]
+  },
   "uchardet": {
     "dependency_names": [
       "uchardet"

--- a/subprojects/packagefiles/type_safe/meson.build
+++ b/subprojects/packagefiles/type_safe/meson.build
@@ -1,0 +1,57 @@
+project(
+    'type_safe',
+    'cpp',
+    license: 'MIT',
+    version: '0.2.3',
+    meson_version: '>= 0.59.0',
+)
+
+da_dep = dependency('debug_assert')
+
+b_ndebug = get_option('b_ndebug')
+if (
+    b_ndebug == 'true'
+    or (
+        b_ndebug == 'if-release'
+        and get_option('buildtype') in ['release', 'plain']
+    )
+)
+    ndebug = true
+else
+    ndebug = false
+endif
+
+assertions_opt = get_option('assertions')
+enable_assertions = assertions_opt.disable_auto_if(ndebug).allowed() ? 1 : 0
+precond_checks = get_option('preconditions') ? 1 : 0
+enable_wrappers = get_option('wrappers') ? 1 : 0
+
+arithmetic_policy_s = get_option('arithmetic-policy')
+if arithmetic_policy_s == 'default'
+    arithmetic_policy = 0
+elif arithmetic_policy_s == 'ub'
+    arithmetic_policy = 1
+elif arithmetic_policy_s == 'checked'
+    arithmetic_policy = 2
+else
+    error('a new option for arithmetic-policy must have been added without changing meson.build')
+endif
+
+comp_args = [
+    f'-DTYPE_SAFE_ENABLE_ASSERTIONS=@enable_assertions@',
+    f'-DTYPE_SAFE_ENABLE_PRECONDITION_CHECKS=@precond_checks@',
+    f'-DTYPE_SAFE_ENABLE_WRAPPER=@enable_wrappers@',
+    f'-DTYPE_SAFE_ARITHMETIC_POLICY=@arithmetic_policy@',
+]
+
+cxx = meson.get_compiler('cpp')
+if cxx.get_id() == 'msvc'
+    comp_args += '/Wd4800'
+endif
+
+type_safe_dep = declare_dependency(
+    compile_args: comp_args,
+    dependencies: [da_dep],
+)
+
+meson.override_dependency('type_safe', type_safe_dep)

--- a/subprojects/packagefiles/type_safe/meson_options.txt
+++ b/subprojects/packagefiles/type_safe/meson_options.txt
@@ -1,0 +1,8 @@
+option('assertions', type: 'feature', value: 'auto',
+      description: 'enable internal assertions. `auto` is based on NDEBUG.')
+option('preconditions', type: 'boolean', value: true,
+      description: 'enable precondition checks')
+option('wrappers', type: 'boolean', value: true,
+      description: 'enable wrappers in types.hpp')
+option('arithmetic-policy', type: 'combo', choices: ['default', 'ub', 'checked'],
+      value: 'default', description: 'default arithmetic policy to use')

--- a/subprojects/type_safe.wrap
+++ b/subprojects/type_safe.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = type_safe-0.2.3
+source_url = https://github.com/foonathan/type_safe/archive/refs/tags/v0.2.3.tar.gz
+source_filename = type_safe-0.2.3.tar.gz
+source_hash = 19008ab9526b0d2db1ae6bbd6640f5f7a398826bb2266561472e9f1b10d85bec
+method = meson
+patch_directory = type_safe
+
+[provide]
+dependency_names = type_safe


### PR DESCRIPTION
Project can be found [here.](https://github.com/foonathan/type_safe)

I'm not super happy about adding the `/Wd4800` for MSVC, but that's something
I will look into doing something about. (read: fixing the code so it doesn't
warn on that in the first place.)

Depends on debug\_assert (PR #1419).
