### PR TITLE
glib: install Python `packaging` package in MSYS CI

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -286,6 +286,9 @@
     "build_options": [
       "glib:tests=false"
     ],
+    "msys_packages": [
+      "python-packaging"
+    ],
     "skip_dependency_check": [
       "gio-windows-2.0",
       "gio-unix-2.0"


### PR DESCRIPTION
glib 2.80+ build-requires the Python `packaging` package, which isn't preinstalled in the MSYS runners.