### PR TITLE
ci: update to macOS 15

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -264,9 +264,9 @@ jobs:
       matrix:
         include:
           - platform: arm64
-            runner: macos-14
+            runner: macos-latest
           - platform: x86_64
-            runner: macos-13
+            runner: macos-15-intel
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -311,9 +311,9 @@ jobs:
       matrix:
         include:
           - platform: arm64
-            runner: macos-14
+            runner: macos-latest
           - platform: x86_64
-            runner: macos-13
+            runner: macos-15-intel
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
`macos-latest` now points to macOS 15.  We no longer need to override a migration, so switch back to the `-latest` label.

GitHub also provides an Intel macOS 15 image, so switch the x86_64 runner over to that.