### PR TITLE
Work around Meson bug ignoring `c_std`/`cpp_std` in subprojects; other 1.9.0rc updates

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -166,10 +166,6 @@ jobs:
           architecture: 'x86'
           python-version: '3.12'
 
-      # https://github.com/actions/runner-images/issues/5459#issuecomment-1532856844
-      - name: Remove bad Strawberry Perl patch binary in search path
-        run: del C:\Strawberry\c\bin\patch.EXE
-
       - name: Install packages
         run: |
           python -m pip install license-expression
@@ -199,10 +195,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      # https://github.com/actions/runner-images/issues/5459#issuecomment-1532856844
-      - name: Remove bad Strawberry Perl patch binary in search path
-        run: del C:\Strawberry\c\bin\patch.EXE
 
       - name: Install packages
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,3 @@ __pycache__
 .idea
 .vscode
 *~
-
-subprojects/packagecache
-subprojects/packagefiles/openssl/generated-config

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,19 @@ project(
   default_options: ['cpp_std=c++17'],
 )
 
+if (
+  meson.version().version_compare('<1.9.1') and
+  meson.version().version_compare('>=1.8.4')
+)
+  # ensure c_std= and cpp_std= are not ignored in subprojects
+  # https://github.com/mesonbuild/meson/issues/14939
+  add_languages(
+    'c',
+    'cpp',
+    native: false,
+  )
+endif
+
 wraps = get_option('wraps')
 
 foreach w : wraps

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,2 +1,3 @@
 /*/
 !packagefiles/
+packagefiles/openssl/generated-config

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,3 +1,4 @@
+/.wraplock
 /*/
 !packagefiles/
 packagefiles/openssl/generated-config

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -159,6 +159,7 @@ SOURCE_FILENAME_PREFIXES = {
 }
 FORMAT_CHECK_FILES = ['meson.build', 'meson_options.txt', 'meson.options']
 NO_TABS_FILES = ['meson.build', 'meson_options.txt', 'meson.options']
+SUBPROJECTS_METADATA_FILES = {'subprojects/.gitignore'}
 PERMITTED_KEYS = {'versions', 'dependency_names', 'program_names'}
 IGNORE_SETUP_WARNINGS = None  # or re.compile(r'something')
 
@@ -363,7 +364,7 @@ class TestReleases(unittest.TestCase):
             if not has_new_releases:
                 last_tag = subprocess.check_output(['git', 'describe', '--tags', '--abbrev=0'], text=True, encoding='utf-8').strip()
                 changed_files = subprocess.check_output(['git', 'diff', '--name-only', 'HEAD', last_tag], text=True, encoding='utf-8').splitlines()
-                if any(f.startswith('subprojects') for f in changed_files):
+                if any(f.startswith('subprojects') and f not in SUBPROJECTS_METADATA_FILES for f in changed_files):
                     self.fail('Subprojects files changed but no new release added into releases.json')
 
     @unittest.skipUnless('TEST_BUILD_ALL' in os.environ, 'Run manually only')


### PR DESCRIPTION
On Meson versions affected (or expected to be affected) by mesonbuild/meson#14939, add C and C++ languages to the root project so subprojects will respect `c_std` and `cpp_std`.

We can adjust the version range if needed once the bug is fixed.  There's probably some value in continuing to carry this check for a while after the fix is released, since developers might have older Meson versions on their machines.

Also remove obsolete Strawberry Perl workaround and ignore `subprojects/.wraplock`.