### PR TITLE
CI: use macos-latest

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -154,7 +154,7 @@ jobs:
 
   MacOS:
     if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
-    runs-on: ${{ matrix.platform == 'arm64' && 'macos-14' || 'macos-12' }}
+    runs-on: ${{ matrix.platform == 'arm64' && 'macos-14' || 'macos-13' }}
     env:
       TEST_BUILD_ALL: 1
       TEST_FATAL_WARNINGS: ${{ github.event.inputs.fatal_warnings }}

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -140,7 +140,7 @@ jobs:
           python tools/sanity_checks.py
 
   MacOS:
-    runs-on: ${{ matrix.platform == 'arm64' && 'macos-14' || 'macos-12' }}
+    runs-on: ${{ matrix.platform == 'arm64' && 'macos-14' || 'macos-13' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
12 is deprecated and it seems Homebrew removed bottles, forcing compilation of everything, slowing CI down massively.