### PR TITLE
xdelta3: add

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -1423,6 +1423,17 @@
       "x-plane-sdk:cpp=enabled"
     ]
   },
+  "xdelta3": {
+    "build_options": [
+      "xdelta3:lzma=enabled"
+    ],
+    "alpine_packages": [
+      "xz-dev"
+    ],
+    "debian_packages": [
+      "liblzma-dev"
+    ]
+  },
   "zycore": {
     "build_options": [
       "zycore:examples=enabled",

--- a/releases.json
+++ b/releases.json
@@ -4347,6 +4347,14 @@
       "4.0.1-1"
     ]
   },
+  "xdelta3": {
+    "program_names": [
+      "xdelta3"
+    ],
+    "versions": [
+      "3.1.0-1"
+    ]
+  },
   "xtensor": {
     "dependency_names": [
       "xtensor"

--- a/subprojects/packagefiles/xdelta3/config.h.meson
+++ b/subprojects/packagefiles/xdelta3/config.h.meson
@@ -1,0 +1,6 @@
+#include "config-generated.h"
+
+#ifdef _WIN32
+// missing include for getpid()
+#include <process.h>
+#endif

--- a/subprojects/packagefiles/xdelta3/meson.build
+++ b/subprojects/packagefiles/xdelta3/meson.build
@@ -1,0 +1,83 @@
+project(
+  'xdelta3',
+  'c',
+  version: '3.1.0',
+  license: 'GPL-2.0-or-later',
+  meson_version: '>=0.63.0',
+  default_options: ['c_std=c99'],
+)
+
+cc = meson.get_compiler('c')
+add_project_arguments(
+  '-DHAVE_CONFIG_H',
+  cc.get_supported_arguments(
+    '-Wno-format-truncation',
+    '-Wno-switch-unreachable',
+    '-Wno-unused-function',
+  ),
+  language: 'c',
+)
+
+cdata = configuration_data()
+cdata.set('HAVE_ALIGNED_ACCESS_REQUIRED', 1)
+cdata.set('REGRESSION_TEST', 1)
+cdata.set('SECONDARY_DJW', 1)
+cdata.set('SECONDARY_FGK', 1)
+cdata.set('XD3_MAIN', 1)
+cdata.set('XD3_DEBUG', 0)
+if host_machine.system() == 'windows'
+  cdata.set('XD3_WIN32', 1)
+  cdata.set('EXTERNAL_COMPRESSION', 0)
+  cdata.set('SHELL_TESTS', 0)
+endif
+
+foreach type : ['unsigned int', 'unsigned long', 'unsigned long long', 'size_t']
+  cdata.set('SIZEOF_' + type.underscorify().to_upper(), cc.sizeof(type))
+endforeach
+if not cc.has_type(
+  'pid_t',
+  prefix: '#include <sys/types.h>',
+)
+  cdata.set('pid_t', 'int')
+endif
+if not cc.has_function_attribute('format')
+  cdata.set('PRINTF_ATTRIBUTE(x,y)', '')
+endif
+
+m_dep = cc.find_library(
+  'm',
+  required: false,
+)
+
+liblzma_dep = dependency(
+  'liblzma',
+  required: get_option('lzma'),
+)
+if liblzma_dep.found()
+  cdata.set('HAVE_LZMA_H', 1)
+endif
+
+configure_file(
+  configuration: cdata,
+  output: 'config-generated.h',
+)
+
+configure_file(
+  input: 'config.h.meson',
+  output: 'config.h',
+  copy: true,
+)
+
+xdelta3 = executable(
+  'xdelta3',
+  'xdelta3.c',
+  dependencies: [m_dep, liblzma_dep],
+)
+meson.override_find_program('xdelta3', xdelta3)
+
+test(
+  'xdelta3',
+  xdelta3,
+  args: 'test',
+  timeout: 500,
+)

--- a/subprojects/packagefiles/xdelta3/meson_options.txt
+++ b/subprojects/packagefiles/xdelta3/meson_options.txt
@@ -1,0 +1,5 @@
+option(
+    'lzma',
+    type: 'feature',
+    description: 'LZMA compression support',
+)

--- a/subprojects/xdelta3.wrap
+++ b/subprojects/xdelta3.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = xdelta3-3.1.0
+source_url = https://github.com/jmacd/xdelta-gpl/releases/download/v3.1.0/xdelta3-3.1.0.tar.gz
+source_filename = xdelta3-3.1.0.tar.gz
+source_hash = 114543336ab6cee3764e3c03202701ef79d7e5e8e4863fe64811e4d9e61884dc
+patch_directory = xdelta3
+
+[provide]
+program_names = xdelta3


### PR DESCRIPTION
It isn't a library and it hasn't been maintained upstream since 2017, but I have a project whose test suite depends on it.

This can also live downstream if WrapDB isn't the right place for it.