### PR TITLE
CI: don't run sanity checks when tags are pushed

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -1,6 +1,9 @@
 name: Sanity checks
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: ['*']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
We already weren't running sanity checks on new tags in `mesonbuild/wrapdb` because the tags are created automatically by a workflow, so GitHub's recursion avoidance doesn't start the checks.  However, when manually testing changes in a fork, it's necessary to keep the fork's tags up-to-date to prevent sanity checks from testing all untagged wrap updates, but pushing tags to the fork would start CI on each of them.

Avoid this by running sanity checks only on pull requests and branch pushes.  This change only affects new tags created after this commit, not older tags which are later pushed to a fork.