### PR TITLE
mockcpp: add `mockcpp` C/C++ test framework (git-master)

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -2372,6 +2372,11 @@
       "3.0.6-1"
     ]
   },
+  "mockcpp": {
+    "versions": [
+      "git-master"
+    ]
+  },
   "mocklibc": {
     "versions": [
       "1.0-2"

--- a/subprojects/mockcpp.wrap
+++ b/subprojects/mockcpp.wrap
@@ -1,0 +1,10 @@
+[wrap-git]
+method = cmake
+; directory = mockcpp-head
+url = https://github.com/sinojelly/mockcpp.git
+revision = head
+depth = 1
+
+[provide]
+; mockcpp = mockcpp_static_dep
+mockcpp = mockcpp_dep


### PR DESCRIPTION
Add the `mockcpp` C/C++ test framework.

mockcpp is a jmock-like generic C/C++ Mock Framework, which doesn't use complex template technique which will result in very heavy compiling overhead.

https://github.com/sinojelly/mockcpp