### PR TITLE
sanity_checks: auto-disable fatal warnings if CMake warning is in logs

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -806,11 +806,9 @@
     "skip_tests": true
   },
   "minizip-ng": {
-    "_comment": "Fatal warnings disabled because CMake is unhappy: https://github.com/mesonbuild/meson/pull/14216",
     "build_options": [
       "minizip-ng:tests=enabled"
-    ],
-    "fatal_warnings": false
+    ]
   },
   "mpdecimal": {
     "build_options": [

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -144,6 +144,7 @@ PER_PROJECT_PERMITTED_FILES = {
 FORMAT_CHECK_FILES = ['meson.build', 'meson_options.txt', 'meson.options']
 NO_TABS_FILES = ['meson.build', 'meson_options.txt', 'meson.options']
 PERMITTED_KEYS = {'versions', 'dependency_names', 'program_names'}
+IGNORE_SETUP_WARNINGS = re.compile(r"CMake reported that the package [^ ]+ was not found, even though Meson's preliminary check succeeded.")
 
 
 class TestReleases(unittest.TestCase):
@@ -373,7 +374,8 @@ class TestReleases(unittest.TestCase):
         options = ['-Dpython.install_env=auto', f'-Dwraps={name}']
         options.append('-Ddepnames={}'.format(','.join(deps or [])))
         options.append('-Dprognames={}'.format(','.join(progs or [])))
-        if ci.get('fatal_warnings', expect_working) and self.fatal_warnings:
+        fatal_warnings = ci.get('fatal_warnings', expect_working) and self.fatal_warnings
+        if fatal_warnings:
             options.append('--fatal-meson-warnings')
         options += [f'-D{o}' for o in ci.get('build_options', [])]
         if Path(builddir, 'meson-private', 'cmd_line.txt').exists():
@@ -416,12 +418,23 @@ class TestReleases(unittest.TestCase):
         if python_packages:
             install_packages('Python', [sys.executable, '-m', 'pip', 'install'], python_packages)
 
-        res = subprocess.run(['meson', 'setup', builddir] + options, env=meson_env)
-        log_file = Path(builddir, 'meson-logs', 'meson-log.txt')
-        logs = log_file.read_text(encoding='utf-8')
-        if is_ci():
-            with ci_group('==== meson-log.txt ===='):
-                print(logs)
+        def do_setup(builddir, options, meson_env):
+            res = subprocess.run(['meson', 'setup', builddir] + options, env=meson_env)
+            log_file = Path(builddir, 'meson-logs', 'meson-log.txt')
+            logs = log_file.read_text(encoding='utf-8')
+            if is_ci():
+                with ci_group('==== meson-log.txt ===='):
+                    print(logs)
+            return res, logs
+        res, logs = do_setup(builddir, options, meson_env)
+        if res.returncode != 0 and fatal_warnings and IGNORE_SETUP_WARNINGS:
+            match = IGNORE_SETUP_WARNINGS.search(logs)
+            if match:
+                print(f'\nFound spurious warning: "{match.group(0)}"')
+                print('Rerunning setup without --fatal-meson-warnings.\n')
+                options.remove('--fatal-meson-warnings')
+                res, logs = do_setup(builddir, options, meson_env)
+
         if res.returncode == 0:
             if not expect_working:
                 raise Exception(f'Wrap {name} successfully configured but was expected to fail')


### PR DESCRIPTION
New Meson releases sometimes add dubious warnings that break existing packages built with `--fatal-meson-warnings`, which is the WrapDB default. Add a mechanism to detect when setup fails on a warning that matches a regex and automatically rerun setup without `--fatal-meson-warnings`.  This is a large hammer, but allows us to continue making forward progress in this repo while fixes percolate into Meson.

For now, match the new warning in 1.7.1+ that triggers if CMake is used to detect a dependency when the `Find*.cmake` file is shipped with CMake itself and the dependency is not available.  This shouldn't be fatal, and in fact it triggers even for optional dependencies.