### PR TITLE
tools: add utility code to load/save wrap files and JSON metadata

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -2,7 +2,7 @@
   "_comment": [
     "This is intentionally undocumented in README.md, do not use it.",
     "Using it is an automatic CI error.",
-    "broken_linux, broken_windows and broken_macos are lists of wraps that are known",
+    "broken_linux, broken_windows and broken_darwin are lists of wraps that are known",
     "to be broken on the CI and ***MUST*** get repaired before updates",
     "will be accepted. If upstream does not support an Operating System,",
     "explicitly disable that Operating System in build_on.",

--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 import io
 import sys
 import configparser
@@ -43,13 +44,13 @@ class CreateRelease:
             self.create_source_fallback()
             self.create_wrap_file()
 
-    def read_wrap(self):
+    def read_wrap(self) -> None:
         filename = Path('subprojects', f'{self.name}.wrap')
         self.wrap = configparser.ConfigParser(interpolation=None)
         self.wrap.read(filename)
         self.wrap_section = self.wrap[self.wrap.sections()[0]]
 
-    def create_patch_zip(self):
+    def create_patch_zip(self) -> None:
         patch_directory = self.wrap_section.get('patch_directory')
         if patch_directory is None:
             return
@@ -99,7 +100,7 @@ class CreateRelease:
         self.wrap_section['patch_url'] = f'https://wrapdb.mesonbuild.com/v2/{self.tag}/get_patch'
         self.wrap_section['patch_hash'] = patch_hash
 
-    def create_wrap_file(self):
+    def create_wrap_file(self) -> None:
         self.wrap_section['wrapdb_version'] = self.version
 
         filename = Path(self.tempdir, f'{self.name}.wrap')
@@ -117,7 +118,7 @@ class CreateRelease:
         print(filename.read_text())
         self.upload(filename, 'text/plain')
 
-    def find_upload_url(self):
+    def find_upload_url(self) -> None:
         if not self.repo or not self.token:
             return
         api = f'https://api.github.com/repos/{self.repo}/releases'
@@ -139,7 +140,7 @@ class CreateRelease:
         self.upload_url = response.json()['upload_url'].replace('{?name,label}','')
         print('Created release:', self.upload_url)
 
-    def upload(self, path: Path, mimetype: str):
+    def upload(self, path: Path, mimetype: str) -> None:
         if not self.repo or not self.token:
             # Write files locally when not run on CI
             with Path('subprojects', 'packagecache', path.name).open('wb') as f:
@@ -153,7 +154,7 @@ class CreateRelease:
         response = requests.post(self.upload_url, headers=headers, params=params, data=path.read_bytes())
         response.raise_for_status()
 
-    def create_source_fallback(self):
+    def create_source_fallback(self) -> None:
         response = requests.get(
             self.wrap_section['source_url'],
             headers={'User-Agent': 'wrapdb/0'},
@@ -164,7 +165,7 @@ class CreateRelease:
         self.upload(filename, 'application/zip')
         self.wrap_section['source_fallback_url'] = f'https://github.com/mesonbuild/wrapdb/releases/download/{self.tag}/{filename.name}'
 
-def run(repo: T.Optional[str], token: T.Optional[str]):
+def run(repo: T.Optional[str], token: T.Optional[str]) -> None:
     with open('releases.json', 'r') as f:
         releases = json.load(f)
     stdout = subprocess.check_output(['git', 'tag'])

--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -26,7 +26,7 @@ import subprocess
 import json
 
 from pathlib import Path
-from utils import Releases, is_ci, is_debianlike, read_wrap, write_wrap
+from utils import CIConfig, Releases, is_ci, is_debianlike, read_wrap, write_wrap
 
 class CreateRelease:
     def __init__(self, repo: T.Optional[str], token: T.Optional[str], tag: str):
@@ -59,11 +59,9 @@ class CreateRelease:
         generator = Path(srcdir, 'generator.sh')
         if generator.exists():
             try:
-                fn = 'ci_config.json'
-                with open(fn, 'r') as f:
-                    ci = json.load(f)
-            except json.decoder.JSONDecodeError:
-                raise RuntimeError(f'file {fn} is malformed')
+                ci = CIConfig.load()
+            except json.decoder.JSONDecodeError as ex:
+                raise RuntimeError(f'CI config is malformed') from ex
 
             debian_packages = ci.get(self.name, {}).get('debian_packages', [])
             if debian_packages and is_debianlike():

--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -26,7 +26,7 @@ import subprocess
 import json
 
 from pathlib import Path
-from utils import is_ci, is_debianlike, read_wrap, write_wrap
+from utils import Releases, is_ci, is_debianlike, read_wrap, write_wrap
 
 class CreateRelease:
     def __init__(self, repo: T.Optional[str], token: T.Optional[str], tag: str):
@@ -155,8 +155,7 @@ class CreateRelease:
         self.wrap_section['source_fallback_url'] = f'https://github.com/mesonbuild/wrapdb/releases/download/{self.tag}/{filename.name}'
 
 def run(repo: T.Optional[str], token: T.Optional[str]) -> None:
-    with open('releases.json', 'r') as f:
-        releases = json.load(f)
+    releases = Releases.load()
     stdout = subprocess.check_output(['git', 'tag'])
     tags = [t.strip() for t in stdout.decode().splitlines()]
     for name, info in releases.items():

--- a/tools/format.py
+++ b/tools/format.py
@@ -15,12 +15,11 @@
 # limitations under the License.
 
 from __future__ import annotations
-from configparser import ConfigParser
 import json
 from pathlib import Path
 import subprocess
 
-from utils import format_meson
+from utils import format_meson, read_wrap
 
 FORMAT_FILES = {'meson.build', 'meson_options.txt', 'meson.options'}
 
@@ -33,8 +32,7 @@ def main() -> None:
     files = []
     for name, info in releases.items():
         if f'{name}_{info["versions"][0]}' not in tags:
-            config = ConfigParser(interpolation=None)
-            config.read(f'subprojects/{name}.wrap', encoding='utf-8')
+            config = read_wrap(name)
             patch_dir_name = config['wrap-file'].get('patch_directory')
             if patch_dir_name:
                 patch_dir = Path('subprojects', 'packagefiles', patch_dir_name)

--- a/tools/format.py
+++ b/tools/format.py
@@ -15,18 +15,15 @@
 # limitations under the License.
 
 from __future__ import annotations
-import json
 from pathlib import Path
 import subprocess
 
-from utils import format_meson, read_wrap
+from utils import Releases, format_meson, read_wrap
 
 FORMAT_FILES = {'meson.build', 'meson_options.txt', 'meson.options'}
 
 def main() -> None:
-    with open('releases.json', 'r', encoding='utf-8') as f:
-        releases = json.load(f)
-
+    releases = Releases.load()
     tags = set(subprocess.check_output(['git', 'tag', '--merged'], text=True).splitlines())
 
     files = []

--- a/tools/internalize_sources.py
+++ b/tools/internalize_sources.py
@@ -16,22 +16,12 @@
 
 from __future__ import annotations
 from argparse import ArgumentParser
-import configparser
 from hashlib import sha256
-from io import StringIO
 import json
 from pathlib import Path
 import subprocess
 
-def wrap_path(name: str) -> Path:
-    return Path('subprojects', f'{name}.wrap')
-
-
-def read_wrap(name: str) -> configparser.ConfigParser:
-    wrap = configparser.ConfigParser(interpolation=None)
-    wrap.read(wrap_path(name), encoding='utf-8')
-    return wrap
-
+from utils import read_wrap, write_wrap, wrap_path
 
 class Internalizer:
     def __init__(self, all=False):
@@ -81,10 +71,7 @@ class Internalizer:
             wf = wrap['wrap-file']
             wf['source_fallback_url'] = wf['source_url']
             wf['source_url'] = f'https://github.com/mesonbuild/wrapdb/releases/download/{tag}/{wf["source_filename"]}'
-            buf = StringIO()
-            wrap.write(buf)
-            with wrap_path(name).open('w') as fh:
-                fh.write(buf.getvalue().strip() + '\n')
+            write_wrap(wrap_path(name), wrap)
         print(f'Rewrote source_url for {len(self.rewrite)} projects.')
 
 

--- a/tools/internalize_sources.py
+++ b/tools/internalize_sources.py
@@ -17,16 +17,14 @@
 from __future__ import annotations
 from argparse import ArgumentParser
 from hashlib import sha256
-import json
 from pathlib import Path
 import subprocess
 
-from utils import read_wrap, write_wrap, wrap_path
+from utils import Releases, read_wrap, write_wrap, wrap_path
 
 class Internalizer:
     def __init__(self, all=False):
-        with open('releases.json') as fh:
-            releases = json.load(fh)
+        releases = Releases.load()
         tags = set(
             subprocess.check_output(['git', 'tag'], text=True).splitlines()
         )

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -29,7 +29,7 @@ import sys
 import shutil
 
 from pathlib import Path
-from utils import Version, ci_group, is_ci, is_alpinelike, is_debianlike, is_macos, is_windows, is_msys, FormattingError, format_meson
+from utils import Version, ci_group, is_ci, is_alpinelike, is_debianlike, is_macos, is_windows, is_msys, read_wrap, FormattingError, format_meson
 
 PERMITTED_FILES = {'generator.sh', 'meson.build', 'meson_options.txt', 'meson.options', 'LICENSE.build'}
 PER_PROJECT_PERMITTED_FILES: dict[str, set[str]] = {
@@ -279,8 +279,7 @@ class TestReleases(unittest.TestCase):
                 extra_checks = latest_tag not in self.tags
 
                 # Make sure we can load wrap file
-                config = configparser.ConfigParser(interpolation=None)
-                config.read(f'subprojects/{name}.wrap', encoding='utf-8')
+                config = read_wrap(name)
 
                 # Basic checks
                 with self.subTest(step='basic'):
@@ -692,8 +691,7 @@ class TestReleases(unittest.TestCase):
                     self.report_meson_version_deps(name)
 
     def report_meson_version_deps(self, name: str, builddir: str = '_build') -> None:
-        wrap = configparser.ConfigParser(interpolation=None)
-        wrap.read(f'subprojects/{name}.wrap', encoding='utf-8')
+        wrap = read_wrap(name)
         patch_dir = self.get_patch_path(wrap['wrap-file'])
         if not patch_dir:
             # only check projects maintained downstream

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -158,7 +158,6 @@ SOURCE_FILENAME_PREFIXES = {
     'libtomcrypt': 'crypt',
 }
 FORMAT_CHECK_FILES = {'meson.build', 'meson_options.txt', 'meson.options'}
-NO_TABS_FILES = {'meson.build', 'meson_options.txt', 'meson.options'}
 SUBPROJECTS_METADATA_FILES = {'subprojects/.gitignore'}
 PERMITTED_KEYS = {'versions', 'dependency_names', 'program_names'}
 IGNORE_SETUP_WARNINGS = None  # or re.compile(r'something')
@@ -666,7 +665,6 @@ class TestReleases(unittest.TestCase):
         return dict(opt.split('=', 1) for opt in opts if opt is not None)
 
     def check_files(self, subproject: str, patch_path: Path) -> None:
-        tabs: list[Path] = []
         not_permitted: list[Path] = []
         unformatted: list[Path] = []
         for f in patch_path.rglob('*'):
@@ -679,11 +677,6 @@ class TestReleases(unittest.TestCase):
                     unformatted.append(f)
             if not self.is_permitted_file(subproject, f.name):
                 not_permitted.append(f)
-            elif f.name in NO_TABS_FILES and '\t' in f.read_text(encoding='utf-8'):
-                tabs.append(f)
-        if tabs:
-            tabs_str = ', '.join([str(f) for f in tabs])
-            self.fail(f'Tabs in meson files are not allowed: {tabs_str}')
         if not_permitted:
             not_permitted_str = ', '.join([str(f) for f in not_permitted])
             self.fail(f'Not permitted files found: {not_permitted_str}')

--- a/tools/update-packagefiles.py
+++ b/tools/update-packagefiles.py
@@ -20,10 +20,7 @@ import zipfile
 import shutil
 from pathlib import Path
 
-def read_wrap(filename: Path) -> configparser.SectionProxy:
-    wrap = configparser.ConfigParser(interpolation=None)
-    wrap.read(filename)
-    return wrap[wrap.sections()[0]]
+from utils import read_wrap
 
 def read_archive_files(path: Path, base_path: Path) -> set[Path]:
     if path.suffix == '.zip':
@@ -36,7 +33,8 @@ def read_archive_files(path: Path, base_path: Path) -> set[Path]:
 
 if __name__ == '__main__':
     for f in Path('subprojects').glob('*.wrap'):
-        wrap_section = read_wrap(f)
+        wrap = read_wrap(f.stem)
+        wrap_section = wrap[wrap.sections()[0]]
         patch_directory = wrap_section.get('patch_directory')
         if not patch_directory:
             continue

--- a/tools/update-packagefiles.py
+++ b/tools/update-packagefiles.py
@@ -20,12 +20,12 @@ import zipfile
 import shutil
 from pathlib import Path
 
-def read_wrap(filename: Path):
+def read_wrap(filename: Path) -> configparser.SectionProxy:
     wrap = configparser.ConfigParser(interpolation=None)
     wrap.read(filename)
     return wrap[wrap.sections()[0]]
 
-def read_archive_files(path: Path, base_path: Path):
+def read_archive_files(path: Path, base_path: Path) -> set[Path]:
     if path.suffix == '.zip':
         with zipfile.ZipFile(path, 'r') as archive:
             archive_files = set(base_path / i for i in archive.namelist())

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 from __future__ import annotations
+import configparser
 from contextlib import contextmanager
 import functools
+import io
 import operator
 import os
 from pathlib import Path
@@ -103,6 +105,21 @@ class Version:
 
         # versions are equal, so compare revisions
         return comparator(self._r, other._r)
+
+def wrap_path(name: str) -> Path:
+    return Path('subprojects', f'{name}.wrap')
+
+def read_wrap(name: str) -> configparser.ConfigParser:
+    config = configparser.ConfigParser(interpolation=None)
+    config.read(wrap_path(name), encoding='utf-8')
+    return config
+
+def write_wrap(path: Path, config: configparser.ConfigParser) -> None:
+    # configparser write() adds multiple trailing newlines, collapse them
+    buf = io.StringIO()
+    config.write(buf)
+    with path.open('w', encoding='utf-8') as f:
+        f.write(buf.getvalue().rstrip('\n') + '\n')
 
 @contextmanager
 def ci_group(title):

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -134,6 +134,31 @@ class ProjectReleases(T.TypedDict):
 class Releases(dict[str, ProjectReleases], _JSONFile):
     FILENAME = 'releases.json'
 
+class ProjectCIConfig(T.TypedDict):
+    build_on: T.NotRequired[dict[str, bool]]
+    build_options: T.NotRequired[list[str]]
+    fatal_warnings: T.NotRequired[bool]
+    has_provides: T.NotRequired[bool]
+    skip_dependency_check: T.NotRequired[list[str]]
+    skip_program_check: T.NotRequired[list[str]]
+    skip_tests: T.NotRequired[bool]
+    test_options: T.NotRequired[list[str]]
+
+    alpine_packages: T.NotRequired[list[str]]
+    brew_packages: T.NotRequired[list[str]]
+    choco_packages: T.NotRequired[list[str]]
+    debian_packages: T.NotRequired[list[str]]
+    msys_packages: T.NotRequired[list[str]]
+    python_packages: T.NotRequired[list[str]]
+
+class CIConfig(dict[str, ProjectCIConfig], _JSONFile):
+    FILENAME = 'ci_config.json'
+
+    @property
+    def broken(self) -> list[str]:
+        system = platform.system().lower()
+        return T.cast('list[str]', self.get(f'broken_{system}', []))
+
 def wrap_path(name: str) -> Path:
     return Path('subprojects', f'{name}.wrap')
 

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -16,15 +16,15 @@ from __future__ import annotations
 from contextlib import contextmanager
 import functools
 import operator
-import re
 import os
-import sys
-import typing as T
 from pathlib import Path
 import platform
+import re
 import subprocess
+import sys
 import time
 import venv
+import typing as T
 
 # a helper class which implements the same version ordering as RPM
 class Version:

--- a/tools/versions.py
+++ b/tools/versions.py
@@ -94,7 +94,7 @@ def get_upstream_versions() -> dict[str, str]:
         if len(packages['items']) < items_per_page:
             break
 
-    def sub(name, old, new):
+    def sub(name: str, old: str, new: str) -> None:
         if name in versions:
             versions[name] = re.sub(old, new, versions[name])
     sub('icu', '-', '.')

--- a/tools/versions.py
+++ b/tools/versions.py
@@ -26,7 +26,7 @@ import re
 import subprocess
 import sys
 import time
-from typing import TypedDict
+import typing as T
 
 import requests
 
@@ -42,14 +42,14 @@ DEPRECATED_WRAPS = set([
 ])
 
 
-class AnityaPackageList(TypedDict):
+class AnityaPackageList(T.TypedDict):
     items: list[AnityaPackage]
     items_per_page: int
     page: int
     total_items: int
 
 
-class AnityaPackage(TypedDict):
+class AnityaPackage(T.TypedDict):
     distribution: str
     ecosystem: str
     name: str
@@ -58,7 +58,7 @@ class AnityaPackage(TypedDict):
     version: str
 
 
-class WrapInfo(TypedDict):
+class WrapInfo(T.TypedDict):
     versions: list[str]
     dependency_names: list[str]
     program_names: list[str]


### PR DESCRIPTION
Consolidate I/O code for `releases.json`, `ci_config.json`, and wrap files.  For the JSON metadata, also ensure type hints are available in all the tools.

Also do some minor cleanups.