### PR TITLE
Support installing Python packages in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ meson compile -C builddir
     on MacOS CI runners.
   - `choco_packages`: (Optional) List of extra packages that will be installed
     on Windows CI runners.
+  - `python_packages`: (Optional) List of extra Python packages that will be
+    installed on all CI runners.
   - `linux_only`: (Optional) If set to `true`, indicates the wrap should be tested
     only on Linux CI.
   - `fatal_warnings`: (Optional) If set to `false` removes --fatal-meson-warning.

--- a/ci_config.json
+++ b/ci_config.json
@@ -283,6 +283,9 @@
     "alpine_packages": [
       "gettext-tiny-dev"
     ],
+    "python_packages": [
+      "packaging"
+    ],
     "build_options": [
       "glib:tests=false"
     ],
@@ -321,8 +324,8 @@
       "harfbuzz:freetype=enabled",
       "harfbuzz:icu=enabled"
     ],
-    "msys_packages": [
-      "python-packaging"
+    "python_packages": [
+      "packaging"
     ],
     "skip_dependency_check": [
       "harfbuzz-cairo"

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -23,6 +23,7 @@ import typing as T
 import os
 import tempfile
 import platform
+import sys
 
 from pathlib import Path
 from utils import Version, is_ci, is_alpinelike, is_debianlike, is_linux, is_macos, is_windows, is_msys
@@ -352,6 +353,7 @@ class TestReleases(unittest.TestCase):
         choco_packages = ci.get('choco_packages', [])
         msys_packages = ci.get('msys_packages', [])
         alpine_packages = ci.get('alpine_packages', [])
+        python_packages = ci.get('python_packages', [])
         meson_env = os.environ.copy()
         if debian_packages and is_debianlike():
             if is_ci():
@@ -387,6 +389,13 @@ class TestReleases(unittest.TestCase):
             else:
                 s = ', '.join(alpine_packages)
                 print(f'The following packages could be required: {s}')
+        # install Python packages on every platform
+        if python_packages:
+            if is_ci():
+                subprocess.check_call([sys.executable, '-m', 'pip', 'install'] + python_packages)
+            else:
+                s = ', '.join(python_packages)
+                print(f'The following Python packages could be required: {s}')
 
         res = subprocess.run(['meson', 'setup', builddir] + options, env=meson_env)
         if res.returncode == 0:


### PR DESCRIPTION
glib 2.80+ build-requires the Python `packaging` package, which isn't preinstalled in the MSYS runners.  In this specific case, we could install it from an MSYS package, but some Python dependencies might not be available from all platform package managers.  Support installing arbitrary Python packages from pip on all platforms.