### PR TITLE
cmark-gfm: Make sure CMARK_GFM_STATIC_DEFINE is set to 0 or 1

### DIFF
--- a/subprojects/packagefiles/cmark-gfm/meson.build
+++ b/subprojects/packagefiles/cmark-gfm/meson.build
@@ -54,7 +54,7 @@ configure_file(
 
 edata = configuration_data(
     {
-        'CMARK_GFM_STATIC_DEFINE': get_option('default_library') == 'static',
+        'CMARK_GFM_STATIC_DEFINE': get_option('default_library') == 'static' ? 1 : 0,
     },
 )
 


### PR DESCRIPTION
Currently (with meson 1.0.1) the file `build/subprojects/cmark-gfm-0.29.0.gfm.13/cmark-gfm_export.h` will contain this (if `default_library=static` is set):

```
/* Is this an exclusively static build */
#if True && ! defined CMARK_GFM_STATIC_DEFINE
#  define CMARK_GFM_STATIC_DEFINE
#endif
```

This will cause a warning with `-Wundef` and will not work, because `True` will be evaulated as `0` by the preprocessor:

```
subprojects/cmark-gfm-0.29.0.gfm.13/cmark-gfm_export.h:5:5: warning: "True" is not defined, evaluates to 0 [-Wundef]
    5 | #if True && ! defined CMARK_GFM_STATIC_DEFINE
```


This PR makes sure that `@CMARK_GFM_STATIC_DEFINE@` is always set to `0` or `1`.
