### PR TITLE
add new wrap: "pegtl"

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -773,6 +773,12 @@
       "windows": false
     }
   },
+  "pegtl": {
+    "build_options": [
+      "pegtl:tests=enabled",
+      "pegtl:examples=enabled"
+    ]
+  },
   "pixman": {
     "_comment": "Some tests takes more than 2min to complete.",
     "test_options": [

--- a/releases.json
+++ b/releases.json
@@ -2712,6 +2712,14 @@
       "10.23-1"
     ]
   },
+  "pegtl":{
+    "dependency_names": [
+      "pegtl"
+    ],
+    "versions": [
+      "3.2.7-1"
+    ]
+  },
   "physfs": {
     "dependency_names": [
       "physfs"

--- a/subprojects/packagefiles/pegtl/meson.build
+++ b/subprojects/packagefiles/pegtl/meson.build
@@ -1,0 +1,23 @@
+project(
+  'pegtl',
+  'cpp',
+  version: '3.2.7',
+  meson_version: '>=1.2.0',
+  default_options: {'cpp_std': 'c++17'},
+)
+
+pegtl_dep = declare_dependency(
+  include_directories: include_directories('include'),
+)
+
+meson.override_dependency('pegtl', pegtl_dep)
+
+is_subproject = meson.is_subproject()
+
+if get_option('tests').disable_auto_if(is_subproject).allowed()
+  subdir('src/test/pegtl')
+endif
+
+if get_option('examples').disable_auto_if(is_subproject).allowed()
+  subdir('src/example/pegtl')
+endif

--- a/subprojects/packagefiles/pegtl/meson.options
+++ b/subprojects/packagefiles/pegtl/meson.options
@@ -1,0 +1,12 @@
+option(
+    'tests',
+    type: 'feature',
+    value: 'auto',
+    description: 'Build test programs',
+)
+option(
+    'examples',
+    type: 'feature',
+    value: 'auto',
+    description: 'Build example programs',
+)

--- a/subprojects/packagefiles/pegtl/src/example/pegtl/meson.build
+++ b/subprojects/packagefiles/pegtl/src/example/pegtl/meson.build
@@ -1,0 +1,63 @@
+example_files = [
+  'abnf2pegtl.cpp',
+  'analyze.cpp',
+  'calculator.cpp',
+  'chomsky_hierarchy.cpp',
+  'csv1.cpp',
+  'csv2.cpp',
+  'dynamic_match.cpp',
+  'expression.cpp',
+  'hello_world.cpp',
+  'indent_aware.cpp',
+  'iri.cpp',
+  'json_analyze.cpp',
+  'json_ast.cpp',
+  'json_build.cpp',
+  'json_count.cpp',
+  'json_coverage.cpp',
+  'json_parse.cpp',
+  'json_print_debug.cpp',
+  'json_print_names.cpp',
+  'json_trace.cpp',
+  'lua53_analyze.cpp',
+  'lua53_parse.cpp',
+  'modulus_match.cpp',
+  'parse_tree.cpp',
+  'parse_tree_user_state.cpp',
+  'peg2pegtl.cpp',
+  'proto3.cpp',
+  'recover.cpp',
+  's_expression.cpp',
+  'sum.cpp',
+  'symbol_table.cpp',
+  'token_input.cpp',
+  'unescape.cpp',
+  'uri.cpp',
+  'uri_print_debug.cpp',
+  'uri_print_names.cpp',
+  'uri_trace.cpp',
+]
+
+args = []
+cpp = meson.get_compiler('cpp')
+
+if cpp.get_argument_syntax() == 'msvc'
+  args += cpp.get_supported_arguments('/W4', '/WX', '/utf-8')
+else
+  args += cpp.get_supported_arguments('-pedantic', '-Wall', '-Wextra', '-Wshadow', '-Werror')
+endif
+
+fs = import('fs')
+
+foreach file : example_files
+
+  name = fs.replace_suffix(file, '')
+
+  example_exe = executable(
+    name,
+    files(file),
+    dependencies: pegtl_dep,
+    cpp_args: args,
+  )
+
+endforeach

--- a/subprojects/packagefiles/pegtl/src/test/pegtl/meson.build
+++ b/subprojects/packagefiles/pegtl/src/test/pegtl/meson.build
@@ -1,0 +1,163 @@
+test_files = [
+  'action_enable.cpp',
+  'action_match.cpp',
+  'actions_one.cpp',
+  'actions_three.cpp',
+  'actions_two.cpp',
+  'argv_input.cpp',
+  'ascii_classes.cpp',
+  'ascii_eol.cpp',
+  'ascii_eolf.cpp',
+  'ascii_forty_two.cpp',
+  'ascii_identifier.cpp',
+  'ascii_istring.cpp',
+  'ascii_keyword.cpp',
+  'ascii_shebang.cpp',
+  'ascii_string.cpp',
+  'ascii_three.cpp',
+  'ascii_two.cpp',
+  'buffer_input.cpp',
+  'change_action_and_state.cpp',
+  'change_action_and_states.cpp',
+  'change_state.cpp',
+  'change_states.cpp',
+  'check_bytes.cpp',
+  'contains.cpp',
+  'contrib_alphabet.cpp',
+  'contrib_analyze.cpp',
+  'contrib_control_action.cpp',
+  'contrib_coverage.cpp',
+  'contrib_function.cpp',
+  'contrib_http.cpp',
+  'contrib_if_then.cpp',
+  'contrib_instantiate.cpp',
+  'contrib_integer.cpp',
+  'contrib_iri.cpp',
+  'contrib_json.cpp',
+  'contrib_parse_tree.cpp',
+  'contrib_parse_tree_to_dot.cpp',
+  'contrib_partial_trace.cpp',
+  'contrib_predicates.cpp',
+  'contrib_print.cpp',
+  'contrib_raw_string.cpp',
+  'contrib_remove_first_state.cpp',
+  'contrib_remove_last_states.cpp',
+  'contrib_rep_one_min_max.cpp',
+  'contrib_rep_string.cpp',
+  'contrib_separated_seq.cpp',
+  'contrib_state_control.cpp',
+  'contrib_to_string.cpp',
+  'contrib_trace1.cpp',
+  'contrib_trace2.cpp',
+  'contrib_unescape.cpp',
+  'contrib_uri.cpp',
+  'control_unwind.cpp',
+  'data_cstring.cpp',
+  'demangle.cpp',
+  'discard_input.cpp',
+  'enable_control.cpp',
+  'error_message.cpp',
+  'file_cstream.cpp',
+  'file_istream.cpp',
+  'icu_general.cpp',
+  'internal_endian.cpp',
+  'internal_file_mapper.cpp',
+  'internal_file_opener.cpp',
+  'limit_bytes.cpp',
+  'limit_depth.cpp',
+  'parse_error.cpp',
+  'pegtl_string_t.cpp',
+  'position.cpp',
+  'restart_input.cpp',
+  'rule_action.cpp',
+  'rule_apply0.cpp',
+  'rule_apply.cpp',
+  'rule_at.cpp',
+  'rule_bof.cpp',
+  'rule_bol.cpp',
+  'rule_bytes.cpp',
+  'rule_control.cpp',
+  'rule_disable.cpp',
+  'rule_discard.cpp',
+  'rule_enable.cpp',
+  'rule_eof.cpp',
+  'rule_failure.cpp',
+  'rule_if_apply.cpp',
+  'rule_if_must.cpp',
+  'rule_if_must_else.cpp',
+  'rule_if_then_else.cpp',
+  'rule_list.cpp',
+  'rule_list_must.cpp',
+  'rule_list_tail.cpp',
+  'rule_minus.cpp',
+  'rule_must.cpp',
+  'rule_not_at.cpp',
+  'rule_opt.cpp',
+  'rule_opt_must.cpp',
+  'rule_pad.cpp',
+  'rule_pad_opt.cpp',
+  'rule_plus.cpp',
+  'rule_raise.cpp',
+  'rule_rematch.cpp',
+  'rule_rep.cpp',
+  'rule_rep_max.cpp',
+  'rule_rep_min.cpp',
+  'rule_rep_min_max.cpp',
+  'rule_rep_opt.cpp',
+  'rule_require.cpp',
+  'rule_seq.cpp',
+  'rule_sor.cpp',
+  'rule_star.cpp',
+  'rule_star_must.cpp',
+  'rule_state.cpp',
+  'rule_success.cpp',
+  'rule_try_catch.cpp',
+  'rule_until.cpp',
+  'test_empty.cpp',
+  'test_result.cpp',
+  'test_setup.cpp',
+  'uint16_general.cpp',
+  'uint32_general.cpp',
+  'uint64_general.cpp',
+  'uint8_general.cpp',
+  'utf16_general.cpp',
+  'utf32_general.cpp',
+  'utf8_general.cpp',
+  'visit.cpp',
+]
+
+cpp = meson.get_compiler('cpp')
+
+# This tests only work on Windows when compiling with MSVC.
+if host_machine.system() != 'windows' or cpp.get_id() in ['clang-cl', 'msvc']
+  test_files += [
+    'file_file.cpp',
+    'file_mmap.cpp',
+    'file_read.cpp',
+  ]
+endif
+
+args = []
+
+if cpp.get_argument_syntax() == 'msvc'
+  args += cpp.get_supported_arguments('/W4', '/WX', '/utf-8')
+else
+  args += cpp.get_supported_arguments('-pedantic', '-Wall', '-Wextra', '-Wshadow', '-Werror')
+endif
+
+fs = import('fs')
+
+foreach file : test_files
+
+  name = fs.replace_suffix(file, '')
+
+  test_exe = executable(
+    name,
+    files(file),
+    dependencies: pegtl_dep,
+    cpp_args: args,
+  )
+
+  test(name, test_exe, workdir: meson.project_source_root())
+
+endforeach

--- a/subprojects/pegtl.wrap
+++ b/subprojects/pegtl.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = PEGTL-3.2.7
+source_url = https://github.com/taocpp/PEGTL/archive/refs/tags/3.2.7.tar.gz
+source_filename = PEGTL-3.2.7.tar.gz
+source_hash = d6cd113d8bd14e98bcbe7b7f8fc1e1e33448dc359e8cd4cca30e034ec2f0642d
+patch_directory = pegtl
+
+[provide]
+pegtl = pegtl_dep


### PR DESCRIPTION
This is a header only library, so nothing special, the rest is taken from their CMake build definitions (example and test build setup)

Per default tests and examples are only built, if NOT in a subproject, but since the CI executes this as a subproject, I enabled those two there. 
