### PR TITLE
tools/versions: add command to commit wrap changes with automatic log

### DIFF
--- a/tools/versions.py
+++ b/tools/versions.py
@@ -242,6 +242,13 @@ def do_autoupdate(args: Namespace) -> None:
         raise Exception(f"Couldn't update {failures} wraps")
 
 
+def do_libtool_ver(args: Namespace) -> None:
+    components = args.info.split(':', 2)
+    components += ['0'] * (3 - len(components))
+    current, revision, age = (int(c) for c in components)
+    print(f'{current - age}.{age}.{revision}')
+
+
 def do_list(args: Namespace) -> None:
     # set default flags
     if not any((args.official, args.port)):
@@ -335,13 +342,6 @@ def do_list(args: Namespace) -> None:
             print(line)
 
 
-def do_libtool_ver(args: Namespace) -> None:
-    components = args.info.split(':', 2)
-    components += ['0'] * (3 - len(components))
-    current, revision, age = (int(c) for c in components)
-    print(f'{current - age}.{age}.{revision}')
-
-
 def main() -> None:
     parser = ArgumentParser(
         prog='versions.py',
@@ -367,6 +367,17 @@ def main() -> None:
         help="update port's revision if version is current"
     )
     autoupdate.set_defaults(func=do_autoupdate)
+
+    libtool_ver = subparsers.add_parser(
+        'libtool-ver',
+        aliases=['ltv'],
+        help='calculate library version from libtool version-info',
+        description='Calculate library version number from libtool version-info.',
+    )
+    libtool_ver.add_argument(
+        'info', metavar='version-info', help='libtool current:revision:age'
+    )
+    libtool_ver.set_defaults(func=do_libtool_ver)
 
     list = subparsers.add_parser(
         'list',
@@ -412,17 +423,6 @@ def main() -> None:
         '-m', '--markdown', action='store_true', help='output Markdown table'
     )
     list.set_defaults(func=do_list)
-
-    libtool_ver = subparsers.add_parser(
-        'libtool-ver',
-        aliases=['ltv'],
-        help='calculate library version from libtool version-info',
-        description='Calculate library version number from libtool version-info.',
-    )
-    libtool_ver.add_argument(
-        'info', metavar='version-info', help='libtool current:revision:age'
-    )
-    libtool_ver.set_defaults(func=do_libtool_ver)
 
     args = parser.parse_args()
     args.func(args)


### PR DESCRIPTION
For version bumps, autogenerate the commit message.  For other wrap changes, require a manually-specified commit message but prepend the wrap name.  (Less useful, but perhaps has some value.)  In all cases, commit only those files that might be relevant.