### PR TITLE
metal-cpp: Add support for macos15-15.2 (#2235)

### DIFF
--- a/subprojects/metal-cpp_macOS15.2_iOS18.2.wrap
+++ b/subprojects/metal-cpp_macOS15.2_iOS18.2.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = metal-cpp-macOS15.2-iOS18.2
+source_url = https://developer.apple.com/metal/cpp/files/metal-cpp_macOS15.2_iOS18.2.zip
+source_filename = metal-cpp_macOS15.2_iOS18.2.zip
+source_hash = 3437e4abfbd3d45217f34772ef3502f31ba3358e5fb6ac9d0ca952a047bcfe25
+patch_directory = metal-cpp_macOS15.2_iOS18.2
+
+[provide]
+metal_cpp_macos15_2_ios18_2 = metal_cpp_macos15_2_ios18_2_dep

--- a/subprojects/metal-cpp_macOS15_iOS18.wrap
+++ b/subprojects/metal-cpp_macOS15_iOS18.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = metal-cpp-macOS15-iOS18
+source_url = https://developer.apple.com/metal/cpp/files/metal-cpp_macOS15_iOS18.zip
+source_filename = metal-cpp_macOS15_iOS18.zip
+source_hash = 0433df1e0ab13c2b0becbd78665071e3fa28381e9714a3fce28a497892b8a184
+patch_directory = metal-cpp_macOS15_iOS18
+
+[provide]
+metal_cpp_macos15_ios18 = metal_cpp_macos15_ios18_dep

--- a/subprojects/packagefiles/metal-cpp_macOS15.2_iOS18.2/meson.build
+++ b/subprojects/packagefiles/metal-cpp_macOS15.2_iOS18.2/meson.build
@@ -1,0 +1,10 @@
+project(
+  'metal-cpp-macOS15-iOS18',
+  'cpp',
+)
+
+include_dirs = include_directories('.')
+
+metal_cpp_macos_15_ios_18_dep = declare_dependency(
+  include_directories: [include_dirs],
+)

--- a/subprojects/packagefiles/metal-cpp_macOS15_iOS18/meson.build
+++ b/subprojects/packagefiles/metal-cpp_macOS15_iOS18/meson.build
@@ -1,0 +1,10 @@
+project(
+  'metal-cpp-macOS15.2-iOS18.2',
+  'cpp',
+)
+
+include_dirs = include_directories('.')
+
+metal_cpp_macos_15_2_ios_18_2_dep = declare_dependency(
+  include_directories: [include_dirs],
+)


### PR DESCRIPTION
This small PR is a rough implementation of the approach I proposed in issue (#2235). In brief, I attempt to add support for [metal-cpp](https://developer.apple.com/metal/cpp/). Considering that library's unorthodox release and versioning scheme, I created different wrap files for different OS versions.

Please let me know if you have better proposals! This is my first wrapfile and it's possible there are features within `meson` that could be leveraged to better resolve the unorthodox versioning problem we have here.