### PR TITLE
`releases.json` formatting cleanups

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -244,8 +244,8 @@
       "c-flags"
     ],
     "versions": [
-        "1.5.8-1",
-        "1.5.4-1"
+      "1.5.8-1",
+      "1.5.4-1"
     ]
   },
   "cairo": {
@@ -1000,11 +1000,11 @@
       "0.9.9.8-1"
     ]
   },
-  "godot-cpp" : {
-    "dependency_names" : [
+  "godot-cpp": {
+    "dependency_names": [
       "godot_cpp"
     ],
-    "versions" : [
+    "versions": [
       "4.2-1"
     ]
   },
@@ -1326,18 +1326,14 @@
     ]
   },
   "jbig2dec": {
-    "versions": [
-      "0.20-1"
-    ],
     "dependency_names": [
       "jbig2dec"
+    ],
+    "versions": [
+      "0.20-1"
     ]
   },
   "jbigkit": {
-    "versions": [
-      "2.1-2",
-      "2.1-1"
-    ],
     "dependency_names": [
       "libjbig",
       "libjbig85"
@@ -1347,6 +1343,10 @@
       "pbmtojbg",
       "jbgtopbm85",
       "pbmtojbg85"
+    ],
+    "versions": [
+      "2.1-2",
+      "2.1-1"
     ]
   },
   "json": {
@@ -1358,6 +1358,9 @@
     ]
   },
   "json-c": {
+    "dependency_names": [
+      "json-c"
+    ],
     "versions": [
       "0.17-2",
       "0.17-1",
@@ -1368,9 +1371,6 @@
       "0.15-2",
       "0.15-1",
       "0.13.1-1"
-    ],
-    "dependency_names": [
-      "json-c"
     ]
   },
   "json-glib": {
@@ -1542,12 +1542,12 @@
     ]
   },
   "libgpiod": {
-    "versions": [
-      "1.6.3-1"
-    ],
     "dependency_names": [
       "libgpiod",
       "libgpiodcxx"
+    ],
+    "versions": [
+      "1.6.3-1"
     ]
   },
   "libjpeg-turbo": {
@@ -1596,11 +1596,11 @@
     ]
   },
   "liblastfm": {
-    "versions": [
-      "1.0.1-1"
-    ],
     "dependency_names": [
       "liblastfm"
+    ],
+    "versions": [
+      "1.0.1-1"
     ]
   },
   "liblbfgs": {
@@ -2117,16 +2117,16 @@
     "dependency_names": [
       "lmdb"
     ],
-    "versions": [
-      "0.9.29-3",
-      "0.9.29-2",
-      "0.9.29-1"
-    ],
     "program_names": [
       "mdb_stat",
       "mdb_copy",
       "mdb_dump",
       "mdb_load"
+    ],
+    "versions": [
+      "0.9.29-3",
+      "0.9.29-2",
+      "0.9.29-1"
     ]
   },
   "lua": {
@@ -2193,23 +2193,23 @@
     ]
   },
   "m4": {
-    "versions": [
-      "1.4.19-1"
-    ],
     "program_names": [
       "m4"
+    ],
+    "versions": [
+      "1.4.19-1"
     ]
   },
   "magic_enum": {
+    "dependency_names": [
+      "magic_enum"
+    ],
     "versions": [
       "0.9.5-1",
       "0.9.3-1",
       "0.9.2-1",
       "0.8.2-1",
       "0.8.1-1"
-    ],
-    "dependency_names": [
-      "magic_enum"
     ]
   },
   "mdds": {
@@ -2311,11 +2311,11 @@
     ]
   },
   "mujs": {
-    "versions": [
-      "1.3.3-1"
-    ],
     "dependency_names": [
       "mujs"
+    ],
+    "versions": [
+      "1.3.3-1"
     ]
   },
   "nanoarrow": {
@@ -2730,11 +2730,11 @@
     ]
   },
   "proxy-libintl": {
-    "versions": [
-      "0.4-1"
-    ],
     "dependency_names": [
       "intl"
+    ],
+    "versions": [
+      "0.4-1"
     ]
   },
   "pugixml": {
@@ -3517,12 +3517,12 @@
     ]
   },
   "vulkan-memory-allocator": {
+    "dependency_names": [
+      "vulkan-memory-allocator"
+    ],
     "versions": [
       "3.1.0-1",
       "3.0.1-1"
-    ],
-    "dependency_names": [
-      "vulkan-memory-allocator"
     ]
   },
   "vulkan-validationlayers": {
@@ -3664,4 +3664,3 @@
     ]
   }
 }
-


### PR DESCRIPTION
Reformat `releases.json` with `json.dump(..., indent=2, sort_keys=True)`.

Broken out of an upcoming automation PR which will likely require extended discussion.