### PR TITLE
cmocka: remove unused variable

### DIFF
--- a/subprojects/packagefiles/cmocka/meson.build
+++ b/subprojects/packagefiles/cmocka/meson.build
@@ -188,7 +188,7 @@ if machine.endian() == 'big'
   config.set('WORDS_BIGENDIAN', 1)
 endif
 
-cfile = configure_file(
+configure_file(
   input: 'config.h.cmake',
   output: 'config.h',
   format: 'cmake',


### PR DESCRIPTION
Remove the variable `cfile` because it is unused.