### PR TITLE
Add tinyexpr mathematical expression parsing library

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -3391,6 +3391,14 @@
       "1.1.1-1"
     ]
   },
+  "tinyexpr": {
+    "dependency_names": [
+      "tinyexpr"
+    ],
+    "versions": [
+      "0.0.0-1"
+    ]
+  },
   "tinyfsm": {
     "dependency_names": [
       "tinyfsm"

--- a/subprojects/packagefiles/tinyexpr/meson.build
+++ b/subprojects/packagefiles/tinyexpr/meson.build
@@ -1,0 +1,21 @@
+project('tinyexpr', 'c',
+    version: '0.0.0',
+    default_options: ['c_std=c99']
+)
+
+cc = meson.get_compiler('c')
+m_dep = cc.find_library('m', required: false)
+
+tinyexpr_lib = library(
+    'tinyexpr',
+    'tinyexpr.c',
+    install: true,
+    dependencies: m_dep
+)
+
+depinc = include_directories('.')
+tinyexpr_dep = declare_dependency(
+    include_directories: depinc,
+    link_with: tinyexpr_lib,
+    dependencies: m_dep
+)

--- a/subprojects/tinyexpr.wrap
+++ b/subprojects/tinyexpr.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = tinyexpr-9907207e5def0fabdb60c443517b0d9e9d521393
+source_url = https://github.com/codeplea/tinyexpr/archive/9907207e5def0fabdb60c443517b0d9e9d521393.tar.gz
+source_filename = tinyexpr-9907207e5def0fabdb60c443517b0d9e9d521393.tar.gz
+source_hash = 897e32058491d3a74d79847d3405cb4bd2de877aa8657dafe9916b8fb915f34d
+patch_directory = tinyexpr
+
+[provide]
+tinyexpr = tinyexpr_dep


### PR DESCRIPTION
Links:
- https://github.com/codeplea/tinyexpr
- https://codeplea.com/tinyexpr


There aren't any releases of the library, so I've numbered it `0.0.0`. The library isn't updated very often as it is mostly complete so I don't think this will be a problem going into the future.