### PR TITLE
tools: add formatting for wrap files and `releases.json`

### DIFF
--- a/tools/format.py
+++ b/tools/format.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from pathlib import Path
 import subprocess
 
-from utils import Releases, format_meson, read_wrap
+from utils import Releases, format_meson, format_wrap, read_wrap
 
 FORMAT_FILES = {'meson.build', 'meson_options.txt', 'meson.options'}
 
@@ -29,6 +29,7 @@ def main() -> None:
     files = []
     for name, info in releases.items():
         if f'{name}_{info["versions"][0]}' not in tags:
+            format_wrap(name)
             config = read_wrap(name)
             patch_dir_name = config['wrap-file'].get('patch_directory')
             if patch_dir_name:

--- a/tools/format.py
+++ b/tools/format.py
@@ -37,6 +37,7 @@ def main() -> None:
                 files += [f for f in patch_dir.rglob('*') if f.name in FORMAT_FILES]
 
     format_meson(files)
+    Releases.format()
 
 
 if __name__ == '__main__':

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -211,12 +211,14 @@ class TestReleases(unittest.TestCase):
             self.assertIn(name, self.releases)
             self.assertIn(version, self.releases[name]['versions'], f'for {name}')
 
-        # Verify keys are sorted
-        self.assertEqual(sorted(self.releases.keys()), list(self.releases.keys()))
-
         for name, info in self.releases.items():
             for k in info.keys():
                 self.assertIn(k, PERMITTED_KEYS)
+
+        try:
+            Releases.format(check=True)
+        except FormattingError:
+            self.fail('releases.json is not formatted.  Run tools/format.py to format it.')
 
     def get_patch_path(self, wrap_section):
         patch_directory = wrap_section.get('patch_directory')

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -29,7 +29,7 @@ import sys
 import shutil
 
 from pathlib import Path
-from utils import CIConfig, ProjectCIConfig, Releases, Version, ci_group, is_ci, is_alpinelike, is_debianlike, is_macos, is_windows, is_msys, read_wrap, FormattingError, format_meson
+from utils import CIConfig, ProjectCIConfig, Releases, Version, ci_group, is_ci, is_alpinelike, is_debianlike, is_macos, is_windows, is_msys, read_wrap, FormattingError, format_meson, format_wrap
 
 PERMITTED_FILES = {'generator.sh', 'meson.build', 'meson_options.txt', 'meson.options', 'LICENSE.build'}
 PER_PROJECT_PERMITTED_FILES: dict[str, set[str]] = {
@@ -649,6 +649,7 @@ class TestReleases(unittest.TestCase):
             self.fail(f'Not permitted files found: {not_permitted_str}')
         try:
             format_meson(check_format, check=True)
+            format_wrap(subproject, check=True)
         except FormattingError:
             self.fail('Unformatted files found.  Run tools/format.py to format these files.')
 

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -126,6 +126,16 @@ class _JSONFile(abc.ABC):
             f.write(self.encode())
         os.rename(f'{self.FILENAME}.new', self.FILENAME)
 
+    @classmethod
+    def format(cls, *, check: bool = False) -> None:
+        contents = Path(cls.FILENAME).read_text(encoding='utf-8')
+        parsed = cls.load()
+        if contents != parsed.encode():
+            if check:
+                raise FormattingError
+            else:
+                parsed.save()
+
 class ProjectReleases(T.TypedDict):
     dependency_names: T.NotRequired[list[str]]
     program_names: T.NotRequired[list[str]]


### PR DESCRIPTION
Have sanity_checks.py check that `releases.json` and wrap files for modified wraps are formatted, and have `format.py` format them.  We could also format `ci_config.json`, but sorting keys alphabetically would break some semantically meaningful groupings, so skip for now.