### PR TITLE
Remove unnecessary subproject variables inside meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ project(
 wraps = get_option('wraps')
 
 foreach w : wraps
-  sub = subproject(w)
+  subproject(w)
 endforeach
 
 foreach name : get_option('depnames')


### PR DESCRIPTION
I'm not sure if it's wright, sanity checks passes - original commit that added this variable was later removed https://github.com/mesonbuild/wrapdb/commit/db21541a5afcaa5daed94c3264c1b12fc4eeb37d