### PR TITLE
sanity_checks: instruct users to run meson format with `-c meson.format`

### DIFF
--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -505,7 +505,7 @@ class TestReleases(unittest.TestCase):
             self.fail(
                 f'''Not formatted files found: {unformatted_str}
 Run the following command to format these files:
-meson format --inplace {unformatted_files_for_command}''')
+meson format --configuration meson.format --inplace {unformatted_files_for_command}''')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Otherwise they'll use the wrong formatting rules.