### PR TITLE
sanity_checks: treat meson_version '>=0.N' as '>=0.N.0'

### DIFF
--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -763,6 +763,8 @@ meson format --configuration meson.format --inplace {unformatted_files_for_comma
         version_request = project_args.get('meson_version')
         if version_request:
             version_request = version_request.replace(' ', '')
+            while version_request.count('.') < 2:
+                version_request += '.0'
 
         options = ['-Dpython.install_env=auto', f'-Dwraps={name}']
         options += [f'-D{o}' for o in ci.get('build_options', [])]
@@ -809,9 +811,9 @@ meson format --configuration meson.format --inplace {unformatted_files_for_comma
             min_version = versions[-1]
         else:
             message = 'No versioned features found.'
-            min_version = '0'
+            min_version = '0.0.0'
         return (
-            'warning' if (version_request or '>=0') != f'>={min_version}' else 'notice',
+            'warning' if (version_request or '>=0.0.0') != f'>={min_version}' else 'notice',
             f'Minimum Meson version is {min_version}',
             message
         )


### PR DESCRIPTION
Don't annotate the `meson_version` as a warning just because the version request is missing a trailing `.0`.

If we don't find any versioned features, report the minimum version as `0.0.0` so we don't have to special-case the canonicalization.  We'll still accept `>=0` in `meson.build`.