### PR TITLE
add new wrap: nativefiledialog-extended

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -608,6 +608,14 @@
       "boost"
     ]
   },
+  "nativefiledialog-extended": {
+    "alpine_packages": [
+      "gtk+3.0-dev"
+    ],
+    "debian_packages": [
+      "libgtk-3-dev"
+    ]
+  },
   "nowide": {
     "build_options": [
       "nowide:tests=true"

--- a/releases.json
+++ b/releases.json
@@ -2240,6 +2240,14 @@
       "mujs"
     ]
   },
+  "nativefiledialog-extended": {
+    "dependency_names": [
+      "nativefiledialog-extended"
+    ],
+    "versions": [
+      "1.1.1-1"
+    ]
+  },
   "netstring-c": {
     "dependency_names": [
       "netstring-c"

--- a/subprojects/nativefiledialog-extended.wrap
+++ b/subprojects/nativefiledialog-extended.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = nativefiledialog-extended-1.1.1
+source_url = https://github.com/btzy/nativefiledialog-extended/archive/refs/tags/v1.1.1.tar.gz
+source_filename = nativefiledialog-extended-1.1.1.tar.gz
+source_hash = 8cce60cb9c046a6fb86a86e7f71d95017dd3353e1596180a6c60f5592f7cc0cb
+patch_directory = nativefiledialog-extended
+
+[provide]
+nativefiledialog-extended = nfde_dep
+

--- a/subprojects/packagefiles/nativefiledialog-extended/meson.build
+++ b/subprojects/packagefiles/nativefiledialog-extended/meson.build
@@ -1,0 +1,16 @@
+project(
+    'nativefiledialog-extended',
+    'cpp',
+    version: '1.1.1',
+    license: 'Zlib',
+    meson_version: '>=1.2.0',
+    default_options: {
+        'cpp_std': ['c++14'],
+    },
+)
+
+subdir('src')
+
+if get_option('tests')
+    subdir('test')
+endif

--- a/subprojects/packagefiles/nativefiledialog-extended/meson_options.txt
+++ b/subprojects/packagefiles/nativefiledialog-extended/meson_options.txt
@@ -1,0 +1,31 @@
+
+
+option(
+    'tests',
+    type: 'boolean',
+    value: false,
+    description: 'whether or not tests should be built',
+)
+
+option(
+    'xdg-desktop-portal',
+    type: 'feature',
+    value: 'auto',
+    description: 'Use xdg-desktop-portal instead of GTK (linux only',
+)
+
+option(
+    'append_extension_linux',
+    type: 'boolean',
+    value: false,
+    description: 'Automatically append file extension to an extensionless selection in SaveDialog() (linux only)',
+)
+
+option(
+    'use_allowed_content_types',
+    type: 'feature',
+    value: 'auto',
+    description: 'Use allowedContentTypes for filter lists on macOS >= 11.0',
+)
+
+

--- a/subprojects/packagefiles/nativefiledialog-extended/src/meson.build
+++ b/subprojects/packagefiles/nativefiledialog-extended/src/meson.build
@@ -1,0 +1,118 @@
+
+inc_dirs = include_directories('include')
+
+src_files = files('include/nfd.h', 'include/nfd.hpp')
+
+deps = []
+compile_args = []
+
+if host_machine.system() == 'windows'
+    src_files += files('nfd_win.cpp')
+elif host_machine.system() == 'darwin'
+
+
+    # For setting the filter list, macOS introduced allowedContentTypes in version 11.0 and deprecated allowedFileTypes in 12.0.
+    # By default (set to ON), NFDe will use allowedContentTypes when targeting macOS >= 11.0.
+    # Set this option to OFF to always use allowedFileTypes regardless of the target macOS version.
+    # This is mainly needed for applications that are built on macOS >= 11.0 but should be able to run on lower versions
+    # and should not be used otherwise.
+
+    deps += dependency('AppKit', required: true)
+
+    use_allowed_content_types_result = false
+
+    use_allowed_content_types_feature = get_option('use_allowed_content_types')
+
+    if use_allowed_content_types_feature.allowed()
+
+        cpp = meson.get_compiler('cpp')
+
+        macos_v11_or_higher = cpp.compiles(
+            '''
+        #include <Availability.h>
+        #if !defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || !defined(__MAC_11_0) || __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_11_0
+        static_assert(false);
+        #endif
+        int main() { return 0; }
+        ''',
+        )
+
+        if macos_v11_or_higher
+
+            ufti_dep = dependency('UniformTypeIdentifiers', required: false)
+            if not ufti_dep.found()
+                if use_allowed_content_types_feature.enabled()
+                    error(
+                        'UniformTypeIdentifiers framework is not available even though we are targeting macOS >= 11.0',
+                    )
+                endif
+            else
+                deps += ufti_dep
+                use_allowed_content_types_result = true
+            endif
+        endif
+    endif
+
+    compile_args += (
+        '-DNFD_MACOS_ALLOWEDCONTENTTYPES=' + (use_allowed_content_types_result ? '1' : '0')
+    )
+
+    add_languages('objc', native: false)
+
+    src_files += files('nfd_cocoa.m')
+
+
+elif host_machine.system() == 'linux'
+
+    # for Linux, we support GTK3 and xdg-desktop-portal
+    use_xdg_portal_feature = get_option('xdg-desktop-portal')
+    if use_xdg_portal_feature.auto()
+
+        # in case of auto we prefer gtk3
+        gtk3_dep = dependency('gtk+-3.0', required: false)
+
+        if gtk3_dep.found()
+            deps += gtk3_dep
+            src_files += files('nfd_gtk.cpp')
+        else
+            deps += dependency('dbus-1', required: true)
+            src_files += files('nfd_portal.cpp')
+        endif
+
+    elif use_xdg_portal_feature.disabled()
+        deps += dependency('gtk+-3.0', required: true)
+        src_files += files('nfd_gtk.cpp')
+    else
+        deps += dependency('dbus-1', required: true)
+        src_files += files('nfd_portal.cpp')
+    endif
+
+
+
+
+    if get_option('append_extension_linux')
+        compile_args += '-DNFD_APPEND_EXTENSION'
+    endif
+
+
+else
+    error('not supported platform')
+endif
+
+
+
+nfde_lib = library(
+    'nativefiledialog-extended',
+    src_files,
+    include_directories: inc_dirs,
+    dependencies: deps,
+    cpp_args: compile_args,
+)
+
+
+nfde_dep = declare_dependency(
+    include_directories: inc_dirs,
+    version: meson.project_version(),
+    link_with: nfde_lib,
+    compile_args: compile_args,
+)

--- a/subprojects/packagefiles/nativefiledialog-extended/test/meson.build
+++ b/subprojects/packagefiles/nativefiledialog-extended/test/meson.build
@@ -1,0 +1,26 @@
+test_files = [
+  'test_opendialog.c',
+  'test_opendialog_cpp.cpp',
+  'test_opendialogmultiple.c',
+  'test_opendialogmultiple_cpp.cpp',
+  'test_opendialogmultiple_enum.c',
+  'test_pickfolder.c',
+  'test_pickfolder_cpp.cpp',
+  'test_savedialog.c',
+]
+
+add_languages('c', native: false)
+
+foreach test : test_files
+  name = test.replace('.', '_')
+
+  text_exe = executable(
+    'test_' + name,
+    test,
+    dependencies: nfde_dep,
+  )
+
+  test('test_' + name, text_exe)
+endforeach
+
+


### PR DESCRIPTION
This is a wrap for this project: [nativefiledialog-extended](https://github.com/btzy/nativefiledialog-extended/)

the tests are disabled by default, since they require a display system and user interaction, but where tested locally