### PR TITLE
Provide nlohmann/json dependency with multiple headers

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -2469,9 +2469,11 @@
   },
   "nlohmann_json": {
     "dependency_names": [
-      "nlohmann_json"
+      "nlohmann_json",
+      "nlohmann_json_multiple_headers"
     ],
     "versions": [
+      "3.11.3-2",
       "3.11.3-1",
       "3.11.2-1",
       "3.10.5-1",

--- a/subprojects/nlohmann_json.wrap
+++ b/subprojects/nlohmann_json.wrap
@@ -8,3 +8,4 @@ source_hash = a22461d13119ac5c78f205d3df1db13403e58ce1bb1794edc9313677313f4a9d
 
 [provide]
 nlohmann_json = nlohmann_json_dep
+nlohmann_json_multiple_headers = nlohmann_json_multiple_headers


### PR DESCRIPTION
meson.build of nlohmann/json contains additional dependency with multiple headers, instead of single one. This PR allows wrapDB users to use it.

Multiple headers are useful eg. if you want to forward-declare nlohmann::json object  (see `json_fwd.hpp`).