### PR TITLE
sdl3_image patch: adding missing 'IMG.c' to img_src files

### DIFF
--- a/subprojects/packagefiles/sdl3_image/src/meson.build
+++ b/subprojects/packagefiles/sdl3_image/src/meson.build
@@ -1,4 +1,5 @@
 img_src = files(
+  'IMG.c',
   'IMG_avif.c',
   'IMG_bmp.c',
   'IMG_gif.c',


### PR DESCRIPTION
'IMG.c' was missing from the img_src files, so some functions like `IMG_Load` were missing