### PR TITLE
boost-mp11: new wrap

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -225,6 +225,14 @@
       "0.10.0-1"
     ]
   },
+  "boost-mp11": {
+    "dependency_names": [
+      "boost-mp11"
+    ],
+    "versions": [
+      "1.83.0-1"
+    ]
+  },
   "box2d": {
     "dependency_names": [
       "box2d"

--- a/subprojects/boost-mp11.wrap
+++ b/subprojects/boost-mp11.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = mp11-boost-1.83.0
+source_url = https://github.com/boostorg/mp11/archive/refs/tags/boost-1.83.0.zip
+source_filename = boost-mp11-1.83.0.zip
+source_hash = 6ed44d67aa6dc8fedb6264afde9f918a94912b7e10be691680f2693e0825c0ee
+patch_directory = boost-mp11
+
+[provide]
+dependency_names = boost-mp11

--- a/subprojects/packagefiles/boost-mp11/meson.build
+++ b/subprojects/packagefiles/boost-mp11/meson.build
@@ -1,0 +1,13 @@
+project(
+  'boost-mp11',
+  'cpp',
+  version: '1.83.0',
+  license: 'BSL-1.0',
+  default_options: ['cpp_std=c++11'],
+)
+
+boost_mp11_dep = declare_dependency(
+  include_directories: 'include',
+)
+
+meson.override_dependency('boost-mp11', boost_mp11_dep)


### PR DESCRIPTION
https://github.com/boostorg/mp11

This is a header-only, standalone Boost library that does not have any other Boost dependencies.