### PR TITLE
add new wrap "zlib-ng"

### DIFF
--- a/subprojects/zlib-ng.wrap
+++ b/subprojects/zlib-ng.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+method = cmake
+directory = zlib-ng-2.1.6
+source_url = https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.1.6.tar.gz
+source_filename = zlib-ng-2.1.6.tar.gz
+source_hash = a5d504c0d52e2e2721e7e7d86988dec2e290d723ced2307145dedd06aeb6fef2
+wrapdb_version = 2.1.6-1
+[provide]
+zlib-ng = zlib_dep


### PR DESCRIPTION
Draft, because I have problem with
```
[226/1971] Linking target src/mapi/shared-glapi/libglapi.so.0.0.0
FAILED: src/mapi/shared-glapi/libglapi.so.0.0.0 
c++  -o src/mapi/shared-glapi/libglapi.so.0.0.0 src/mapi/shared-glapi/libglapi.so.0.0.0.p/.._entry.c.o src/mapi/shared-glapi/libglapi.so.0.0.0.p/.._u_current.c.o src/mapi/shared-glapi/libglapi.so.0.0.0.p/glapi.c.o src/mapi/shared-glapi/libglapi.so.0.0.0.p/stub.c.o src/mapi/shared-glapi/libglapi.so.0.0.0.p/table.c.o -Wl,--as-needed -Wl,--no-undefined -shared -fPIC -Wl,-soname,libglapi.so.0 '-Wl,-rpath,$ORIGIN/../../../subprojects/zlib-ng-2.1.6' -Wl,-rpath-link,/home/projects/mesa/build/subprojects/zlib-ng-2.1.6 -Wl,--start-group src/util/libmesa_util.a src/util/libmesa_util_sse41.a subprojects/zlib-ng-2.1.6/libzlib.so src/util/blake3/libblake3.a src/c11/impl/libmesa_util_c11.a -Wl,--gc-sections -pthread -Wl,--version-script,/home/projects/mesa/subprojects/zlib-ng-2.1.6/zlib-ng.map -lm /usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/libzstd.so /usr/lib/x86_64-linux-gnu/libunwind.so -Wl,--end-group -Wl,--version-script,/home/projects/mesa/subprojects/zlib-ng-2.1.6/zlib-ng.map
/usr/bin/ld: duplicate version tag `ZLIB_NG_2.1.0'
/usr/bin/ld: duplicate version tag `ZLIB_NG_2.0.0'
/usr/bin/ld: duplicate version tag `ZLIB_NG_GZ_2.0.0'
/usr/bin/ld: duplicate version tag `FAIL'
collect2: error: ld returned 1 exit status
```

Modern drop-in replacement for zlib, including all needed CPU optimizations.