### PR TITLE
concurrentqueue: update to 1.0.4

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -447,6 +447,7 @@
       "concurrentqueue"
     ],
     "versions": [
+      "1.0.4-1",
       "1.0.3-1"
     ]
   },

--- a/subprojects/concurrentqueue.wrap
+++ b/subprojects/concurrentqueue.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
-directory = concurrentqueue-1.0.3
-source_url = https://github.com/cameron314/concurrentqueue/archive/refs/tags/v1.0.3.tar.gz
-source_filename = concurrentqueue-1.0.3.tar.xz
-source_hash = eb37336bf9ae59aca7b954db3350d9b30d1cab24b96c7676f36040aa76e915e8
+directory = concurrentqueue-1.0.4
+source_url = https://github.com/cameron314/concurrentqueue/archive/refs/tags/v1.0.4.tar.gz
+source_filename = concurrentqueue-1.0.4.tar.xz
+source_hash = 87fbc9884d60d0d4bf3462c18f4c0ee0a9311d0519341cac7cbd361c885e5281
 patch_directory = concurrentqueue
 
 [provide]

--- a/subprojects/packagefiles/concurrentqueue/meson.build
+++ b/subprojects/packagefiles/concurrentqueue/meson.build
@@ -3,12 +3,11 @@ project(
     'concurrentqueue',
     ['cpp'],
     # Dual licensing
-    license: ['symplified-BSD', 'Boost 1.0'],
-    version: '1.0.3',
+    license: ['BSD-2-Clause', 'BSL-1.0'],
+    version: '1.0.4',
 )
 
 concurrentqueue_dep = declare_dependency(
-
     # it should be better if it was in a subdirectory
     # like moodycamel/ConcurrentQueue
     include_directories: [include_directories('.')],


### PR DESCRIPTION
Use SPDX license identifiers.