### PR TITLE
Add wrap for Snitch

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -3848,6 +3848,14 @@
       "4.6.1-1"
     ]
   },
+  "snitch": {
+    "dependency_names": [
+      "snitch"
+    ],
+    "versions": [
+      "1.3.2-1"
+    ]
+  },
   "soundtouch": {
     "dependency_names": [
       "soundtouch"

--- a/subprojects/snitch.wrap
+++ b/subprojects/snitch.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = snitch-1.3.2
+source_url = https://github.com/snitch-org/snitch/archive/v1.3.2.tar.gz
+source_filename = snitch-1.3.2.tar.gz
+source_hash = 5b3a0af7e5637f02ac95652f2238b89eb227b4881bf4e5ffc6935f184ff11626
+
+[provide]
+snitch = snitch_dep
+


### PR DESCRIPTION
Snitch is a lightweight unit testing library for C++. It implements subset of Catch2 API, usually is smaller and faster than Catch2 or doctest: https://github.com/snitch-org/snitch

The library contains its own meson.build. It is still somewhat limited compared to CMakeLists.txt (see https://github.com/snitch-org/snitch/issues/116), but perfectly usable.

Snitch project already mistakenly claims to be present in the WrapDB (https://github.com/snitch-org/snitch?tab=readme-ov-file#example-build-configuration-with-meson), but was never really added to it (see https://github.com/snitch-org/snitch/issues/156). This is my attempt to fix the situation. Also my first WrapDB PR, so please feel free to point out any mistakes.