### PR TITLE
CI: add Ubuntu aarch64

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -13,10 +13,13 @@ on:
 jobs:
   Ubuntu:
     if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     env:
       TEST_BUILD_ALL: 1
       TEST_FATAL_WARNINGS: ${{ github.event.inputs.fatal_warnings }}
+    strategy:
+      matrix:
+        platform: ['x86_64', 'aarch64']
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -8,7 +8,10 @@ concurrency:
 
 jobs:
   Ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    strategy:
+      matrix:
+        platform: ['x86_64', 'aarch64']
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Until now, we've only tested aarch64 on macOS.

https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/