### PR TITLE
CI: Alpine improvements

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -37,10 +37,16 @@ jobs:
 
   Alpine:
     if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    strategy:
+      matrix:
+        platform: ['x86_64', 'aarch64']
     steps:
       - uses: jirutka/setup-alpine@v1
         with:
+          # next two lines: https://github.com/jirutka/setup-alpine/pull/22
+          arch: ${{ matrix.platform }}
+          apk-tools-url: ${{ matrix.platform == 'aarch64' && 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/aarch64/apk.static#!sha256!27a975638ddc95a411c9f17c63383e335da9edf6bb7de2281d950c291a11f878' || 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/x86_64/apk.static#!sha256!bdd044e0fd6cc388c5e571e1093efa5f35f7767cc5aa338b0a2576a429009a62' }}
           packages: >
             binutils clang libc-dev fortify-headers make patch cmake git linux-headers pkgconf py3-pip samurai sudo
 

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -28,7 +28,7 @@ jobs:
           ./tools/fake_tty.py ./tools/sanity_checks.py
 
   Alpine:
-    runs-on: ubuntu-latest
+    runs-on: ${{ startsWith(matrix.platform, 'x86') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +40,9 @@ jobs:
 
       - uses: jirutka/setup-alpine@v1
         with:
-          arch: ${{matrix.platform}}
+          arch: ${{ matrix.platform }}
+          # https://github.com/jirutka/setup-alpine/pull/22
+          apk-tools-url: ${{ startsWith(matrix.platform, 'x86') && 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/x86_64/apk.static#!sha256!bdd044e0fd6cc388c5e571e1093efa5f35f7767cc5aa338b0a2576a429009a62' || 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/aarch64/apk.static#!sha256!27a975638ddc95a411c9f17c63383e335da9edf6bb7de2281d950c291a11f878' }}
           packages: >
             binutils clang libc-dev fortify-headers make patch cmake git linux-headers pkgconf py3-pip samurai sudo
 

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ['x86', 'riscv64', 'ppc64le', 'armv7']
+        platform: ['x86_64', 'x86', 'aarch64', 'armv7', 'riscv64', 'ppc64le']
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
ff119ca60184 dropped Alpine sanity checks on x86_64 and did not add aarch64.  Both architectures are tested elsewhere, but it's useful to be able to do side-by-side comparisons if a build fails only on some arches.  Add x86_64 and aarch64 to Alpine sanity checks.

Use aarch64 runners for non-x86 Alpine.  They can run aarch64 natively (and also armv7 when setup-alpine supports it), and also execute CPU emulation faster than the x86_64 runners.

Add Alpine aarch64 to `build_all` workflow.