### PR TITLE
tools/versions: quality-of-life improvements

### DIFF
--- a/tools/versions.py
+++ b/tools/versions.py
@@ -325,6 +325,7 @@ def main() -> None:
 
     autoupdate = subparsers.add_parser(
         'autoupdate',
+        aliases=['au'],
         help='automatically update non-port wraps',
         description='Attempt to automatically update wraps that support Meson upstream.'
     )
@@ -335,6 +336,7 @@ def main() -> None:
 
     list = subparsers.add_parser(
         'list',
+        aliases=['ls'],
         help='list wraps and their versions',
         description='List wraps and their versions.',
     )

--- a/tools/versions.py
+++ b/tools/versions.py
@@ -215,6 +215,14 @@ def do_autoupdate(args: Namespace) -> None:
                     print(f'Updating {name}...')
                 update_wrap(name, cur_ver, upstream_ver)
                 releases[name]['versions'].insert(0, f'{upstream_ver}-1')
+            elif name in ports and args.revision:
+                # only allow for ports, since official wraps can't have
+                # downstream changes
+                print(f'Updating {name} revision...')
+                cur_rev = int(releases[name]['versions'][0].split('-')[1])
+                releases[name]['versions'].insert(
+                    0, f'{cur_vers[name]}-{cur_rev + 1}'
+                )
             else:
                 continue
 
@@ -341,6 +349,10 @@ def main() -> None:
     autoupdate.add_argument(
         '-p', '--port', action='store_true',
         help='allow updating wraps with Meson support added in wrapdb'
+    )
+    autoupdate.add_argument(
+        '-r', '--revision', action='store_true',
+        help="update port's revision if version is current"
     )
     autoupdate.set_defaults(func=do_autoupdate)
 

--- a/tools/versions.py
+++ b/tools/versions.py
@@ -206,8 +206,8 @@ def do_autoupdate(args: Namespace) -> None:
     failures = 0
     for name in names:
         cur_ver, upstream_ver = cur_vers[name], upstream_vers[name]
-        if cur_ver != upstream_ver:
-            try:
+        try:
+            if cur_ver != upstream_ver:
                 if name in ports:
                     # manual packagefiles changes will also be needed
                     print(f'Updating {name}.wrap and releases.json...')
@@ -215,13 +215,16 @@ def do_autoupdate(args: Namespace) -> None:
                     print(f'Updating {name}...')
                 update_wrap(name, cur_ver, upstream_ver)
                 releases[name]['versions'].insert(0, f'{upstream_ver}-1')
-                with open('releases.json.new', 'w') as f:
-                    json.dump(releases, f, indent=2, sort_keys=True)
-                    f.write('\n')
-                os.rename('releases.json.new', 'releases.json')
-            except Exception as e:
-                print(e, file=sys.stderr)
-                failures += 1
+            else:
+                continue
+
+            with open('releases.json.new', 'w') as f:
+                json.dump(releases, f, indent=2, sort_keys=True)
+                f.write('\n')
+            os.rename('releases.json.new', 'releases.json')
+        except Exception as e:
+            print(e, file=sys.stderr)
+            failures += 1
     if failures:
         raise Exception(f"Couldn't update {failures} wraps")
 


### PR DESCRIPTION
- Add short subcommand aliases: `au` for `autoupdate`, `ls` for `list`
- Add `autoupdate -p|--port` option to update ports (wraps with downstream packagefiles).  The packagefiles will need manual changes, so don't allow this by default, but it's useful to provide a command for automatically handling the `<port>.wrap` and `releases.json` portions of the update.
- Add `autoupdate -r|--revision` option to update the revision number of an otherwise-current port, since it's a common operation that's trivial to automate.