### PR TITLE
ci: store ancillary job parameters in matrix

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       fatal_warnings:
-        description: 'Build with --fatal-meson-warning (yes/no)'
+        description: 'Build with --fatal-meson-warnings (yes/no)'
         default: 'no'
         required: false
   schedule:

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -18,8 +18,8 @@ env:
   TEST_FATAL_WARNINGS: ${{ github.event.inputs.fatal_warnings }}
 
 jobs:
-  sources:
-    name: Download sources
+  prelude:
+    name: Initial setup
     runs-on: ubuntu-latest
     outputs:
       cache-key: ${{ steps.cache-key.outputs.cache-key }}
@@ -63,7 +63,7 @@ jobs:
     if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
     name: Ubuntu (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
-    needs: sources
+    needs: prelude
     strategy:
       matrix:
         include:
@@ -85,7 +85,7 @@ jobs:
       - name: Restore sources
         uses: actions/cache/restore@v4
         with:
-          key: ${{ needs.sources.outputs.cache-key }}
+          key: ${{ needs.prelude.outputs.cache-key }}
           path: subprojects/packagecache
           enableCrossOsArchive: true
           fail-on-cache-miss: true
@@ -98,7 +98,7 @@ jobs:
     if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
     name: Alpine (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
-    needs: sources
+    needs: prelude
     strategy:
       matrix:
         include:
@@ -124,7 +124,7 @@ jobs:
       - name: Restore sources
         uses: actions/cache/restore@v4
         with:
-          key: ${{ needs.sources.outputs.cache-key }}
+          key: ${{ needs.prelude.outputs.cache-key }}
           path: subprojects/packagecache
           enableCrossOsArchive: true
           fail-on-cache-miss: true
@@ -140,7 +140,7 @@ jobs:
   VisualStudio:
     if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
     runs-on: windows-latest
-    needs: sources
+    needs: prelude
     strategy:
       matrix:
         platform: ['x64', 'x86']
@@ -168,7 +168,7 @@ jobs:
       - name: Restore sources
         uses: actions/cache/restore@v4
         with:
-          key: ${{ needs.sources.outputs.cache-key }}
+          key: ${{ needs.prelude.outputs.cache-key }}
           path: subprojects/packagecache
           enableCrossOsArchive: true
           fail-on-cache-miss: true
@@ -180,7 +180,7 @@ jobs:
   VisualStudio-clang-cl:
     if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
     runs-on: windows-latest
-    needs: sources
+    needs: prelude
     env:
       CC: clang-cl
       CXX: clang-cl
@@ -198,7 +198,7 @@ jobs:
       - name: Restore sources
         uses: actions/cache/restore@v4
         with:
-          key: ${{ needs.sources.outputs.cache-key }}
+          key: ${{ needs.prelude.outputs.cache-key }}
           path: subprojects/packagecache
           enableCrossOsArchive: true
           fail-on-cache-miss: true
@@ -210,7 +210,7 @@ jobs:
   MSYS2:
     if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
     runs-on: windows-latest
-    needs: sources
+    needs: prelude
     strategy:
       matrix:
         platform: ['UCRT64', 'CLANG64']
@@ -245,7 +245,7 @@ jobs:
       - name: Restore sources
         uses: actions/cache/restore@v4
         with:
-          key: ${{ needs.sources.outputs.cache-key }}
+          key: ${{ needs.prelude.outputs.cache-key }}
           path: subprojects/packagecache
           enableCrossOsArchive: true
           fail-on-cache-miss: true
@@ -259,7 +259,7 @@ jobs:
     if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
     name: MacOS (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
-    needs: sources
+    needs: prelude
     strategy:
       matrix:
         include:
@@ -286,7 +286,7 @@ jobs:
       - name: Restore sources
         uses: actions/cache/restore@v4
         with:
-          key: ${{ needs.sources.outputs.cache-key }}
+          key: ${{ needs.prelude.outputs.cache-key }}
           path: subprojects/packagecache
           enableCrossOsArchive: true
           fail-on-cache-miss: true

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -61,11 +61,16 @@ jobs:
 
   Ubuntu:
     if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
-    runs-on: ${{ matrix.platform == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    name: Ubuntu (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     needs: sources
     strategy:
       matrix:
-        platform: ['x86_64', 'aarch64']
+        include:
+          - platform: aarch64
+            runner: ubuntu-24.04-arm
+          - platform: x86_64
+            runner: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
         with:
@@ -91,17 +96,24 @@ jobs:
 
   Alpine:
     if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
-    runs-on: ${{ matrix.platform == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    name: Alpine (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     needs: sources
     strategy:
       matrix:
-        platform: ['x86_64', 'aarch64']
+        include:
+          - platform: aarch64
+            runner: ubuntu-24.04-arm
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/aarch64/apk.static#!sha256!27a975638ddc95a411c9f17c63383e335da9edf6bb7de2281d950c291a11f878'
+          - platform: x86_64
+            runner: ubuntu-latest
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/x86_64/apk.static#!sha256!bdd044e0fd6cc388c5e571e1093efa5f35f7767cc5aa338b0a2576a429009a62'
     steps:
       - uses: jirutka/setup-alpine@v1
         with:
           # next two lines: https://github.com/jirutka/setup-alpine/pull/22
           arch: ${{ matrix.platform }}
-          apk-tools-url: ${{ matrix.platform == 'aarch64' && 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/aarch64/apk.static#!sha256!27a975638ddc95a411c9f17c63383e335da9edf6bb7de2281d950c291a11f878' || 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/x86_64/apk.static#!sha256!bdd044e0fd6cc388c5e571e1093efa5f35f7767cc5aa338b0a2576a429009a62' }}
+          apk-tools-url: ${{ matrix.apk-tools-url }}
           packages: >
             binutils clang libc-dev fortify-headers make patch cmake git linux-headers pkgconf py3-pip samurai sudo
 
@@ -245,11 +257,16 @@ jobs:
 
   MacOS:
     if: github.event_name != 'schedule' || github.repository == 'mesonbuild/wrapdb'
-    runs-on: ${{ matrix.platform == 'arm64' && 'macos-14' || 'macos-13' }}
+    name: MacOS (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     needs: sources
     strategy:
       matrix:
-        platform: ['arm64', 'x86_64']
+        include:
+          - platform: arm64
+            runner: macos-14
+          - platform: x86_64
+            runner: macos-13
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -60,16 +60,19 @@ jobs:
           ./tools/fake_tty.py ./tools/sanity_checks.py
 
   Ubuntu:
-    runs-on: ${{ matrix.platform == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    name: Ubuntu (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     needs: prelude
     strategy:
       fail-fast: false
       matrix:
         include:
-          - platform: x86_64
-            python: 3.13
           - platform: aarch64
+            runner: ubuntu-24.04-arm
             python: 3.8
+          - platform: x86_64
+            runner: ubuntu-latest
+            python: 3.13
     steps:
       - uses: actions/checkout@v5
         with:
@@ -109,12 +112,31 @@ jobs:
           ./tools/fake_tty.py ./tools/sanity_checks.py TestReleases.test_meson_version_deps
 
   Alpine:
-    runs-on: ${{ startsWith(matrix.platform, 'x86') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
+    name: Alpine (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     needs: prelude
     strategy:
       fail-fast: false
       matrix:
-        platform: ['x86_64', 'x86', 'aarch64', 'armv7', 'riscv64', 'ppc64le']
+        include:
+          - platform: aarch64
+            runner: ubuntu-24.04-arm
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/aarch64/apk.static#!sha256!27a975638ddc95a411c9f17c63383e335da9edf6bb7de2281d950c291a11f878'
+          - platform: armv7
+            runner: ubuntu-24.04-arm
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/aarch64/apk.static#!sha256!27a975638ddc95a411c9f17c63383e335da9edf6bb7de2281d950c291a11f878'
+          - platform: ppc64le
+            runner: ubuntu-24.04-arm
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/aarch64/apk.static#!sha256!27a975638ddc95a411c9f17c63383e335da9edf6bb7de2281d950c291a11f878'
+          - platform: riscv64
+            runner: ubuntu-24.04-arm
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/aarch64/apk.static#!sha256!27a975638ddc95a411c9f17c63383e335da9edf6bb7de2281d950c291a11f878'
+          - platform: x86
+            runner: ubuntu-latest
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/x86_64/apk.static#!sha256!bdd044e0fd6cc388c5e571e1093efa5f35f7767cc5aa338b0a2576a429009a62'
+          - platform: x86_64
+            runner: ubuntu-latest
+            apk-tools-url: 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/x86_64/apk.static#!sha256!bdd044e0fd6cc388c5e571e1093efa5f35f7767cc5aa338b0a2576a429009a62'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -124,7 +146,7 @@ jobs:
         with:
           arch: ${{ matrix.platform }}
           # https://github.com/jirutka/setup-alpine/pull/22
-          apk-tools-url: ${{ startsWith(matrix.platform, 'x86') && 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/x86_64/apk.static#!sha256!bdd044e0fd6cc388c5e571e1093efa5f35f7767cc5aa338b0a2576a429009a62' || 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/aarch64/apk.static#!sha256!27a975638ddc95a411c9f17c63383e335da9edf6bb7de2281d950c291a11f878' }}
+          apk-tools-url: ${{ matrix.apk-tools-url }}
           packages: >
             binutils clang libc-dev fortify-headers make patch cmake git linux-headers pkgconf py3-pip samurai sudo
 
@@ -281,12 +303,17 @@ jobs:
           python tools/sanity_checks.py
 
   MacOS:
-    runs-on: ${{ matrix.platform == 'arm64' && 'macos-14' || 'macos-13' }}
+    name: MacOS (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     needs: prelude
     strategy:
       fail-fast: false
       matrix:
-        platform: ['arm64', 'x86_64']
+        include:
+          - platform: arm64
+            runner: macos-14
+          - platform: x86_64
+            runner: macos-13
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
If we override the job name, we can put additional parameters in the job matrix and GitHub won't display them.  Use that to get rid of the ternaries.

Also some minor cleanups.

Broken out of #2406.