### PR TITLE
glaze: add v5.5.2

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1094,6 +1094,14 @@
       "5.2.1-1"
     ]
   },
+  "glaze": {
+    "dependency_names": [
+      "glaze"
+    ],
+    "versions": [
+      "5.5.2-1"
+    ]
+  },
   "glbinding": {
     "dependency_names": [
       "glbinding",

--- a/subprojects/glaze.wrap
+++ b/subprojects/glaze.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = glaze-5.5.2
+source_url = https://github.com/stephenberry/glaze/archive/refs/tags/v5.5.2.tar.gz
+source_filename = glaze-5.5.2.tar.gz
+source_hash = 92382568999829a531db5a3800a36d8699674d640d3862fcb7e79ee2879d95ec
+patch_directory = glaze
+
+[provide]
+glaze = glaze_dep

--- a/subprojects/packagefiles/glaze/meson.build
+++ b/subprojects/packagefiles/glaze/meson.build
@@ -1,0 +1,11 @@
+project(
+  'glaze',
+  'cpp',
+  license: 'MIT',
+  version: '5.5.2',
+)
+
+glaze_dep = declare_dependency(
+  include_directories: include_directories('include'),
+  compile_args: '-std=c++23',
+)


### PR DESCRIPTION
couldn't sanity check on my local copy but i tested with gcc on Windows 11 and Ubuntu 13 (WSL)