### PR TITLE
Stop disabling fatal warnings for Wayland

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -1051,8 +1051,7 @@
   },
   "wayland": {
     "_comment": [
-      "- relies on Linux-specific APIs",
-      "- uses install_data() without install_dir"
+      "- relies on Linux-specific APIs"
     ],
     "alpine_packages": [
       "python3-dev"
@@ -1064,8 +1063,7 @@
     },
     "build_options": [
       "wayland:documentation=false"
-    ],
-    "fatal_warnings": false
+    ]
   },
   "wayland-protocols": {
     "_comment": "- relies on wayland-scanner which uses Linux-specific APIs",


### PR DESCRIPTION
Wayland 1.23.1 [fixes the warning](https://gitlab.freedesktop.org/wayland/wayland/-/commit/cc34a7a4f1d720498ef2b3b62a113d818d4141a7) that this option suppressed in the past.