### PR TITLE
ci: disable `fail-fast` option on macOS matrix jobs

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -132,6 +132,7 @@ jobs:
   MacOS:
     runs-on: ${{ matrix.platform == 'arm64' && 'macos-14' || 'macos-12' }}
     strategy:
+      fail-fast: false
       matrix:
         platform: ['arm64', 'x86_64']
     steps:


### PR DESCRIPTION
A failure to build on `arm64` does not necessarily mean `x86_64` will fail too, and vice versa, so it's useful to try to run both jobs to completion. Case in point: it looks like the openssl install on `arm64` is borked (see #1466 and #1492).