### PR TITLE
CI: disable `fail-fast` for Ubuntu sanity check jobs

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -10,6 +10,7 @@ jobs:
   Ubuntu:
     runs-on: ${{ matrix.platform == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
+      fail-fast: false
       matrix:
         platform: ['x86_64', 'aarch64']
     steps:


### PR DESCRIPTION
Allow one Ubuntu job to run to completion if the other fails, as we do for the other job types.