### PR TITLE
ci: report any `ci_config.json` stanzas as workflow annotations

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -184,7 +184,7 @@ jobs:
 
       - name: Install packages
         run: |
-          brew install ninja
+          brew install --quiet ninja
           python3 -m pip install git+https://github.com/mesonbuild/meson
 
       - name: Sanity Checks

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -190,7 +190,7 @@ jobs:
 
       - name: Install packages
         run: |
-          brew install ninja
+          brew install --quiet ninja
           python3 -m pip install license-expression
           python3 -m pip install --pre meson
 

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -29,6 +29,8 @@ jobs:
           python3 -m pip install --pre meson
 
       - name: Sanity Checks
+        env:
+          TEST_ANNOTATE_CONTEXT: ${{ matrix.platform == 'x86_64' && 'yes' || 'no' }}
         run: |
           ./tools/fake_tty.py ./tools/sanity_checks.py
 

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -187,6 +187,7 @@ class TestReleases(unittest.TestCase):
     # requires casts for special keys e.g. broken_*
     ci_config: dict[str, CiConfigProject]
     fatal_warnings: bool
+    annotate_context: bool
     releases: dict[str, ReleasesProject]
     skip: list[str]
     tags: set[str]
@@ -215,6 +216,7 @@ class TestReleases(unittest.TestCase):
         system = platform.system().lower()
         cls.skip = T.cast(T.List[str], cls.ci_config[f'broken_{system}'])
         cls.fatal_warnings = os.environ.get('TEST_FATAL_WARNINGS', 'yes') == 'yes'
+        cls.annotate_context = os.environ.get('TEST_ANNOTATE_CONTEXT') == 'yes'
         cls.timeout_multiplier = float(os.environ.get('TEST_TIMEOUT_MULTIPLIER', 1))
 
     def test_releases_json(self):
@@ -435,6 +437,9 @@ class TestReleases(unittest.TestCase):
             system = platform.system().lower()
         ci = self.ci_config.get(name, {})
         expect_working = ci.get('build_on', {}).get(system, True)
+
+        if ci and self.annotate_context:
+            print(f'::notice title={name} config::' + json.dumps(ci, indent=2).replace('\n', '%0A'))
 
         if deps:
             skip_deps = ci.get('skip_dependency_check', [])


### PR DESCRIPTION
The annotations appear on the workflow summary screen and look like this by default:

![image](https://github.com/user-attachments/assets/cf15b1bc-177a-4236-a306-09b691b151cb)

and expanded:

![image](https://github.com/user-attachments/assets/45076b0a-3df1-48cf-b18c-abf1b24de236)

Also, avoid spurious Homebrew annotations:

![image](https://github.com/user-attachments/assets/6abade2f-287a-4533-a605-fd98c2cefb03)
