### PR TITLE
spdlog wrap: Option to disable installation of headers.

### DIFF
--- a/subprojects/packagefiles/spdlog/meson.build
+++ b/subprojects/packagefiles/spdlog/meson.build
@@ -51,15 +51,17 @@ else
 endif
 
 # install header and pkg-config file
-install_subdir('include/spdlog', install_dir: get_option('includedir'))
-pkg = import('pkgconfig')
-pkg.generate(
-  name: 'libspdlog',
-  filebase: 'spdlog',
-  description: 'Fast C++ logging library.',
-  url: 'https://github.com/gabime/spdlog',
-  libraries: [spdlog_dep, fmt_dep],
-  extra_cflags: spdlog_compile_args,
-)
+if get_option('install_spdlog')
+    install_subdir('include/spdlog', install_dir: get_option('includedir'))
+    pkg = import('pkgconfig')
+    pkg.generate(
+    name: 'libspdlog',
+    filebase: 'spdlog',
+    description: 'Fast C++ logging library.',
+    url: 'https://github.com/gabime/spdlog',
+    libraries: [spdlog_dep, fmt_dep],
+    extra_cflags: spdlog_compile_args,
+    )
+endif
 
 subdir('tests')

--- a/subprojects/packagefiles/spdlog/meson_options.txt
+++ b/subprojects/packagefiles/spdlog/meson_options.txt
@@ -1,5 +1,6 @@
 option('tests', type: 'feature', description: 'Build the unit tests')
 
 option('compile_library', type: 'boolean', value: false, description: 'Builds a static/shared lib for faster compile times')
+option('install_spdlog', type: 'boolean', value: true, description: 'Whether or not to install spdlog headers and pkg-config file')
 option('external_fmt', type: 'feature', description: 'Builds with external fmt lib instead of internal')
 option('std_format', type: 'feature', description: 'Use std::format instead of internal fmt lib')


### PR DESCRIPTION
Added a meson option to specify whether or not to install headers.

Installing headers and pkg-config files is not always wanted, especially as spdlog is naturally used as a subproject. After compilation, one does not need the header files anymore, except when compiling spdlog as a shared library.

This patch adds an option to disable installation, but does not change the current default behaviour. The current CMAKE build file of spdlog currently contains this option as well, so it only makes sense to replicate it.