### PR TITLE
Use latest Meson prerelease for `meson format`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__
 .idea
 .vscode
 *~
+
+tools/mesonenv

--- a/tools/format.py
+++ b/tools/format.py
@@ -20,6 +20,8 @@ import json
 from pathlib import Path
 import subprocess
 
+from utils import format_meson
+
 FORMAT_FILES = {'meson.build', 'meson_options.txt', 'meson.options'}
 
 def main() -> None:
@@ -38,9 +40,7 @@ def main() -> None:
                 patch_dir = Path('subprojects', 'packagefiles', patch_dir_name)
                 files += [f for f in patch_dir.rglob('*') if f.name in FORMAT_FILES]
 
-    if files:
-        cmd = ['meson', 'format', '--configuration', './meson.format', '--inplace']
-        subprocess.run(cmd + files, check=True)
+    format_meson(files)
 
 
 if __name__ == '__main__':

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 from contextlib import contextmanager
 import operator
 import re
 import os
 import sys
 import typing as T
+from pathlib import Path
 import platform
+import subprocess
 
 # a helper class which implements the same version ordering as RPM
 class Version:
@@ -125,3 +128,20 @@ def is_msys() -> bool:
 
 def is_macos():
     return any(platform.mac_ver()[0])
+
+class FormattingError(Exception):
+    pass
+
+def format_meson(files: T.Iterable[Path], *, check: bool = False) -> None:
+    if not files:
+        return
+    cmd: list[str | Path] = ['meson', 'format', '--configuration', './meson.format']
+    if check:
+        cmd.append('--check-only')
+    else:
+        cmd.append('--inplace')
+    cmd.extend(files)
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as ex:
+        raise FormattingError from ex


### PR DESCRIPTION
Formatting rules change over time, and CI uses the latest Meson prerelease, so we should match that version on developers' systems.  If not running in CI, install Meson into a virtualenv that we update at most once per day.