### PR TITLE
ci: add IBM-hosted ppc64le and s390x runners

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -23,13 +23,15 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       cache-key: ${{ steps.cache-key.outputs.cache-key }}
+      matrix-alpine: ${{ steps.alpine.outputs.matrix }}
+      matrix-ubuntu: ${{ steps.ubuntu.outputs.matrix }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Install packages
-        run: python3 -m pip install git+https://github.com/mesonbuild/meson
+        run: python3 -m pip install PyYAML git+https://github.com/mesonbuild/meson
 
       - name: Calculate cache key
         id: cache-key
@@ -59,6 +61,40 @@ jobs:
           path: subprojects/packagecache
           enableCrossOsArchive: true
 
+      - name: Build Ubuntu matrix
+        id: ubuntu
+        shell: python tools/filter_matrix.py {0}
+        run: |
+          - platform: aarch64
+            runner: ubuntu-24.04-arm
+          - platform: ppc64le
+            runner: ubuntu-24.04-ppc64le
+            selfhosted: true
+          - platform: s390x
+            runner: ubuntu-24.04-s390x
+            selfhosted: true
+          - platform: x86_64
+            runner: ubuntu-latest
+
+      - name: Build Alpine matrix
+        id: alpine
+        shell: python tools/filter_matrix.py {0}
+        run: |
+          - platform: aarch64
+            runner: ubuntu-24.04-arm
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static#!sha256!e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4'
+          - platform: ppc64le
+            runner: ubuntu-24.04-ppc64le
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/ppc64le/apk.static#!sha256!fb576913fe730e039c9ca55f78c0686053aa2c3d9c4c593822a6e70ae36f0472'
+            selfhosted: true
+          - platform: s390x
+            runner: ubuntu-24.04-s390x
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/s390x/apk.static#!sha256!6880a5f5e7f62e1f4c47ad3a75d699f9b1f99f3f20f9f8be01637bef1012b8e7'
+            selfhosted: true
+          - platform: x86_64
+            runner: ubuntu-latest
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/x86_64/apk.static#!sha256!34bb1a96f0258982377a289392d4ea9f3f4b767a4bb5806b1b87179b79ad8a1c'
+
   Ubuntu:
     if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
     name: Ubuntu (${{ matrix.platform }})
@@ -66,15 +102,7 @@ jobs:
     needs: prelude
     strategy:
       matrix:
-        include:
-          - platform: aarch64
-            runner: ubuntu-24.04-arm
-          - platform: ppc64le
-            runner: ubuntu-24.04-ppc64le
-          - platform: s390x
-            runner: ubuntu-24.04-s390x
-          - platform: x86_64
-            runner: ubuntu-latest
+        include: ${{ fromJson(needs.prelude.outputs.matrix-ubuntu) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -105,19 +133,7 @@ jobs:
     needs: prelude
     strategy:
       matrix:
-        include:
-          - platform: aarch64
-            runner: ubuntu-24.04-arm
-            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static#!sha256!e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4'
-          - platform: ppc64le
-            runner: ubuntu-24.04-ppc64le
-            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/ppc64le/apk.static#!sha256!fb576913fe730e039c9ca55f78c0686053aa2c3d9c4c593822a6e70ae36f0472'
-          - platform: s390x
-            runner: ubuntu-24.04-s390x
-            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/s390x/apk.static#!sha256!6880a5f5e7f62e1f4c47ad3a75d699f9b1f99f3f20f9f8be01637bef1012b8e7'
-          - platform: x86_64
-            runner: ubuntu-latest
-            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/x86_64/apk.static#!sha256!34bb1a96f0258982377a289392d4ea9f3f4b767a4bb5806b1b87179b79ad8a1c'
+        include: ${{ fromJson(needs.prelude.outputs.matrix-alpine) }}
     steps:
       # https://github.com/jirutka/setup-alpine/pull/28
       - name: Create work directory

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -69,6 +69,10 @@ jobs:
         include:
           - platform: aarch64
             runner: ubuntu-24.04-arm
+          - platform: ppc64le
+            runner: ubuntu-24.04-ppc64le
+          - platform: s390x
+            runner: ubuntu-24.04-s390x
           - platform: x86_64
             runner: ubuntu-latest
     steps:
@@ -105,10 +109,20 @@ jobs:
           - platform: aarch64
             runner: ubuntu-24.04-arm
             apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static#!sha256!e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4'
+          - platform: ppc64le
+            runner: ubuntu-24.04-ppc64le
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/ppc64le/apk.static#!sha256!fb576913fe730e039c9ca55f78c0686053aa2c3d9c4c593822a6e70ae36f0472'
+          - platform: s390x
+            runner: ubuntu-24.04-s390x
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/s390x/apk.static#!sha256!6880a5f5e7f62e1f4c47ad3a75d699f9b1f99f3f20f9f8be01637bef1012b8e7'
           - platform: x86_64
             runner: ubuntu-latest
             apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/x86_64/apk.static#!sha256!34bb1a96f0258982377a289392d4ea9f3f4b767a4bb5806b1b87179b79ad8a1c'
     steps:
+      # https://github.com/jirutka/setup-alpine/pull/28
+      - name: Create work directory
+        run: mkdir -p $HOME/work
+
       - uses: jirutka/setup-alpine@v1
         with:
           # next two lines: https://github.com/jirutka/setup-alpine/pull/22
@@ -116,6 +130,8 @@ jobs:
           apk-tools-url: ${{ matrix.apk-tools-url }}
           packages: >
             binutils clang libc-dev fortify-headers make patch cmake git linux-headers pkgconf py3-pip samurai sudo
+          # https://github.com/jirutka/setup-alpine/pull/28
+          volumes: ${{ github.workspace }} ${{ runner.temp }}
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       cache-key: ${{ steps.cache-key.outputs.cache-key }}
+      matrix-alpine: ${{ steps.alpine.outputs.matrix }}
+      matrix-ubuntu: ${{ steps.ubuntu.outputs.matrix }}
       need-build: ${{ steps.sanity-checks.outputs.need-build }}
     steps:
       - uses: actions/checkout@v6
@@ -26,7 +28,7 @@ jobs:
 
       - name: Install packages
         run: |
-          python3 -m pip install license-expression
+          python3 -m pip install license-expression PyYAML
           python3 -m pip install --pre meson
 
       - name: Calculate cache key
@@ -61,6 +63,54 @@ jobs:
         run: |
           ./tools/fake_tty.py ./tools/sanity_checks.py
 
+      - name: Build Ubuntu matrix
+        id: ubuntu
+        shell: python tools/filter_matrix.py {0}
+        run: |
+          - platform: aarch64
+            runner: ubuntu-24.04-arm
+            python: 3.8
+          - platform: ppc64le
+            runner: ubuntu-24.04-ppc64le
+            selfhosted: true
+          - platform: s390x
+            runner: ubuntu-24.04-s390x
+            selfhosted: true
+          - platform: x86_64
+            runner: ubuntu-latest
+            python: 3.13
+
+      - name: Build Alpine matrix
+        id: alpine
+        shell: python tools/filter_matrix.py {0}
+        run: |
+          - platform: aarch64
+            runner: ubuntu-24.04-arm
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static#!sha256!e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4'
+          - platform: armv7
+            runner: ubuntu-24.04-arm
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static#!sha256!e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4'
+          - platform: loongarch64
+            runner: ubuntu-24.04-arm
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static#!sha256!e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4'
+          - platform: ppc64le
+            runner: ubuntu-24.04-ppc64le
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/ppc64le/apk.static#!sha256!fb576913fe730e039c9ca55f78c0686053aa2c3d9c4c593822a6e70ae36f0472'
+            selfhosted: true
+          - platform: riscv64
+            runner: ubuntu-24.04-arm
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static#!sha256!e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4'
+          - platform: s390x
+            runner: ubuntu-24.04-s390x
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/s390x/apk.static#!sha256!6880a5f5e7f62e1f4c47ad3a75d699f9b1f99f3f20f9f8be01637bef1012b8e7'
+            selfhosted: true
+          - platform: x86
+            runner: ubuntu-latest
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/x86_64/apk.static#!sha256!34bb1a96f0258982377a289392d4ea9f3f4b767a4bb5806b1b87179b79ad8a1c'
+          - platform: x86_64
+            runner: ubuntu-latest
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/x86_64/apk.static#!sha256!34bb1a96f0258982377a289392d4ea9f3f4b767a4bb5806b1b87179b79ad8a1c'
+
   Ubuntu:
     name: Ubuntu (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
@@ -69,17 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: aarch64
-            runner: ubuntu-24.04-arm
-            python: 3.8
-          - platform: ppc64le
-            runner: ubuntu-24.04-ppc64le
-          - platform: s390x
-            runner: ubuntu-24.04-s390x
-          - platform: x86_64
-            runner: ubuntu-latest
-            python: 3.13
+        include: ${{ fromJson(needs.prelude.outputs.matrix-ubuntu) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -131,31 +171,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: aarch64
-            runner: ubuntu-24.04-arm
-            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static#!sha256!e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4'
-          - platform: armv7
-            runner: ubuntu-24.04-arm
-            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static#!sha256!e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4'
-          - platform: loongarch64
-            runner: ubuntu-24.04-arm
-            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static#!sha256!e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4'
-          - platform: ppc64le
-            runner: ubuntu-24.04-ppc64le
-            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/ppc64le/apk.static#!sha256!fb576913fe730e039c9ca55f78c0686053aa2c3d9c4c593822a6e70ae36f0472'
-          - platform: riscv64
-            runner: ubuntu-24.04-arm
-            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static#!sha256!e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4'
-          - platform: s390x
-            runner: ubuntu-24.04-s390x
-            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/s390x/apk.static#!sha256!6880a5f5e7f62e1f4c47ad3a75d699f9b1f99f3f20f9f8be01637bef1012b8e7'
-          - platform: x86
-            runner: ubuntu-latest
-            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/x86_64/apk.static#!sha256!34bb1a96f0258982377a289392d4ea9f3f4b767a4bb5806b1b87179b79ad8a1c'
-          - platform: x86_64
-            runner: ubuntu-latest
-            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/x86_64/apk.static#!sha256!34bb1a96f0258982377a289392d4ea9f3f4b767a4bb5806b1b87179b79ad8a1c'
+        include: ${{ fromJson(needs.prelude.outputs.matrix-alpine) }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -73,6 +73,10 @@ jobs:
           - platform: aarch64
             runner: ubuntu-24.04-arm
             python: 3.8
+          - platform: ppc64le
+            runner: ubuntu-24.04-ppc64le
+          - platform: s390x
+            runner: ubuntu-24.04-s390x
           - platform: x86_64
             runner: ubuntu-latest
             python: 3.13
@@ -83,6 +87,7 @@ jobs:
 
       - name: Install Python ${{ matrix.python }}
         uses: actions/setup-python@v6
+        if: matrix.python
         with:
           python-version: ${{ matrix.python }}
 
@@ -137,11 +142,14 @@ jobs:
             runner: ubuntu-24.04-arm
             apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static#!sha256!e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4'
           - platform: ppc64le
-            runner: ubuntu-24.04-arm
-            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static#!sha256!e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4'
+            runner: ubuntu-24.04-ppc64le
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/ppc64le/apk.static#!sha256!fb576913fe730e039c9ca55f78c0686053aa2c3d9c4c593822a6e70ae36f0472'
           - platform: riscv64
             runner: ubuntu-24.04-arm
             apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static#!sha256!e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4'
+          - platform: s390x
+            runner: ubuntu-24.04-s390x
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/s390x/apk.static#!sha256!6880a5f5e7f62e1f4c47ad3a75d699f9b1f99f3f20f9f8be01637bef1012b8e7'
           - platform: x86
             runner: ubuntu-latest
             apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/x86_64/apk.static#!sha256!34bb1a96f0258982377a289392d4ea9f3f4b767a4bb5806b1b87179b79ad8a1c'
@@ -153,6 +161,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      # https://github.com/jirutka/setup-alpine/pull/28
+      - name: Create work directory
+        run: mkdir -p $HOME/work
+
       - uses: jirutka/setup-alpine@v1
         with:
           arch: ${{ matrix.platform }}
@@ -160,6 +172,8 @@ jobs:
           apk-tools-url: ${{ matrix.apk-tools-url }}
           packages: >
             binutils clang libc-dev fortify-headers make patch cmake git linux-headers pkgconf py3-pip samurai sudo
+          # https://github.com/jirutka/setup-alpine/pull/28
+          volumes: ${{ github.workspace }} ${{ runner.temp }}
 
       # https://github.com/jirutka/setup-alpine/pull/22
       - name: Disable QEMU emulation

--- a/tools/filter_matrix.py
+++ b/tools/filter_matrix.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Benjamin Gilbert <bgilbert@backtick.net>
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import sys
+import yaml
+import typing as T
+
+UPSTREAM_OWNER = 'mesonbuild'
+
+with open(sys.argv[1]) as f:
+    jobs: list[dict[str, T.Any]] = yaml.safe_load(f)
+
+if os.environ['GITHUB_REPOSITORY_OWNER'] != UPSTREAM_OWNER:
+    jobs = [j for j in jobs if not j.get('selfhosted', False)]
+
+with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+    f.write('matrix=')
+    json.dump(jobs, f, separators=(',', ':'))
+    f.write('\n')


### PR DESCRIPTION
They're only available in `mesonbuild/wrapdb`, not in forks.  As a result the emulated ppc64le job is potentially still useful, but it would likely bitrot since it wouldn't run in the main repo.  Drop that job.

Self-hosted runners don't count toward the concurrent job limit so this actually improves our parallelism.

setup-alpine doesn't understand that `$GITHUB_WORKSPACE` and `$RUNNER_TEMP` might not be under `$HOME/work`, so explicitly bind those into the chroot until this is fixed upstream.

GitHub doesn't have per-version Python builds for these arches, so just use the default Python.

In forks, the new jobs would sit indefinitely waiting for a runner to pick them up, blocking the workflow from completing.  We want to skip those jobs, but the job's `if:` directive can't read the `matrix` context.  Instead, preprocess the matrix from the prelude job.