### PR TITLE
sanity_checks: Also disable builds by CPU family

### DIFF
--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -335,19 +335,40 @@ class TestReleases(unittest.TestCase):
         self.assertTrue(version in source_url or version_ in source_url,
                         f'Version {version} not found in {source_url}')
 
+    @classmethod
+    def get_cpu_family(cls, builddir: str = '_build'):
+        if not hasattr(cls, "_cpu_family"):
+            options = ['-Dwraps=[]']
+            if Path(builddir, 'meson-private', 'cmd_line.txt').exists():
+                options.append('--wipe')
+            res = subprocess.run(['meson', 'setup', *options, builddir], check=True)
+            with Path(builddir, 'meson-logs', 'meson-log.txt').open() as log_f:
+                for line in log_f:
+                    if line.startswith('Host machine cpu family:'):
+                        cls._cpu_family = line.split(':', maxsplit=1)[1].strip()
+                        break
+                else:
+                    raise Exception('Unable to determine cpu family from Meson logs')
+        return cls._cpu_family
+
     def check_new_release(self, name: str, builddir: str = '_build', deps=None, progs=None):
         print() # Ensure output starts from an empty line (we're running under unittest).
         if is_msys():
             system = 'msys2'
         else:
             system = platform.system().lower()
+        cpu_family = self.get_cpu_family(builddir)
+        sys_cpu = f"{system}-{cpu_family}"
         ci = self.ci_config.get(name, {})
         # kept for backwards compatibility
         expect_working = True
+        build_on = ci.get('build_on', {})
         if ci.get('linux_only', False) and not is_linux():
             expect_working = False
-        elif not ci.get('build_on', {}).get(system, True):
-            expect_working = False
+        elif sys_cpu in build_on:
+            expect_working = bool(build_on[sys_cpu])
+        else:
+            expect_working = bool(build_on.get(system, True) and build_on.get(cpu_family, True))
 
         if deps:
             skip_deps = ci.get('skip_dependency_check', [])


### PR DESCRIPTION
In some cases the OS is not enough to determine if a build will succeed or fail, the CPU architecture may also change the result. This PR extends `tools/sanity_checks.py` to additionally consult the `host_machine.cpu_family()` (as determined by Meson), if either the system or CPU family is marked `false` the build is expected to fail, unless the composite `{system}-{cpu_family}` key is `true`. By example:

```json5
"wrap_name": {
  // Build expected to fail on Linux on any CPU, e.g. Linux + aarch64
  "build_on": {"linux": false},

  // Build expected to fail on x86_64 on any OS, e.g. Windows + x86_64
  "build_on": {"x86_64": false},

  // Build expected to fail on Linux on any CPU, and on x86_64 on any OS
  "build_on": {"linux": false, "x86_64": false},

  // Build expected to fail on Linux on any CPU, and on x86_64 on any OS,
  // except build expected to pass on Linux + x86_64
  "build_on": {"linux": false, "x86_64": false, "linux-x86_64": true},
}
```