### PR TITLE
Downgrade Ubuntu for Alpine

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -25,7 +25,7 @@ jobs:
           ./tools/fake_tty.py ./tools/sanity_checks.py
 
   Alpine:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         platform: ['x86', 'riscv64', 'ppc64le', 'armv7']


### PR DESCRIPTION
It seems on update of ubuntu latest to ubuntu 24.04, it broke Alpine.