### PR TITLE
ci: determine minimum Meson version and annotate diff

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -34,6 +34,14 @@ jobs:
         run: |
           ./tools/fake_tty.py ./tools/sanity_checks.py
 
+      - name: Report Meson version dependencies
+        if: matrix.platform == 'x86_64'
+        continue-on-error: true
+        env:
+          TEST_MESON_VERSION_DEPS: 1
+        run: |
+          ./tools/fake_tty.py ./tools/sanity_checks.py TestReleases.test_meson_version_deps
+
   Alpine:
     runs-on: ${{ startsWith(matrix.platform, 'x86') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     strategy:

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -780,6 +780,11 @@ meson format --configuration meson.format --inplace {unformatted_files_for_comma
                     raise Exception('Did not find end of feature version report')
                 break
 
+        default_options = self.get_default_options(project_args)
+        for opt in 'c_std', 'cpp_std':
+            if opt in default_options:
+                features.setdefault('0.63.0', []).append(f'{opt} in subproject default_options')
+
         versions = sorted(
             features, key=lambda ver: tuple(int(c) for c in ver.split('.'))
         )

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -631,8 +631,7 @@ class TestReleases(unittest.TestCase):
                     raise Exception('Invalid license; see https://spdx.org/licenses/') from exc
 
         with self.subTest(step='check_default_options'):
-            for opt in project.get('default_options', []):
-                name, _ = opt.split('=', 1)
+            for name in self.get_default_options(project):
                 # Before Meson 1.8 these were ignored in subproject
                 # default_options, and in any case it's not clear that wraps
                 # should have an opinion about them.  We don't check for all
@@ -645,6 +644,16 @@ class TestReleases(unittest.TestCase):
                             'strip',
                             'unity'}:
                     raise Exception(f'{name} is not permitted in default_options')
+
+    def get_default_options(self, project: dict[str, T.Any]) -> dict[str, str]:
+        opts = project.get('default_options')
+        if not opts:
+            return {}
+        elif isinstance(opts, dict):
+            return opts
+        elif isinstance(opts, str):
+            opts = [opts]
+        return dict(opt.split('=', 1) for opt in opts)
 
     def check_files(self, subproject: str, patch_path: Path) -> None:
         tabs: list[Path] = []


### PR DESCRIPTION
After sanity checks run, put `meson_version: '>=0'` into the `project()` call of any updated downstream wrap, rerun `meson setup`, collect the new-feature warnings, and add them to an annotation on the `meson_version` argument (or on `project()` if none).  Make the annotation a notice if the Meson dependency matches what we expect and a warning otherwise.  Also explicitly check for `c_std` or `cpp_std` in `default_options`, which requires Meson &ge; 0.63.

To avoid duplicate annotations we can only do this in one CI job, so pick Ubuntu x86_64.  That platform should be compatible with most wraps; only two have `"linux": false` in `ci_config.json`.

Don't fail CI if the Meson dependency doesn't match or if the check fails. Failures can occur due to rewriter limitations, and a wrap might need a newer Meson for platform-specific code, build options we don't test, or reasons unknown to `FeatureNew`.  For now this is just a review aid.

The resulting annotations look like this:

![image](https://github.com/user-attachments/assets/bd80fa7e-917c-43cd-a8e2-dcae0b58924e)

Also fix `default_options` checks when the `default_options` argument is not a list.