### PR TITLE
google-benchmark: update to 1.8.3

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1003,9 +1003,11 @@
   },
   "google-benchmark": {
     "dependency_names": [
-      "benchmark"
+      "benchmark",
+      "benchmark-main"
     ],
     "versions": [
+      "1.8.3-1",
       "1.7.1-2",
       "1.7.1-1",
       "1.7.0-1",

--- a/subprojects/google-benchmark.wrap
+++ b/subprojects/google-benchmark.wrap
@@ -1,9 +1,10 @@
 [wrap-file]
-directory = benchmark-1.7.1
-source_url = https://github.com/google/benchmark/archive/refs/tags/v1.7.1.tar.gz
-source_filename = benchmark-1.7.1.tar.gz
-source_hash = 6430e4092653380d9dc4ccb45a1e2dc9259d581f4866dc0759713126056bc1d7
+directory = benchmark-1.8.3
+source_url = https://github.com/google/benchmark/archive/refs/tags/v1.8.3.tar.gz
+source_filename = benchmark-1.8.3.tar.gz
+source_hash = 6bc180a57d23d4d9515519f92b0c83d61b05b5bab188961f36ac7b06b0d9e9ce
 patch_directory = google-benchmark
 
 [provide]
 benchmark = google_benchmark_dep
+benchmark-main = google_benchmark_main_dep

--- a/subprojects/packagefiles/google-benchmark/meson.build
+++ b/subprojects/packagefiles/google-benchmark/meson.build
@@ -1,7 +1,7 @@
 project(
   'benchmark',
   'cpp',
-  version: '1.7.1',
+  version: '1.8.3',
   default_options: ['cpp_std=c++14'],
   license: 'Apache-2.0',
 )
@@ -13,6 +13,7 @@ benchmark_sources = files(
   'src/benchmark_name.cc',
   'src/benchmark_register.cc',
   'src/benchmark_runner.cc',
+  'src/check.cc',
   'src/colorprint.cc',
   'src/commandlineflags.cc',
   'src/complexity.cc',
@@ -22,7 +23,6 @@ benchmark_sources = files(
   'src/json_reporter.cc',
   'src/perf_counters.cc',
   'src/reporter.cc',
-  'src/sleep.cc',
   'src/statistics.cc',
   'src/string_util.cc',
   'src/sysinfo.cc',
@@ -79,7 +79,9 @@ lib_benchmark_main = library(
 google_benchmark_main_dep = declare_dependency(
   compile_args: dargs,
   link_with: lib_benchmark_main,
-  include_directories: inc,
+  dependencies: google_benchmark_dep,
 )
 
-subdir('test')
+if not get_option('tests').disabled()
+  subdir('test')
+endif

--- a/subprojects/packagefiles/google-benchmark/meson_options.txt
+++ b/subprojects/packagefiles/google-benchmark/meson_options.txt
@@ -1,0 +1,1 @@
+option('tests', type: 'feature', value: 'auto', description: 'Build unit tests')

--- a/subprojects/packagefiles/google-benchmark/test/meson.build
+++ b/subprojects/packagefiles/google-benchmark/test/meson.build
@@ -1,20 +1,62 @@
+# Plain tests
+
 benchmark_tests = {
-  'benchmark_test': '--benchmark_min_time=0.01',
+  'benchmark_test': '--benchmark_min_time=0.01s',
   'spec_arg_test': '--benchmark_filter=BM_NotChosen',
   'spec_arg_verbosity_test': '--v=42',
   'benchmark_setup_teardown_test': [],
-  'options_test': '--benchmark_min_time=0.01',
-  'basic_test': '--benchmark_min_time=0.01',
-# 'diagnostics_test': '--benchmark_min_time=0.01',
-# 'skip_with_error_test': '--benchmark_min_time=0.01',
-  'donotoptimize_test': '--benchmark_min_time=0.01',
-  'fixture_test': '--benchmark_min_time=0.01',
-# 'register_benchmark_test': '--benchmark_min_time=0.01',
-  'map_test': '--benchmark_min_time=0.01',
-  'multiple_ranges_test': '--benchmark_min_time=0.01',
-  'args_product_test': '--benchmark_min_time=0.01',
+  'benchmark_min_time_flag_time_test': [],
+  'benchmark_min_time_flag_iters_test': [],
+  'options_test': '--benchmark_min_time=0.01s',
+  'basic_test': '--benchmark_min_time=0.01s',
+# 'diagnostics_test': '--benchmark_min_time=0.01s',
+  'skip_with_error_test': '--benchmark_min_time=0.01s',
+  'donotoptimize_test': '--benchmark_min_time=0.01s',
+  'fixture_test': '--benchmark_min_time=0.01s',
+  'register_benchmark_test': '--benchmark_min_time=0.01s',
+  'map_test': '--benchmark_min_time=0.01s',
+  'multiple_ranges_test': '--benchmark_min_time=0.01s',
+  'args_product_test': '--benchmark_min_time=0.01s',
 }
 
 foreach t, a : benchmark_tests
-  test(t, executable(t, '@0@.cc'.format(t), dependencies: google_benchmark_dep), args: a)
+  test(t,
+    executable(t, '@0@.cc'.format(t),
+      dependencies: google_benchmark_dep),
+    args: a
+  )
 endforeach
+
+# Filter tests (omitted here)
+
+# Output tests
+
+benchmark_output_tests = {
+  'repetitions_test': ['--benchmark_min_time=0.01s', '--benchmark_repetitions=3'],
+  'reporter_output_test': '--benchmark_min_time=0.01s',
+  'templated_fixture_test': '--benchmark_min_time=0.01s',
+  'user_counters_test': '--benchmark_min_time=0.01s',
+  'perf_counters_test': ['--benchmark_min_time=0.01s', '--benchmark_perf_counters=CYCLES,BRANCHES'],
+  'internal_threading_test': '--benchmark_min_time=0.01s',
+  'report_aggregates_only_test': '--benchmark_min_time=0.01s',
+  'display_aggregates_only_test': '--benchmark_min_time=0.01s',
+  'user_counters_tabular_test': ['--benchmark_counters_tabular=true', '--benchmark_min_time=0.01s'],
+  'user_counters_thousands_test': '--benchmark_min_time=0.01s',
+  'memory_manager_test': '--benchmark_min_time=0.01s',
+}
+
+foreach t, a : benchmark_output_tests
+  test(t,
+    executable(t, ['@0@.cc'.format(t), 'output_test_helper.cc'],
+      dependencies: google_benchmark_dep),
+    args: a
+  )
+endforeach
+
+# Link-main test
+
+test('link_main_test',
+  executable('link_main_test', 'link_main_test.cc',
+    dependencies: google_benchmark_main_dep),
+  args: '--benchmark_min_time=0.01s'
+)


### PR DESCRIPTION
Compared to 1.7.1-2, this
- Additionally provides 'benchmark-main' which includes the provided `main()`
- Adds the option 'tests' to disable tests (Closes #1311)
- Adds more of the tests