### PR TITLE
Add Apache ORC wrap

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -23,6 +23,14 @@
     "graphite2",
     "mocklibc"
   ],
+  "apache-orc": {
+    "test_options": [
+      "--timeout-multiplier=2"
+    ],
+    "alpine_packages": [
+      "tzdata"
+    ]
+  },
   "atomic_queue": {
     "_comment": "Tests require Boost, which is not available on WrapDB",
     "build_on": {

--- a/releases.json
+++ b/releases.json
@@ -132,6 +132,14 @@
       "20200225.2-1"
     ]
   },
+  "apache-orc": {
+    "dependency_names": [
+      "orc"
+    ],
+    "versions": [
+      "2.2.0-1"
+    ]
+  },
   "arduinocore-avr": {
     "versions": [
       "1.8.2-2",

--- a/subprojects/apache-orc.wrap
+++ b/subprojects/apache-orc.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = orc-2.2.0
+source_url = https://www.apache.org/dyn/closer.lua?action=download&filename=orc/orc-2.2.0/orc-2.2.0.tar.gz
+source_fallback_url = https://github.com/apache/orc/archive/refs/tags/v2.2.0.tar.gz
+source_filename = orc-2.2.0.tar.gz
+source_hash = b15aca45a7e73ffbd1bbc36a78cd1422d41f07721092a25f43448e6e16f4763b
+
+[provide]
+orc = orc_dep


### PR DESCRIPTION
Meson support for Apache ORC was implemented in https://github.com/apache/orc/pull/2249 . We will have to wait for the next release to make this official, but I figured its worth testing a wrap entry anyway, in case any issues need to be patched before the next release

FYI @dongjoon-hyun