### PR TITLE
Disable magic_enum tests

### DIFF
--- a/subprojects/magic_enum.wrap
+++ b/subprojects/magic_enum.wrap
@@ -3,6 +3,7 @@ directory = magic_enum-0.9.7
 source_url = https://github.com/Neargye/magic_enum/archive/refs/tags/v0.9.7.tar.gz
 source_filename = magic_enum-0.9.7.tar.gz
 source_hash = b403d3dad4ef542fdc3024fa37d3a6cedb4ad33c72e31b6d9bab89dcaf69edf7
+patch_directory = magic_enum
 
 [provide]
 magic_enum = magic_enum_dep

--- a/subprojects/packagefiles/magic_enum/meson_options.txt
+++ b/subprojects/packagefiles/magic_enum/meson_options.txt
@@ -1,0 +1,13 @@
+option(
+    'test',
+    type : 'boolean',
+    value : false,
+    description : 'Build and run tests'
+)
+
+option(
+    'hash',
+    type : 'boolean',
+    value : false,
+    description : 'Do hashing at build time - longer build times, but O(1) string lookup'
+)


### PR DESCRIPTION
I think usually anything using this as a dependency won't want these. Additionally, currently the tests bundle a version of catch2 that has problems with Windows.