### PR TITLE
CI: Run Alpine armv7 job on aarch64 without CPU emulation

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -47,6 +47,11 @@ jobs:
           packages: >
             binutils clang libc-dev fortify-headers make patch cmake git linux-headers pkgconf py3-pip samurai sudo
 
+      # https://github.com/jirutka/setup-alpine/pull/22
+      - name: Disable QEMU emulation
+        if: matrix.platform == 'armv7'
+        run: sudo update-binfmts --disable qemu-arm
+
       - name: Sanity Checks
         env:
           CC: clang


### PR DESCRIPTION
Until setup-alpine supports this directly, we can undo its binfmt_misc configuration so builds run natively.