### PR TITLE
ci: run macOS builds on both arm64 and x86_64

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -145,10 +145,13 @@ jobs:
 
   MacOS:
     if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
-    runs-on: macos-latest
+    runs-on: ${{ matrix.platform == 'arm64' && 'macos-14' || 'macos-12' }}
     env:
       TEST_BUILD_ALL: 1
       TEST_FATAL_WARNINGS: ${{ github.event.inputs.fatal_warnings }}
+    strategy:
+      matrix:
+        platform: ['arm64', 'x86_64']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -158,11 +161,11 @@ jobs:
       # github actions overwrites brew's python. Force it to reassert itself, by running in a separate step.
       - name: unbreak python in github actions
         run: |
-          find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
+          find $(brew --prefix)/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
           sudo rm -rf /Library/Frameworks/Python.framework/
           brew install --force python3 && brew unlink python3 && brew unlink python3 && brew link --overwrite python3
           # Work around PEP 668 nonsense…
-          find /usr/local/Cellar/python* -name EXTERNALLY-MANAGED -print0 | xargs -0 rm -vf
+          find $(brew --prefix)/Cellar/python* -name EXTERNALLY-MANAGED -print0 | xargs -0 rm -vf
       - name: Install packages
         run: |
           brew install ninja

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -130,7 +130,10 @@ jobs:
           python tools/sanity_checks.py
 
   MacOS:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.platform == 'arm64' && 'macos-14' || 'macos-12' }}
+    strategy:
+      matrix:
+        platform: ['arm64', 'x86_64']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -140,11 +143,11 @@ jobs:
       # github actions overwrites brew's python. Force it to reassert itself, by running in a separate step.
       - name: unbreak python in github actions
         run: |
-          find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
+          find $(brew --prefix)/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
           sudo rm -rf /Library/Frameworks/Python.framework/
           brew install --force python3 && brew unlink python3 && brew unlink python3 && brew link --overwrite python3
           # Work around PEP 668 nonsense…
-          find /usr/local/Cellar/python* -name EXTERNALLY-MANAGED -print0 | xargs -0 rm -vf
+          find $(brew --prefix)/Cellar/python* -name EXTERNALLY-MANAGED -print0 | xargs -0 rm -vf
       - name: Install packages
         run: |
           brew install ninja


### PR DESCRIPTION
The `macos-latest` runner image has historically been x86_64, but it's [currently migrating](https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/) from `macos-12` to `macos-14` which [runs on arm64 hardware](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/).  It seems useful to get test coverage on both architectures, so arrange that for now.  Presumably we'll eventually have to drop macOS x86_64 tests when the `macos-12` image goes out of support.

Homebrew installs into `/opt/homebrew` on arm64 Macs.