### PR TITLE
sanity_checks: fix test failure if rewriter can't parse a default option

### DIFF
--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -646,7 +646,7 @@ class TestReleases(unittest.TestCase):
                             'unity'}:
                     raise Exception(f'{name} is not permitted in default_options')
 
-    def get_default_options(self, project: dict[str, T.Any]) -> dict[str, str]:
+    def get_default_options(self, project: dict[str, T.Any]) -> dict[str, str | None]:
         opts = project.get('default_options')
         if not opts:
             return {}
@@ -654,7 +654,7 @@ class TestReleases(unittest.TestCase):
             return opts
         elif isinstance(opts, str):
             opts = [opts]
-        return dict(opt.split('=', 1) for opt in opts)
+        return dict(opt.split('=', 1) for opt in opts if opt is not None)
 
     def check_files(self, subproject: str, patch_path: Path) -> None:
         tabs: list[Path] = []


### PR DESCRIPTION
If the rewriter can't parse a `default_options` member, e.g. because of a ternary operator, it claims that option is null.  Don't fail tests over this.

Also adjust a type to anticipate null dict values once the rewriter supports `default_options` dicts.

Fixes: #2211