### PR TITLE
add win-iconv wrap

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -1308,6 +1308,14 @@
       "wayland:dtd_validation=false"
     ]
   },
+  "win-iconv": {
+    "_comment": "- Requires Windows",
+    "build_on": {
+      "alpine": false,
+      "darwin": false,
+      "linux": false
+    }
+  },
   "x-plane-sdk": {
     "build_options": [
       "x-plane-sdk:cpp=enabled"

--- a/releases.json
+++ b/releases.json
@@ -4064,6 +4064,17 @@
       "0.8.2-1"
     ]
   },
+  "win-iconv": {
+    "dependency_names": [
+      "iconv"
+    ],
+    "program_names": [
+      "win_iconv"
+    ],
+    "versions": [
+      "0.0.8-1"
+    ]
+  },
   "wren": {
     "dependency_names": [
       "wren"

--- a/subprojects/packagefiles/win-iconv/meson.build
+++ b/subprojects/packagefiles/win-iconv/meson.build
@@ -1,0 +1,60 @@
+project(
+  'win-iconv',
+  'c',
+  version: '0.0.8',
+  meson_version: '>=0.54.0',
+)
+
+if host_machine.system() != 'windows'
+  error(
+    'win-iconv is only supported on windows, and not supported on ' + host_machine.system(),
+  )
+endif
+
+default_libiconv_dll = get_option('default_libiconv_dll')
+
+c_args = [
+  '-D_CRT_SECURE_NO_WARNINGS',
+  '-DUSE_LIBICONV_DLL',
+  '-DDEFAULT_LIBICONV_DLL="' + default_libiconv_dll + '"',
+]
+
+c_lib_args = []
+
+if get_option('default_library') == 'both'
+  error('default_library=both is not supported')
+elif get_option('default_library') == 'shared'
+  c_lib_args += '-DMAKE_DLL'
+endif
+
+src_files = files('win_iconv.c')
+
+iconv_lib = library(
+  'iconv',
+  src_files,
+  c_args: c_args + c_lib_args,
+  vs_module_defs: 'iconv.def',
+  install: true,
+)
+
+win_iconv_dep = declare_dependency(
+  include_directories: include_directories('.'),
+  link_with: iconv_lib,
+)
+
+meson.override_dependency('iconv', win_iconv_dep)
+
+win_iconv = executable(
+  'win_iconv',
+  src_files,
+  c_args: c_args + ['-DMAKE_EXE'],
+  install: true,
+)
+meson.override_find_program('win_iconv', win_iconv)
+
+install_headers('iconv.h')
+
+if get_option('tests')
+  win_iconv_test_exe = executable('win_iconv_test', files('win_iconv_test.c'))
+  test('win_iconv_test', win_iconv_test_exe)
+endif

--- a/subprojects/packagefiles/win-iconv/meson_options.txt
+++ b/subprojects/packagefiles/win-iconv/meson_options.txt
@@ -1,0 +1,13 @@
+option(
+    'tests',
+    type: 'boolean',
+    value: true,
+    description: 'build tests',
+)
+
+option(
+    'default_libiconv_dll',
+    type: 'string',
+    value: '',
+    description: 'comma-separated list of iconv DLLs to try loading at runtime, e.g. "iconv.dll,libiconv.dll"',
+)

--- a/subprojects/win-iconv.wrap
+++ b/subprojects/win-iconv.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = win-iconv-0.0.8
+source_url = https://github.com/win-iconv/win-iconv/archive/refs/tags/v0.0.8.tar.gz
+source_filename = win-iconv-0.0.8.tar.gz
+source_hash = 23adea990a8303c6e69e32a64a30171efcb1b73824a1c2da1bbf576b0ae7c520
+patch_directory = win-iconv
+
+[provide]
+dependency_names = iconv
+program_names = win_iconv


### PR DESCRIPTION
See https://github.com/mesonbuild/wrapdb/pull/2044#issuecomment-2802862225 😄 

The latest release is quite old, the diff between then and now has a few changes :(
[see here](https://github.com/win-iconv/win-iconv/compare/v0.0.8...master)
(ref https://github.com/win-iconv/win-iconv/issues/43)
Edit: 0.0.9 released, I will add that later, once this PR is merged

Note: after this PR we can remove all occurrences of `libxml2:iconv=disabled` in the ci_config, as `iconv` can be found on Windows.

~~Question: Why is the ci_config settings not working? Why are non-windows ci jobs not skipped?~~
I should just read the entire log 🤦🏼‍♂️ 