### PR TITLE
Add meson.build format check in ci

### DIFF
--- a/.github/workflows/format-meson.yml
+++ b/.github/workflows/format-meson.yml
@@ -1,0 +1,19 @@
+name: Check meson.build Format
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  format-meson:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Meson
+        run: pip install git+https://github.com/mesonbuild/meson
+
+      - name: Format Checks
+        run: python ./tools/run_meson_fmt.py --check

--- a/tools/run_meson_fmt.py
+++ b/tools/run_meson_fmt.py
@@ -1,0 +1,66 @@
+"""
+format or check all meson.build file in projects
+
+arguments:
+
+--check: do check without formatting
+--dirty: do not format/check all files, only process files changed (only valid in git repo)
+"""
+
+import sys
+import shlex
+import pathlib
+import subprocess
+from shutil import which
+from itertools import chain
+
+is_check = "--check" in sys.argv
+only_dirty = "--dirty" in sys.argv
+
+meson = which("meson")
+if not meson:
+    print("failed to find meson")
+    sys.exit(1)
+
+base_command = [meson, "fmt", "--editor-config"]
+if is_check:
+    base_command.append("--check-only")
+else:
+    base_command.append("--inplace")
+
+project_root = pathlib.Path(__file__).parent.parent
+
+
+def get_file_list_from_git(cmd):
+    out = subprocess.check_output(
+        cmd,
+        cwd=str(project_root),
+    )
+    return [
+        project_root.joinpath(file)
+        for file in out.decode().splitlines()
+        if file.endswith("meson.build")
+    ]
+
+
+if only_dirty:
+    all_meson_files = get_file_list_from_git(shlex.split("git diff --name-only HEAD"))
+else:
+    all_meson_files = sorted(
+        chain(
+            [project_root.joinpath("meson.build")],
+            project_root.glob("subprojects/packagefiles/**/meson.build"),
+        )
+    )
+
+for i, meson_file in enumerate(all_meson_files):
+    readable_filename = meson_file.relative_to(project_root).as_posix()
+    print("processing {}/{}: {}".format(i + 1, len(all_meson_files), readable_filename))
+    try:
+        subprocess.check_call(base_command + [str(meson_file)], cwd=str(project_root))
+    except subprocess.CalledProcessError as e:
+        if is_check:
+            print("{} is not formatted".format(readable_filename))
+            sys.exit(e.returncode)
+        else:
+            print("failed to format {}".format(readable_filename))


### PR DESCRIPTION
maybe part of #1807

Add a script to format all `meson.build` files with `meson fmt -e`  and with `--check` flags to check then in CI.

This new CI job currently failed because we need to format all `meson.build` file first, which will make this PR hard to review so I didn't do it.

it will take 1-3 minutes to format all files

```text
time python .\tools\run_meson_fmt.py
00:00:53.7844648
```
