### PR TITLE
create_release: improve source fallback handling

### DIFF
--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -80,12 +80,12 @@ class CreateRelease:
 
             subprocess.check_call([generator])
 
+        shutil.copytree(srcdir, destdir)
         # If no specific license is specified, copy wrapdb's
-        license_file = srcdir / 'LICENSE.build'
+        license_file = destdir / 'LICENSE.build'
         if not license_file.exists():
             shutil.copyfile('COPYING', license_file)
 
-        shutil.copytree(srcdir, destdir)
         base_name = Path(self.tempdir, f'{self.tag}_patch')
         shutil.make_archive(base_name.as_posix(), 'zip', root_dir=self.tempdir, base_dir=directory)
 
@@ -167,7 +167,7 @@ class CreateRelease:
             self.warn("Couldn't download source archive; skipping creation of source fallback")
             return
 
-        filename = Path(self.wrap_section['source_filename'])
+        filename = Path(self.tempdir, self.wrap_section['source_filename'])
         filename.write_bytes(response.content)
         self.upload(filename, 'application/zip')
         self.wrap_section['source_fallback_url'] = f'https://github.com/mesonbuild/wrapdb/releases/download/{self.tag}/{filename.name}'

--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -39,8 +39,8 @@ class CreateRelease:
         with tempfile.TemporaryDirectory() as self.tempdir:
             self.read_wrap()
             self.find_upload_url()
-            self.create_patch_zip()
             self.create_source_fallback()
+            self.create_patch_zip()
             self.create_wrap_file()
 
     def warn(self, message: str) -> None:

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -220,7 +220,7 @@ def is_macos():
 
 @functools.lru_cache
 def venv_meson_path() -> Path:
-    if os.getenv('CI', 'false') == 'true':
+    if is_ci():
         # assume CI already has a current Meson
         return Path('meson')
 


### PR DESCRIPTION
Verify the hash of the downloaded source archive before uploading it.  If the download is truncated or upstream has changed the file, there's no point creating a corrupt mirror.

If we can't fetch from the `source_url`, try the `source_fallback_url`, since some of the wraps have one.

If we fail to download a valid source archive, finish the release without setting `source_fallback_url`.  Previously we crashed and left behind an unusable GitHub release without a wrap file, which we did not (and do not) try to fix on subsequent runs.

Also reorder `source_fallback_url` in the published wrap files to be next to the other `source_*` keys, not after `patch_*`, and clean up some places where `create_release.py` was writing temporary files to the Git workdir.