### PR TITLE
create_release: upload to draft release, then publish

### DIFF
--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -129,9 +129,12 @@ class CreateRelease:
                 else:
                     raise Exception('Refusing to recreate existing release')
 
+        cmd = ['git', 'rev-parse', 'HEAD']
+        commit = subprocess.check_output(cmd, text=True).strip()
         content = {
             'tag_name': self.tag,
             'name': self.tag,
+            'target_commitish': commit,
             'draft': True,
         }
         response = requests.post(api, headers=headers, json=content)

--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -42,6 +42,7 @@ class CreateRelease:
             self.create_source_fallback()
             self.create_patch_zip()
             self.create_wrap_file()
+            self.finalize()
 
     def warn(self, message: str) -> None:
         if is_ci():
@@ -120,6 +121,7 @@ class CreateRelease:
         response.raise_for_status()
         for r in response.json():
             if r['tag_name'] == self.tag:
+                self.release_id = r['id']
                 self.upload_url = r['upload_url'].replace('{?name,label}','')
                 print('Found release:', self.upload_url)
                 return
@@ -127,10 +129,13 @@ class CreateRelease:
         content = {
             'tag_name': self.tag,
             'name': self.tag,
+            'draft': True,
         }
         response = requests.post(api, headers=headers, json=content)
         response.raise_for_status()
-        self.upload_url = response.json()['upload_url'].replace('{?name,label}','')
+        r = response.json()
+        self.release_id = r['id']
+        self.upload_url = r['upload_url'].replace('{?name,label}','')
         print('Created release:', self.upload_url)
 
     def upload(self, path: Path, mimetype: str) -> None:
@@ -171,6 +176,16 @@ class CreateRelease:
         filename.write_bytes(response.content)
         self.upload(filename, 'application/zip')
         self.wrap_section['source_fallback_url'] = f'https://github.com/mesonbuild/wrapdb/releases/download/{self.tag}/{filename.name}'
+
+    def finalize(self) -> None:
+        if not self.repo or not self.token:
+            return
+        api = f'https://api.github.com/repos/{self.repo}/releases/{self.release_id}'
+        headers = { 'Authorization': f'token {self.token}' }
+        content = { 'draft': False }
+        response = requests.patch(api, headers=headers, json=content)
+        response.raise_for_status()
+        print('Published release:', self.upload_url)
 
 def run(repo: T.Optional[str], token: T.Optional[str]) -> None:
     releases = Releases.load()


### PR DESCRIPTION
We've been creating a public release and then uploading files into it.  However, if we crash halfway through, we leave behind a Git tag and an unusable release without a wrap file, since that's the last thing to be uploaded.  Subsequent runs see the tag and don't retry.

(Also, if we enable [immutable releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases) in the future, GitHub won't allow us to upload to a published release.)

Instead, create the release in draft form, upload to it, and then publish the release.  GitHub doesn't create the tag until we publish, so newly-created tags will reflect only releases that have actually completed.

As a consequence, we now retry failed releases on subsequent runs.  However, if we locate an existing draft release and any assets have been uploaded to it, GitHub refuses to let us upload those again.  Instead of manually clearing out existing assets, just delete any existing drafts with the intended tag name.

Fixes: #2224