### PR TITLE
backward: Add dependency to just grab header

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -192,9 +192,11 @@
   },
   "backward-cpp": {
     "dependency_names": [
-      "backward-cpp"
+      "backward-cpp",
+      "backward-cpp-interface"
     ],
     "versions": [
+      "1.6-6",
       "1.6-5",
       "1.6-4",
       "1.6-3",

--- a/subprojects/backward-cpp.wrap
+++ b/subprojects/backward-cpp.wrap
@@ -8,3 +8,4 @@ patch_directory = backward-cpp
 
 [provide]
 backward-cpp = backward_dep
+backward-cpp-interface = backward_interface_dep

--- a/subprojects/packagefiles/backward-cpp/meson.build
+++ b/subprojects/packagefiles/backward-cpp/meson.build
@@ -25,35 +25,23 @@ dwarf = dependency(
 )
 
 deps = []
-
+args = []
 # stack walking
 if libunwind.found()
   deps += libunwind
-  add_project_arguments(
-    '-DBACKWARD_HAS_LIBUNWIND=1',
-    language: 'cpp',
-  )
+  args += ['-DBACKWARD_HAS_LIBUNWIND=1']
 endif
 
 # stack detail extraction
 if dw.found()
   deps += dw
-  add_project_arguments(
-    '-DBACKWARD_HAS_DW=1',
-    language: 'cpp',
-  )
+  args += ['-DBACKWARD_HAS_DW=1']
 elif dwarf.found()
   deps += dwarf
-  add_project_arguments(
-    '-DBACKWARD_HAS_DWARF=1',
-    language: 'cpp',
-  )
+  args += ['-DBACKWARD_HAS_DWARF=1']
 elif bfd.found()
   deps += bfd
-  add_project_arguments(
-    '-DBACKWARD_HAS_BFD=1',
-    language: 'cpp',
-  )
+  args += ['-DBACKWARD_HAS_BFD=1']
   if host_machine.system() != 'windows'
     if meson.version().version_compare('>= 0.62')
       deps += dependency('dl')
@@ -75,6 +63,7 @@ if host_machine.system() == 'windows'
     'backward.cpp',
     dependencies: deps,
     install: true,
+    cpp_args: args,
   )
 else
   backward = library(
@@ -82,11 +71,18 @@ else
     'backward.cpp',
     dependencies: deps,
     install: true,
+    cpp_args: args,
   )
 endif
 
-backward_dep = declare_dependency(
+backward_interface_dep = declare_dependency(
+  include_directories: include_directories('.'),
   dependencies: deps,
+  compile_args: args,
+)
+
+backward_dep = declare_dependency(
+  dependencies: backward_interface_dep,
   link_with: backward,
 )
 
@@ -118,6 +114,7 @@ if meson.project_version() != '1.6' or host_machine.cpu_family() not in [
         'testexe_' + test,
         'test/' + test + '.cpp',
         'test/_test_main.cpp',
+        cpp_args: args,
       ),
     )
   endforeach


### PR DESCRIPTION
backward-cpp distributes a a header-only library in addition to the module. The header-only library can be useful as a standalone dependency, especially on systems where the module may be difficult to compile (i.e. Windows)

https://github.com/bombela/backward-cpp?tab=readme-ov-file#installation