### PR TITLE
sanity_checks: add support for installing Python packages

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -151,14 +151,18 @@ jobs:
           fetch-depth: 0
 
       - run: brew update
-      # github actions overwrites brew's python. Force it to reassert itself, by running in a separate step.
-      - name: unbreak python in github actions
-        run: |
-          find $(brew --prefix)/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
-          sudo rm -rf /Library/Frameworks/Python.framework/
-          brew install --force --quiet python3 && brew unlink python3 && brew unlink python3 && brew link --overwrite python3
-          # Work around PEP 668 nonsense…
-          find $(brew --prefix)/Cellar/python* -name EXTERNALLY-MANAGED -print0 | xargs -0 rm -vf
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - run: |
+          set -x
+          which python
+          python --version
+          which python3
+          python --version
+
       - name: Install packages
         run: |
           brew install ninja

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -56,16 +56,12 @@ jobs:
           fetch-depth: 0
 
       # Install a 32-bit Python so building related stuff work.
-      - name: Setup x86 Python (1/2)
+      - name: Setup x86 Python
         if: matrix.platform == 'x86'
         uses: actions/setup-python@v5
         with:
           architecture: 'x86'
           python-version: '3.12'
-      - name: Setup x86 Python (2/2)
-        if: matrix.platform == 'x86'
-        # Note: GLib needs `packaging`.
-        run: python -m pip install packaging
 
       # https://github.com/actions/runner-images/issues/5459#issuecomment-1532856844
       - name: Remove bad Strawberry Perl patch binary in search path

--- a/ci_config.json
+++ b/ci_config.json
@@ -260,8 +260,8 @@
     "alpine_packages": [
       "shared-mime-info"
     ],
-    "msys_packages": [
-      "python-packaging"
+    "python_packages": [
+      "packaging"
     ],
     "fatal_warnings": false,
     "skip_tests": true
@@ -334,14 +334,11 @@
     "alpine_packages": [
       "gettext-tiny-dev"
     ],
-    "brew_packages": [
-      "python-packaging"
-    ],
     "build_options": [
       "glib:tests=false"
     ],
-    "msys_packages": [
-      "python-packaging"
+    "python_packages": [
+      "packaging"
     ],
     "skip_dependency_check": [
       "gio-windows-2.0",
@@ -393,8 +390,10 @@
       "harfbuzz:icu=enabled"
     ],
     "msys_packages": [
-      "icu",
-      "python-packaging"
+      "icu"
+    ],
+    "python_packages": [
+      "packaging"
     ],
     "skip_dependency_check": [
       "harfbuzz-cairo"


### PR DESCRIPTION
In preparation for Homebrew disabling `python-packaging`:

> python-packaging has been deprecated! It will be disabled on 2024-10-05.

Cf. https://github.com/Homebrew/homebrew-core/issues/157500
