### PR TITLE
Add tool to check for new upstream versions and autoupdate if possible

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -1,0 +1,79 @@
+name: Autoupdate wraps
+
+on:
+  schedule:
+    - cron: "15 0 * * 0"
+    - cron: "15 0 * * 4"
+  workflow_dispatch:
+    inputs:
+      wraps:
+        description: Update only these wraps (space-separated, optional)
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency: autoupdate
+
+env:
+  # fork to push branches to
+  HEAD_REPO: wrapdb-bot/wrapdb
+
+jobs:
+  check:
+    name: Check for updates
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.check.outputs.matrix }}
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Check for updates
+        id: check
+        run: tools/versions.py list --github --official --update ${{ inputs.wraps }} >> $GITHUB_OUTPUT
+      - name: Report untracked wraps
+        run: |
+          echo "## Manual update required" >> $GITHUB_STEP_SUMMARY
+          tools/versions.py list --markdown --port --update >> $GITHUB_STEP_SUMMARY
+          echo "## Not configured in [Anitya](https://release-monitoring.org/)" >> $GITHUB_STEP_SUMMARY
+          tools/versions.py list --markdown --untracked >> $GITHUB_STEP_SUMMARY
+      - name: Delete stale branches
+        env:
+          GITHUB_TOKEN: ${{ github.repository != env.HEAD_REPO && secrets.BOT_TOKEN || github.token }}
+        run: |
+          tools/versions.py list --json --official --update | \
+              jq -r "keys | .[]" | \
+              sed "s:^:auto/:" > expected-branches
+          gh auth setup-git
+          # delete unneeded auto branches, which closes any corresponding PRs
+          gh api "/repos/${{ env.HEAD_REPO }}/branches" -q .[].name | \
+              grep "^auto/" | \
+              grep -Fvxf expected-branches | \
+              sed "s/^/:/" | \
+              xargs -r git push "${{ github.server_url }}/${{ env.HEAD_REPO }}"
+
+  update:
+    name: Update
+    needs: check
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.check.outputs.matrix) }}
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Update
+        run: tools/versions.py autoupdate "${{ matrix.wrap }}"
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ github.repository != env.HEAD_REPO && secrets.BOT_TOKEN || github.token }}
+          push-to-fork: ${{ github.repository != env.HEAD_REPO && env.HEAD_REPO || '' }}
+          branch: auto/${{ matrix.wrap }}
+          title: "${{ matrix.wrap }}: update from ${{ matrix.old-version }} to ${{ matrix.new-version }}"
+          body: ""
+          commit-message: "${{ matrix.wrap }}: update from ${{ matrix.old-version }} to ${{ matrix.new-version }}"
+          author: "WrapDB Bot <wrapdb@mesonbuild.com>"
+          committer: "WrapDB Bot <wrapdb@mesonbuild.com>"

