### PR TITLE
sanity_checks: add tip about using old format

### DIFF
--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -692,7 +692,7 @@ class TestReleases(unittest.TestCase):
             unformatted_str = ', '.join([str(f) for f in unformatted])
             self.fail(
                 f'''Not formatted files found: {unformatted_str}
-Run tools/format.py to format these files.''')
+Run tools/format.py to format these files. A recent enough version of Meson may be required.''')
 
     @unittest.skipUnless('TEST_MESON_VERSION_DEPS' in os.environ, 'Run manually only')
     def test_meson_version_deps(self) -> None:


### PR DESCRIPTION
I spent a lot of time trying to follow this error message's advice to run `tools/format.py` without success. It took me a while to figure out that newer versions of Meson modified its formatting rules, so a file that was correctly formatted with Meson 1.6.1 (to give an example) will be considered unformatted by Meson 1.9.0rc2 (or whatever the runners use now). 1.6.1 isn't even _that_ old.

The wording may need to be changed, this PR is more of a proposal.