### PR TITLE
CI: Don't cancel sanity checks upon push to a different branch

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -3,7 +3,7 @@ name: Sanity checks
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
`github.head_ref` is only defined for pull requests, not for pushes, so pushes to different branches within a repo would cancel each other's CI runs.  That wouldn't have affected mesonbuild/wrapdb, but in forked repos it made it hard to test multiple branches at once without creating PRs. Switch to `github.ref`, which has the desired semantics and is valid for both pull requests and pushes.