### PR TITLE
cxxopts: make install optional

### DIFF
--- a/subprojects/packagefiles/cxxopts/meson.build
+++ b/subprojects/packagefiles/cxxopts/meson.build
@@ -4,13 +4,17 @@ project('cxxopts',
     license : 'MIT'
 )
 
-install_headers('include/cxxopts.hpp')
+install = get_option('install')
 
-pkgc = import('pkgconfig')
-pkgc.generate(name: 'cxxopts',
-    version: meson.project_version(),
-    description: 'Lightweight C++ command line option parser'
-)
+if install
+  install_headers('include/cxxopts.hpp')
+
+  pkgc = import('pkgconfig')
+  pkgc.generate(name: 'cxxopts',
+      version: meson.project_version(),
+      description: 'Lightweight C++ command line option parser'
+  )
+endif
 
 cxxopts_dep = declare_dependency(
     include_directories : include_directories('include')

--- a/subprojects/packagefiles/cxxopts/meson_options.txt
+++ b/subprojects/packagefiles/cxxopts/meson_options.txt
@@ -1,0 +1,6 @@
+option(
+  'install',
+  type: 'boolean',
+  value: 'true',
+  description: 'install cxxopts.hpp to prefix'
+)


### PR DESCRIPTION
When using a header-only library such as cxxopts, it shouldn't be required for it to be installed to the system. I primarily oriented myself wrt. the `header-only` option of `fmt.wrap`.