### PR TITLE
ci: restrict `GITHUB_TOKEN` to read access where possible

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -10,6 +10,9 @@ on:
     # Run every Sunday at midnight
     - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+
 env:
   TEST_BUILD_ALL: 1
   TEST_FATAL_WARNINGS: ${{ github.event.inputs.fatal_warnings }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}
   # We do NOT want `cancel-in-progress` here since only one website job
@@ -13,6 +16,8 @@ concurrency:
 jobs:
   create_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -20,6 +25,7 @@ jobs:
       - name: Upload release assets
         run: |
           ./tools/create_release.py ${{ github.repository }} ${{ secrets.GITHUB_TOKEN }}
+
   # Ideally we should trigger Meson's CI to update the website, but unfortunately
   # it requires a Personal Access Token. Instead clone meson and do it ourself.
   # This job is copied from Meson's workflows.

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: ['*']
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
The `create_release` job needs write access, but nothing else does.