### PR TITLE
CI: Alpine: Don't fail all jobs if one fails; run containers on Ubuntu 24.04

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -25,7 +25,7 @@ jobs:
           ./tools/fake_tty.py ./tools/sanity_checks.py
 
   Alpine:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -27,6 +27,7 @@ jobs:
   Alpine:
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         platform: ['x86', 'riscv64', 'ppc64le', 'armv7']
     steps:


### PR DESCRIPTION
If there's a common-mode failure, `fail-fast: false` wastes CI resources, since emulated builds may take significant time.  However, if failures are specific to particular architectures, it's useful to know that.

`jirutka/setup-alpine@v1.3.0` fixes compatibility with Ubuntu 24.04.