### PR TITLE
CI: Alpine: Be explicit about clang

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -41,6 +41,9 @@ jobs:
             binutils clang libc-dev fortify-headers make patch cmake git linux-headers pkgconf py3-pip samurai sudo
 
       - name: Sanity Checks
+        env:
+          CC: clang
+          CXX: clang++
         run: |
           # Work around PEP 668 nonsense…
           sudo rm -vf /usr/lib*/python3.*/EXTERNALLY-MANAGED


### PR DESCRIPTION
clang++ gets used as g++ is missing whereas gcc is present. Just override.