### PR TITLE
ci: disable `fail-fast` option on VisualStudio matrix jobs

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -47,6 +47,7 @@ jobs:
   VisualStudio:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         platform: ['x64', 'x86']
     steps:


### PR DESCRIPTION
Rational: the failure modes are not always the same, and you end up wasting more CI resources if you need to trigger multiple builds because you were not aware of different issues.