### PR TITLE
Add libaegis-0.4.0 to wrapdb

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -501,6 +501,12 @@
       "--timeout-multiplier=2"
     ]
   },
+  "libaegis": {
+    "_comment": "Fails in only VisualStudio-clang-cl. Reporting to upstream",
+    "build_on": {
+      "windows": false
+    }
+  },
   "libdrm": {
     "_comment": "- relies on Linux and BSD specific APIs",
     "build_on": {

--- a/releases.json
+++ b/releases.json
@@ -1619,6 +1619,14 @@
       "1.83.1-1"
     ]
   },
+  "libaegis": {
+    "dependency_names": [
+      "libaegis"
+    ],
+    "versions": [
+      "0.4.0-1"
+    ]
+  },
   "libarchive": {
     "dependency_names": [
       "libarchive"

--- a/subprojects/libaegis.wrap
+++ b/subprojects/libaegis.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = libaegis-0.4.0
+source_url = https://github.com/aegis-aead/libaegis/archive/refs/tags/0.4.0.tar.gz
+source_filename = libaegis-0.4.0.tar.gz
+source_hash = bf8d363edc28b9969e9d0decc41b41f818461136619652b1a977c8afa9b81363
+patch_directory = libaegis
+
+[provide]
+libaegis = libaegis_dep

--- a/subprojects/packagefiles/libaegis/meson.build
+++ b/subprojects/packagefiles/libaegis/meson.build
@@ -1,0 +1,70 @@
+project(
+  'libaegis',
+  'c',
+  version: '0.4.0',
+  license: 'MIT',
+)
+
+libaegis_sources = files(
+    'src/aegis128l/aegis128l_aesni.c',
+    'src/aegis128l/aegis128l_altivec.c',
+    'src/aegis128l/aegis128l_armcrypto.c',
+    'src/aegis128l/aegis128l_soft.c',
+    'src/aegis128l/aegis128l.c',
+
+    'src/aegis128x2/aegis128x2_aesni.c',
+    'src/aegis128x2/aegis128x2_altivec.c',
+    'src/aegis128x2/aegis128x2_avx2.c',
+    'src/aegis128x2/aegis128x2_armcrypto.c',
+    'src/aegis128x2/aegis128x2_soft.c',
+    'src/aegis128x2/aegis128x2.c',
+
+    'src/aegis128x4/aegis128x4_aesni.c',
+    'src/aegis128x4/aegis128x4_altivec.c',
+    'src/aegis128x4/aegis128x4_avx2.c',
+    'src/aegis128x4/aegis128x4_avx512.c',
+    'src/aegis128x4/aegis128x4_armcrypto.c',
+    'src/aegis128x4/aegis128x4_armcrypto.c',
+    'src/aegis128x4/aegis128x4_soft.c',
+    'src/aegis128x4/aegis128x4.c',
+
+    'src/aegis256/aegis256_aesni.c',
+    'src/aegis256/aegis256_altivec.c',
+    'src/aegis256/aegis256_armcrypto.c',
+    'src/aegis256/aegis256_soft.c',
+    'src/aegis256/aegis256.c',
+
+    'src/aegis256x2/aegis256x2_aesni.c',
+    'src/aegis256x2/aegis256x2_altivec.c',
+    'src/aegis256x2/aegis256x2_avx2.c',
+    'src/aegis256x2/aegis256x2_armcrypto.c',
+    'src/aegis256x2/aegis256x2_soft.c',
+    'src/aegis256x2/aegis256x2.c',
+    'src/aegis256x4/aegis256x4_aesni.c',
+    'src/aegis256x4/aegis256x4_altivec.c',
+    'src/aegis256x4/aegis256x4_avx2.c',
+    'src/aegis256x4/aegis256x4_avx512.c',
+    'src/aegis256x4/aegis256x4_armcrypto.c',
+    'src/aegis256x4/aegis256x4_soft.c',
+    'src/aegis256x4/aegis256x4.c',
+
+    'src/common/common.c',
+    'src/common/cpu.c',
+    'src/common/softaes.c',
+)
+
+libaegis_headers = [
+    include_directories('src/include'),
+]
+
+libaegis_lib = library(
+    'aegis',
+    libaegis_sources,
+    include_directories: libaegis_headers,
+)
+
+libaegis_dep = declare_dependency(
+    include_directories: libaegis_headers,
+    link_with: libaegis_lib,
+)
+


### PR DESCRIPTION
This adds a wrap for libaegis, from https://github.com/aegis-aead/libaegis:

> Portable C implementations of the [AEGIS](https://datatracker.ietf.org/doc/draft-irtf-cfrg-aegis-aead/) family of high-performance authenticated ciphers (AEGIS-128L, AEGIS-128X2, AEGIS-128X4, AEGIS-256, AEGIS-256X2, AEGIS-256X4), with runtime CPU detection.

Which is basically AES-GCM but 5x faster than even openssl's implementation.