### PR TITLE
Require valid license declaration for updated projects in this repo

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y install build-essential python3-pip ninja-build
+          python3 -m pip install license-expression
           python3 -m pip install --pre meson
 
       - name: Sanity Checks
@@ -62,6 +63,7 @@ jobs:
         run: |
           # Work around PEP 668 nonsense…
           sudo rm -vf /usr/lib*/python3.*/EXTERNALLY-MANAGED
+          python -m pip install license-expression
           python -m pip install --pre meson
           if grep -q qemu /proc/$$/cmdline; then
               export TEST_TIMEOUT_MULTIPLIER=10
@@ -95,6 +97,7 @@ jobs:
 
       - name: Install packages
         run: |
+          python -m pip install license-expression
           python -m pip install --pre meson
 
       - uses: ilammy/msvc-dev-cmd@v1
@@ -117,6 +120,7 @@ jobs:
 
       - name: Install packages
         run: |
+          python -m pip install license-expression
           python -m pip install --pre meson
 
       - uses: ilammy/msvc-dev-cmd@v1
@@ -159,6 +163,7 @@ jobs:
       - name: Install packages
         shell: msys2 {0}
         run: |
+          python -m pip install license-expression
           python -m pip install --pre meson
 
       - name: Sanity Checks
@@ -186,6 +191,7 @@ jobs:
       - name: Install packages
         run: |
           brew install ninja
+          python3 -m pip install license-expression
           python3 -m pip install --pre meson
 
       - name: Sanity Checks

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -233,7 +233,7 @@ class TestReleases(unittest.TestCase):
 
         return None
 
-    def check_meson_version(self, name: str, version: str, patch_path: str, builddir: str = '_build'):
+    def check_meson_version(self, name: str, version: str, patch_path: str | None, builddir: str = '_build') -> None:
         with self.subTest(step="check_meson_version"):
             json_file = Path(builddir) / "meson-info/intro-projectinfo.json"
             # don't check if the build was skipped

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -329,6 +329,8 @@ class TestReleases(unittest.TestCase):
                             with self.subTest(f'If this works now, please remove it from broken_{platform.system().lower()}!'):
                                 self.assertNotIn(name, self.skip)
                             self.check_meson_version(name, ver, patch_path)
+                            if patch_path:
+                                self.check_license(Path('subprojects') / wrap_section['directory'])
                     else:
                         with self.subTest(step='version is tagged'):
                             self.assertIn(t, self.tags)
@@ -570,6 +572,34 @@ class TestReleases(unittest.TestCase):
             ]
         )
         return res.returncode == 0
+
+    def check_license(self, dir: Path) -> None:
+        with self.subTest(step='check_license'):
+            try:
+                project_json = subprocess.check_output(
+                    ['meson', 'rewrite', 'kwargs', 'info', 'project', '/'],
+                    cwd=dir, text=True, stderr=subprocess.DEVNULL
+                )
+            except subprocess.CalledProcessError:
+                # rewriter fails if any compilers are missing; ignore
+                return
+            project = json.loads(project_json)['kwargs']['project#/']
+            self.assertIn('license', project)  # project must specify license
+            self.assertIs(type(project['license']), str)  # license must not use legacy list syntax
+
+            try:
+                import license_expression  # type: ignore[import-untyped]
+            except ImportError:
+                print('\nno license_expression library; skipping SPDX validation')
+                return
+            try:
+                license_expression.get_spdx_licensing().parse(
+                    project['license'], validate=True, strict=True
+                )
+            except license_expression.ExpressionParseError as exc:
+                raise Exception('Invalid license expression; see https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/') from exc
+            except license_expression.ExpressionError as exc:
+                raise Exception('Invalid license; see https://spdx.org/licenses/') from exc
 
     def check_files(self, subproject: str, patch_path: Path) -> None:
         tabs: list[Path] = []


### PR DESCRIPTION
WrapDB includes a lot of projects with missing license declarations or invalid SPDX expressions.  Projects with upstream Meson configs have a longer fix cycle, so it'd be too painful to fail CI on invalid licenses, but for downstream Meson configs we can certainly require fixes when wraps are updated.

`meson-info` doesn't mention the licenses of subprojects, but we can extract that information from the rewriter, if it is working.  (Extraction fails if the Meson requests a compiler that isn't installed.)

Use the [license-expression](https://pypi.org/project/license-expression/) library, if installed, to validate the SPDX expression.  Install it in every sanity-check job since we don't know which jobs will successfully run the rewriter.

Of course, CI can't force the license declaration to be _correct_, but then again, upstream may not have it right either.