### PR TITLE
sanity_checks: in PR CI, avoid tag check racing with tag creation

### DIFF
--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -177,14 +177,14 @@ class TestReleases(unittest.TestCase):
     fatal_warnings: bool
     releases: dict[str, ReleasesProject]
     skip: list[str]
-    tags: list[str]
+    tags: set[str]
     timeout_multiplier: float
 
     @classmethod
     def setUpClass(cls):
         # Take list of git tags
         stdout = subprocess.check_output(['git', 'tag'])
-        cls.tags = [t.strip() for t in stdout.decode().splitlines()]
+        cls.tags = {t.strip() for t in stdout.decode().splitlines()}
 
         try:
             fn = 'releases.json'

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -182,9 +182,13 @@ class TestReleases(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        # Take list of git tags
-        stdout = subprocess.check_output(['git', 'tag'])
+        # Take list of git tags.  Ignore tags unreachable from HEAD so we
+        # don't fail on tags created after the branch was pushed.
+        stdout = subprocess.check_output(['git', 'tag', '--merged'])
         cls.tags = {t.strip() for t in stdout.decode().splitlines()}
+        stdout = subprocess.check_output(['git', 'tag', '--no-merged'])
+        if stdout.strip():
+            print(f'Ignoring unreachable tags: {stdout.decode().splitlines()}')
 
         try:
             fn = 'releases.json'


### PR DESCRIPTION
`test_releases_json` validates that all existing tags are mentioned in `releases.json`.  This ensures PRs don't mangle or remove old `releases.json` entries, but poses the potential for races in CI.  We don't want PR CI to fail because of a newly-created tag the PR branch doesn't know about.

If a PR is created from a stale branch, this doesn't cause a problem. `actions/checkout` checks out a synthetic merge commit against the current master branch, so the `releases.json` seen by `sanity_checks.py` includes any newly-tagged versions even if the PR branch does not.  Likewise, if a tag is created after `actions/checkout` runs, the CI job doesn't see the new tag, so there's no problem.

However, if a tag is created *after* the synthetic merge commit but *before* a job runs `actions/checkout`, that job's `test_releases_json` will fail.  This is annoying because merging a PR breaks any pending CI for other PRs.  Each PR today runs 15 CI jobs, we only get 20 concurrent slots, we have some slow emulated-CPU jobs, and wrapdb-bot tends to submit multiple PRs at once, so it's not uncommon to have pending jobs in the queue.

Avoid the race by checking for a synthetic merge commit and comparing its timestamp to the committer timestamp for each tagged commit.  (We can't compare to the tag timestamp because lightweight tags don't have those.) If a tagged commit is newer than the synthetic merge commit, don't require that tag to be mentioned in `releases.json`.