--- a/tools/versions.py
+++ b/tools/versions.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 Benjamin Gilbert <bgilbert@backtick.net>
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+from argparse import ArgumentParser, Namespace
+from configparser import ConfigParser
+from functools import cache
+from hashlib import sha256
+from itertools import count
+import json
+import os
+import re
+import sys
+import time
+from typing import TypedDict
+
+import requests
+
+WRAP_URL_TEMPLATE = (
+    'https://github.com/mesonbuild/wrapdb/blob/master/subprojects/{0}.wrap'
+)
+# wraps that exist but whose versions should not be reported or updated
+DEPRECATED_WRAPS = set([
+    # replaced with nlohmann_json
+    'json',
+    # replaced with doctest
+    'onqtam-doctest'
+])
+
+
+class AnityaPackageList(TypedDict):
+    items: list[AnityaPackage]
+    items_per_page: int
+    page: int
+    total_items: int
+
+
+class AnityaPackage(TypedDict):
+    distribution: str
+    ecosystem: str
+    name: str
+    project: str
+    stable_version: str
+    version: str
+
+
+class WrapInfo(TypedDict):
+    versions: list[str]
+    dependency_names: list[str]
+    program_names: list[str]
+
+
+@cache
+def get_upstream_versions() -> dict[str, str]:
+    '''Query Anitya and return a dict: wrap_name -> upstream_version.'''
+
+    items_per_page = 250
+    versions = {}
+    for i in count(1):
+        for attempt in range(3):
+            if attempt > 0:
+                time.sleep(5)
+            resp = requests.get(
+                f'https://release-monitoring.org/api/v2/packages/'
+                f'?distribution=Meson%20WrapDB'
+                f'&items_per_page={items_per_page}'
+                f'&page={i}'
+            )
+            # retry a few times on gateway timeout
+            if resp.status_code != 504:
+                resp.raise_for_status()
+                break
+        else:
+            raise Exception('Repeated gateway timeouts querying Anitya')
+        packages: AnityaPackageList = resp.json()
+        versions.update({
+            package['name']: package['stable_version']
+            for package in packages['items']
+        })
+        if len(packages['items']) < items_per_page:
+            break
+
+    def sub(name, old, new):
+        if name in versions:
+            versions[name] = re.sub(old, new, versions[name])
+    sub('icu', '-', '.')
+    sub('inih', '^', 'r')
+    sub('mt32emu', '_', '.')
+    sub('re2', '-', '')
+    return versions
+
+
+@cache
+def get_releases() -> dict[str, WrapInfo]:
+    '''Parse and return releases.json.'''
+    with open('releases.json') as f:
+        return json.load(f)
+
+
+def get_wrap_versions() -> dict[str, str]:
+    '''Return a dict: wrap_name -> wrapdb_version.'''
+    return {
+        name: info['versions'][0].split('-')[0]
+        for name, info in get_releases().items()
+        if name not in DEPRECATED_WRAPS
+    }
+
+
+def get_wrap_contents(name: str) -> ConfigParser:
+    '''Return a ConfigParser loaded with the specified wrap.'''
+    wrap = ConfigParser(interpolation=None)
+    wrap.read(f'subprojects/{name}.wrap', encoding='utf-8')
+    return wrap
+
+
+def get_port_wraps() -> set[str]:
+    '''Return the names of wraps that have a patch directory.'''
+    ports = set()
+    for name, info in get_releases().items():
+        wrap = get_wrap_contents(name)
+        if wrap.has_option('wrap-file', 'patch_directory'):
+            ports.add(name)
+    return ports
+
+
+def update_wrap(name: str, old_ver: str, new_ver: str) -> None:
+    '''Try to update the specified wrap file from old_ver to new_ver.'''
+
+    # read wrap file
+    filename = f'subprojects/{name}.wrap'
+    with open(filename) as f:
+        lines = f.readlines()
+
+    # update versions
+    # rewrite wrap manually to preserve comments and spacing
+    for i, line in enumerate(lines):
+        line = line.replace(old_ver, new_ver)
+        if old_ver.count('.') == 2 and new_ver.count('.') == 2:
+            # some projects use URLs like
+            # .../projname/2.60/projname-2.60.3.tar.gz
+            line = line.replace(
+                '.'.join(old_ver.split('.')[:2]),
+                '.'.join(new_ver.split('.')[:2])
+            )
+        if '=' in line:
+            k, v = line.split('=', 1)
+            if k.strip() == 'source_url':
+                source_url = v.strip()
+        lines[i] = line
+
+    # update source hash
+    resp = requests.get(source_url, stream=True)
+    resp.raise_for_status()
+    hash = sha256()
+    while True:
+        buf = resp.raw.read(1 << 20)
+        if not buf:
+            break
+        hash.update(buf)
+    for i, line in enumerate(lines):
+        if '=' in line:
+            k, v = line.split('=', 1)
+            if k.strip() == 'source_hash':
+                lines[i] = f'source_hash = {hash.hexdigest()}\n'
+                break
+
+    # write
+    with open(filename, 'w') as f:
+        f.write(''.join(lines))
+
+
+def do_autoupdate(args: Namespace) -> None:
+    # run queries
+    releases = get_releases()
+    cur_vers = get_wrap_versions()
+    upstream_vers = get_upstream_versions()
+    ports = get_port_wraps()
+
+    # decide what to update
+    names = args.names
+    if names:
+        for name in names:
+            if name not in upstream_vers:
+                raise ValueError(f'{name} is not tracked in Anitya; upstream version is unknown')
+            if name in ports:
+                raise ValueError(f'{name} upstream does not use Meson; cannot update automatically')
+    else:
+        names = [
+            name for name in cur_vers
+            if name not in ports and name in upstream_vers
+        ]
+
+    # update
+    failures = 0
+    for name in names:
+        cur_ver, upstream_ver = cur_vers[name], upstream_vers[name]
+        if cur_ver != upstream_ver:
+            try:
+                print(f'Updating {name}...')
+                update_wrap(name, cur_ver, upstream_ver)
+                releases[name]['versions'].insert(0, f'{upstream_ver}-1')
+                with open('releases.json.new', 'w') as f:
+                    json.dump(releases, f, indent=2, sort_keys=True)
+                    f.write('\n')
+                os.rename('releases.json.new', 'releases.json')
+            except Exception as e:
+                print(e, file=sys.stderr)
+                failures += 1
+    if failures:
+        raise Exception(f"Couldn't update {failures} wraps")
+
+
+def do_list(args: Namespace) -> None:
+    # set default flags
+    if not any((args.official, args.port)):
+        args.official = args.port = True
+    if not any((args.current, args.update, args.untracked)):
+        args.current = args.update = args.untracked = True
+
+    # build list
+    names = set(args.names)
+    cur_vers = get_wrap_versions()
+    upstream_vers = get_upstream_versions()
+    ports = get_port_wraps()
+    wraps = []
+    for name in cur_vers:
+        if names and name not in names:
+            # user isn't interested in this wrap
+            continue
+        if name in ports:
+            if not args.port:
+                continue
+        else:
+            if not args.official:
+                continue
+        if name in upstream_vers:
+            if cur_vers[name] == upstream_vers[name]:
+                if not args.current:
+                    continue
+            else:
+                if not args.update:
+                    continue
+        else:
+            if not args.untracked:
+                continue
+        wraps.append(name)
+
+    # report
+    if args.github:
+        print('matrix=', end='')
+        json.dump(
+            {
+                "include": [
+                    {
+                        'wrap': name,
+                        'old-version': cur_vers[name],
+                        'new-version': upstream_vers.get(name),
+                    } for name in wraps
+                ]
+            },
+            sys.stdout,
+        )
+        print()
+    elif args.json:
+        json.dump(
+            {
+                name: {
+                    'wrapdb': cur_vers[name],
+                    'upstream': upstream_vers.get(name),
+                    'port': name in ports,
+                    'source': get_wrap_contents(name).get(
+                        'wrap-file', 'source_url'
+                    )
+                } for name in wraps
+            }, sys.stdout, indent=2, sort_keys=True
+        )
+        print()
+    elif args.markdown:
+        print('| Type | Wrap | WrapDB Version | Upstream Version |')
+        print('| --- | --- | --- | --- |')
+        for name in wraps:
+            typ = ':construction:' if name in ports else ':bank:'
+            fname = f'[{name}]({WRAP_URL_TEMPLATE.format(name)})'
+            if name not in upstream_vers:
+                upstream_ver = '_unknown_'
+            elif cur_vers[name] != upstream_vers[name]:
+                upstream_ver = f'**{upstream_vers[name]}**'
+            else:
+                upstream_ver = upstream_vers[name]
+            print(
+                f'| {typ} | {fname} | {cur_vers[name]} | {upstream_ver} |'
+            )
+        if not wraps:
+            print('| _none_ | | | |')
+    else:
+        for name in wraps:
+            official = '*' if name not in ports else ' '
+            line = f'{official} {name:25} {cur_vers[name]:>15}'
+            if name not in upstream_vers:
+                line += '  =>|'
+            elif cur_vers[name] != upstream_vers[name]:
+                line += f'  => {upstream_vers[name]:>15}'
+            print(line)
+
+
+def main() -> None:
+    parser = ArgumentParser(
+        prog='versions.py',
+        description='Manage wrap versions.'
+    )
+    subparsers = parser.add_subparsers(metavar='subcommand', required=True)
+
+    autoupdate = subparsers.add_parser(
+        'autoupdate',
+        help='automatically update non-port wraps',
+        description='Attempt to automatically update wraps that support Meson upstream.'
+    )
+    autoupdate.add_argument(
+        'names', metavar='name', nargs='*', help='wrap to update'
+    )
+    autoupdate.set_defaults(func=do_autoupdate)
+
+    list = subparsers.add_parser(
+        'list',
+        help='list wraps and their versions',
+        description='List wraps and their versions.',
+    )
+    list.add_argument(
+        'names', metavar='name', nargs='*', help='wrap to check'
+    )
+    group = list.add_argument_group('filter on upstream Meson support')
+    group.add_argument(
+        '-o', '--official', action='store_true',
+        help='only list wraps with Meson support upstream'
+    )
+    group.add_argument(
+        '-p', '--port', action='store_true',
+        help='only list wraps with Meson support added in wrapdb'
+    )
+    group = list.add_argument_group('filter on update status')
+    group.add_argument(
+        '-c', '--current', action='store_true',
+        help='only list wraps without new upstream release'
+    )
+    group.add_argument(
+        '-u', '--update', action='store_true',
+        help='only list wraps with new upstream release'
+    )
+    group.add_argument(
+        '-x', '--untracked', action='store_true',
+        help='only list wraps whose upstream version is not tracked'
+    )
+    group = list.add_argument_group('output format')
+    xgroup = group.add_mutually_exclusive_group()
+    xgroup.add_argument(
+        '-g', '--github', action='store_true',
+        help='output GitHub Actions matrix'
+    )
+    xgroup.add_argument(
+        '-j', '--json', action='store_true', help='output JSON'
+    )
+    xgroup.add_argument(
+        '-m', '--markdown', action='store_true', help='output Markdown table'
+    )
+    list.set_defaults(func=do_list)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Use upstream release data from Anitya ([release-monitoring.org](https://release-monitoring.org/)).  Anitya has a database of known software projects, a polling mechanism for identifying new releases, and a mechanism to map downstream package names to Anitya-tracked projects.

I've [populated Anitya](https://release-monitoring.org/distro/Meson%20WrapDB/) with WrapDB package names (click the names in the package name column), manually verifying in each case that the Anitya project matches the software actually shipped in WrapDB.  In cases where Anitya doesn't know about a project, I have mostly not added a new record, and am not sure whether or not we should add records in all such cases.

With Anitya populated, we can query a single HTTPS endpoint to get the current versions of all our projects it knows about.

Add a tool to use this data.  It can:

* List wraps, their versions in WrapDB, and their versions upstream.  Command-line options can select ports with or without official Meson support upstream, ports with or without updates available, and ports where Anitya doesn't know the current upstream version (because Anitya doesn't know about the project or doesn't know it's packaged in WrapDB).

    <details>
    <summary><tt>tools/versions.py list</tt> (click for sample run)</summary>
    <pre>
    abseil-cpp                     20230802.1  =>      20240116.2
    arduinocore-avr                     1.8.2  =>           1.8.6
    argparse                              3.0
    argtable3                           3.2.2
  * argu-parser                         0.0.1  =>|
    asio                               1.30.2
    backward-cpp                          1.6  =>|
    bdwgc                               8.2.2  =>           8.2.6
  * blueprint-compiler                 0.10.0  =>          0.12.0
    box2d                               2.4.1
    bshoshany-thread-pool               4.1.0  =>|
    c-ares                             1.24.0  =>          1.31.0
  * c-flags                             1.5.8  =>|
  * cairo                              1.18.0
    catch                               2.2.2  =>         2.13.10
  * catch2                              3.6.0
    catchorg-clara                      1.1.5  =>|
    centurion                           7.3.0
    cereal                              1.3.2
  * cexception                          1.3.3  =>|
  * cglm                                0.9.2  =>           0.9.4
    check                              0.15.2
    chipmunk                            7.0.3
    cjson                              1.7.17  =>          1.7.18
  * cli11                               2.4.1  =>           2.4.2
    cmark-gfm                   0.29.0.gfm.13
  * cmock                               2.5.3  =>|
    cmocka                              1.1.7
    concurrentqueue                     1.0.3  =>           1.0.4
  * cpp-httplib                        0.15.3  =>          0.16.0
    cpp-semver                          0.3.3  =>|
    cpputest                              4.0
    cppzmq                             4.10.0
    cpr                                1.10.5
    croaring                            1.3.0  =>           4.0.0
    curl                                8.8.0
    cxxopts                             3.1.1  =>           3.2.1
    debug_assert                        1.3.3  =>           1.3.4
    directxmath                         3.1.9  =>|
    dlfcn-win32                         1.3.1  =>           1.4.1
    docopt                              0.6.3
  * doctest                            2.4.11
    dragonbox                           1.1.2  =>           1.1.3
    eigen                               3.4.0
    emilk-loguru                        2.1.0
    enet                               1.3.17  =>          1.3.18
    entt                               3.11.0  =>          3.13.2
  * epoxy                              1.5.10
  * exiv2                              0.28.1  =>          0.28.2
    expat                               2.6.0  =>           2.6.2
    facil                               0.7.6
    fdk-aac                             2.0.2  =>           2.0.3
    ff-nvcodec-headers               11.1.5.1  =>       12.2.72.0
    flac                                1.4.3
    flatbuffers                        24.3.6  =>         24.3.25
    fluidsynth                          2.3.3  =>           2.3.5
    fmt                                10.2.0  =>          10.2.1
  * fontconfig                         2.14.2  =>          2.15.0
    freeglut                            3.4.0  =>           3.6.0
  * freetype2                          2.13.2
  * fribidi                            1.0.13  =>          1.0.15
    frozen                              1.1.1
    ftxui                               5.0.0
    fuse                                2.9.9
    gdbm                                 1.23
  * gdk-pixbuf                        2.42.12
    gee                                0.20.6
    giflib                              5.2.2
    glbinding                           3.3.0  =>|
    glew                                2.2.0
    glfw                               3.3.10  =>             3.4
  * glib                               2.80.3
  * glib-networking                    2.78.0  =>          2.80.0
    glm                                 1.0.1
    godot-cpp                             4.2  =>           4.2.2
    google-benchmark                    1.8.4
    google-brotli                       1.1.0
    google-snappy                       1.1.9  =>           1.2.1
    google-woff2                        1.0.2
    graphite2                          1.3.14
    grpc                               1.59.1  =>          1.64.2
    gtest                              1.14.0
    gumbo-parser                       0.12.1  =>|
  * harfbuzz                            8.3.1  =>           8.5.0
    hedley                                 15
    hinnant-date                        3.0.1
    htslib                               1.17  =>            1.20
    icu                                  73.2  =>            75.1
    iir                                 1.9.3  =>           1.9.4
    imgui                              1.89.9  =>          1.90.8
    imgui-sfml                            2.6  =>|
    imguizmo                             1.83  =>|
    implot                               0.16
    indicators                            2.3  =>|
  * inih                                  r57  =>             r58
  * irepeat                               0.6  =>|
    jansson                              2.14
    jbig2dec                             0.20
    jbigkit                               2.1
    json-c                               0.17
  * json-glib                           1.6.6  =>    1.8.0-actual
  * jsoncpp                             1.9.5
    lame                                3.100
  * lcms2                                2.16
    leptonica                          1.84.1
    libarchive                          3.7.4
    libccp4c                            8.0.0  =>|
  * libdicom                            1.1.0
  * libdrm                            2.4.121
    libebml                             1.4.5
    libexif                            0.6.24
    libffi                              3.4.4  =>           3.4.6
    libffmpegthumbnailer                2.2.2
    libgpiod                            1.6.3  =>           2.1.2
    libjpeg-turbo                       3.0.3
    libkqueue                           2.6.2
    liblangtag                          0.6.7
  * liblastfm                           1.0.1  =>|
    liblbfgs                             1.10  =>|
  * libliftoff                          0.3.0  =>           0.5.0
    liblzma                            5.2.12  =>           5.6.2
    libmatroska                         1.7.1
    libmicrohttpd                      0.9.77  =>           1.0.1
  * libnpupnp                           6.1.2  =>           6.1.3
  * libobsd                             1.1.1  =>|
    libopenjp2                          2.5.2
    libpng                             1.6.43
  * libpsl                             0.21.5
    libsass                             3.6.4  =>           3.6.6
    libsignal-protocol-c                2.3.3
    libsndfile                          1.2.2
  * libsrtp2                            2.5.0  =>           2.6.0
    libssh2                            1.11.0
    libtiff                             4.6.0
    libtirpc                            1.3.3  =>           1.3.4
    libtomcrypt                        1.18.2
    libunibreak                           6.1
    libupnp                           1.14.19
    liburing                              2.5  =>             2.6
    libusb                             1.0.27
    libuv                              1.48.0
    libwebp                             1.3.2  =>           1.4.0
    libwebsockets                       4.3.3
    libxcursor                          1.2.1  =>           1.2.2
    libxext                             1.3.5  =>           1.3.6
    libxinerama                         1.1.4  =>           1.1.5
  * libxkbcommon                        1.7.0
  * libxml2                            2.13.1
  * libxmlpp                            5.2.0
    libxrandr                           1.5.2  =>           1.5.4
    libxrender                         0.9.10  =>          0.9.11
    libxslt                            1.1.39  =>          1.1.41
    libxv                              1.0.11  =>          1.0.12
    libxxf86vm                          1.1.4  =>           1.1.5
    libyaml                             0.2.5
    littlefs                            2.9.0  =>           2.9.3
    lmdb                               0.9.29  =>|
    lua                                 5.4.6  =>           5.4.7
    luajit                     2.1.1713773202  =>           2.0.5
    ludocode-mpack                        1.1  =>|
    lz4                                 1.9.4
    lzo2                                 2.10
    m4                                 1.4.19
  * magic_enum                          0.9.5
    mdds                                2.1.1
    microsoft-gsl                       4.0.0
    miniz                               3.0.2
    minizip-ng                          4.0.4  =>           4.0.7
    mocklibc                              1.0  =>|
    mpdecimal                           2.5.1  =>           4.0.0
    msgpackc-cxx                        6.1.1
    mt32emu                             2.7.1
    muellan-clipp                       1.2.3  =>|
    mujs                                1.3.3  =>           1.3.5
  * nanoarrow                           0.5.0
    nativefiledialog-extended           1.1.1  =>           1.2.0
    netstring-c                         0.0.0  =>|
    nghttp2                            1.58.0  =>          1.62.1
  * nlohmann_json                      3.11.2  =>          3.11.3
    nng                                 1.5.2  =>           1.8.0
    nonstd-any-lite                     0.2.0  =>|
    nonstd-byte-lite                    0.2.0  =>|
    nonstd-expected-lite                0.3.0  =>|
    nonstd-observer-ptr-lite            0.4.0  =>|
    nonstd-optional-lite                3.2.0  =>|
    nonstd-span-lite                    0.5.0  =>|
    nonstd-status-value-lite            1.1.0  =>|
    nonstd-string-view-lite             1.3.0  =>|
    nowide                             11.3.0  =>|
    oatpp                               1.3.0  =>    1.3.0-latest
    oatpp-openssl                       1.3.0  =>|
    oatpp-sqlite                        1.3.0  =>|
    oatpp-swagger                       1.3.0  =>|
    oatpp-websocket                     1.3.0  =>|
    oatpp-zlib                          1.3.0  =>|
    ogg                                 1.3.5
    openal-soft                        1.23.1
    opencl-headers                 2023.04.17  =>      2024.05.08
  * openh264                            2.3.1  =>           2.4.1
    openssl                             3.0.8  =>           3.3.1
  * opus                                  1.4  =>           1.5.2
    orcus                              0.19.2
    orocos_kdl                          1.5.1
  * pango                              1.51.0  =>          1.54.0
    pcg                                0.98.1
  * pciaccess                            0.18  =>          0.18.1
    pcre                                 8.45
    pcre2                               10.44
    physfs                              3.2.0
  * pixman                             0.43.4
  * pkgconf                             2.1.1  =>           2.2.0
    protobuf                             25.2  =>            27.1
    protobuf-c                          1.4.1  =>           1.5.0
  * proxy-libintl                         0.4
    pugixml                              1.14
    pv                                 1.8.10
    pybind11                           2.12.0
  * qarchive                            2.2.7  =>           2.2.9
    qrencode                            4.1.1
    quazip                                1.4
  * quill                               4.4.0  =>           4.4.1
    rang                                  3.2
    range-v3                           0.12.0
    rapidjson                           1.1.0
    rdkafka                             2.3.0  =>         2.4.0-3
    re2                              20230301  =>        20240601
    reflex                             3.2.11  =>           4.4.0
    robin-map                           1.2.1  =>           1.3.0
  * rtaudio                             6.0.1
  * rubberband                          2.0.2  =>           3.3.0
    rxcpp                               4.1.1  =>|
    sassc                               3.6.2
    sdl2                               2.30.3  =>          2.30.4
    sdl2_image                          2.6.3  =>           2.8.2
    sdl2_mixer                          2.6.2  =>           2.8.0
    sdl2_net                            2.2.0
    sdl2_ttf                           2.20.1  =>          2.22.0
    sds                                 2.0.0  =>|
    sergiusthebest-plog                1.1.10
    sfml                                2.6.1
    simdjson                            3.3.0  =>           3.9.4
  * slirp                               4.7.0  =>           4.8.0
    soundtouch                          2.3.2  =>           2.3.3
    sparsehash-c11                     2.11.1  =>|
    spdlog                             1.14.1
    speexdsp                            1.2.1
  * spng                                0.7.4
    sqlite3                            3.46.0
    sqlitecpp                           3.3.1
    sqlpp11                              0.64  =>|
    stduuid                             1.2.3
    tabulate                              1.5
    taglib                                2.0  =>           2.0.1
    tclap                               1.2.4  =>           1.2.5
    termbox                             1.1.2  =>|
    theora                              1.1.1
    tinyfsm                             0.3.3
    tinyply                             2.3.4
  * tinyxml2                           10.0.0
    tl-expected                         1.1.0
    tl-optional                         1.0.0  =>|
  * tomlplusplus                        3.4.0
  * tracy                                0.10
    tree-sitter                        0.22.5  =>          0.22.6
    trompeloeil                            47
    tronkko-dirent                     1.23.2  =>|
    turtle                              1.3.2
    type_safe                           0.2.3  =>|
    uchardet                            0.0.8
  * unit-system                         0.7.1  =>|
    unittest-cpp                        2.0.0
  * unity                               2.5.2  =>|
    utf8proc                            2.9.0
    utfcpp                              4.0.5
    uthash                              2.3.0
    vo-aacenc                           0.1.3
    vorbis                              1.3.7
    vulkan-headers                    1.3.283  =>         1.3.288
    vulkan-memory-allocator             3.1.0
    vulkan-validationlayers           1.2.158  =>         1.3.288
  * wayland                            1.20.0  =>          1.23.0
  * wayland-protocols                    1.35  =>            1.36
    websocketpp                         0.8.2
    wren                                0.4.0
    x-plane-sdk                         4.0.1  =>|
    xtensor                            0.21.5  =>          0.25.0
    xtl                                0.6.12  =>           0.7.7
    xxhash                              0.8.2
    yajl                                2.1.0
    zlib                                1.3.1
    zstd                                1.5.6</pre>
    </details>

* Attempt to update wraps automatically.  This only works for upstreams that support Meson directly, and may fail e.g. due to URL changes.

Add a semiweekly GitHub Actions workflow that submits individual PRs for wraps that can be autoupdated.  [Sample workflow run](https://github.com/bgilbert/wrapdb/actions/runs/9788938871).  (The wayland failure is fixed by #1554.)  [Sample PRs](https://github.com/bgilbert/wrapdb/pulls).

The update workflow doesn't run sanity checks on the updated wrap; it assumes PR CI will do that.  However, that means we can't use `GITHUB_TOKEN` to push the PR branches, since GitHub doesn't allow actions by the token to invoke other workflows.  This PR assumes the following workaround:

1. Create a `wrapdb-bot` GitHub account to hold the PR branches.  That account should not be given any special privileges on `mesonbuild/wrapdb`.  Fork `mesonbuild/wrapdb` into the bot account.
2. Create a Personal Access Token for the bot account and add it to `mesonbuild/wrapdb` as a GitHub Actions secret named `BOT_TOKEN`.
3. The `peter-evans/create-pull-request` Action will create PRs from the bot's fork, using the bot's access token.