### PR TITLE
bdwgc: provide dependency name used by many distros

### DIFF
--- a/subprojects/bdwgc.wrap
+++ b/subprojects/bdwgc.wrap
@@ -7,3 +7,4 @@ patch_directory = bdwgc
 
 [provide]
 gc = bdwgc_dep
+bdw-gc = bdwgc_dep


### PR DESCRIPTION
The pkg-config file for Boehm GC is typically `bdw-gc.pc`, so adding this will allow defaulting to the system libgc and only falling back if not present.