### PR TITLE
wayland-protocols: avoid CI failures for unsupported platforms

### DIFF
--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -511,9 +511,16 @@ class TestReleases(unittest.TestCase):
             if expect_working:
                 res.check_returncode()
             else:
-                if 'unsupported' in error or 'not supported' in error or 'does not support' in error:
-                    print('unsupported, as expected')
-                    return
+                for msg in [
+                    'unsupported',
+                    'not supported',
+                    'does not support',
+                    # wayland-protocols upstream
+                    'SFD_CLOEXEC is needed to compile Wayland libraries',
+                ]:
+                    if msg in error:
+                        print('unsupported, as expected')
+                        return
                 if 'ERROR: Could not execute Vala compiler: valac' in error:
                     print('cannot verify in wrapdb due to missing dependency')
                     return


### PR DESCRIPTION
Upstream has a custom error message for this.  Add it to the detection list.