### PR TITLE
imgui-docking: update to 1.92.3

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1612,9 +1612,10 @@
   },
   "imgui-docking": {
     "dependency_names": [
-      "imgui_docking"
+      "imgui-docking"
     ],
     "versions": [
+      "1.92.3-1",
       "1.91.6-1",
       "1.91.0-1"
     ]

--- a/subprojects/imgui-docking.wrap
+++ b/subprojects/imgui-docking.wrap
@@ -1,9 +1,9 @@
 [wrap-file]
-directory = imgui-1.91.6-docking
-source_url = https://github.com/ocornut/imgui/archive/refs/tags/v1.91.6-docking.tar.gz
-source_filename = imgui-docking-1.91.6.tar.gz
-source_hash = C78A11730F6E3F4911E151F96F2AA43E96ED77119599D8E7302F8294DFDB40D1
+directory = imgui-1.92.3-docking
+source_url = https://github.com/ocornut/imgui/archive/refs/tags/v1.92.3-docking.tar.gz
+source_filename = imgui-docking-1.92.3.tar.gz
+source_hash = fd0f88fcc593faa4d536c02baded6abc85463b9deb2d75ee829fed6d5dd48e0e
 patch_directory = imgui-docking
 
 [provide]
-imgui_docking = imgui_dep
+dependency_names = imgui-docking

--- a/subprojects/packagefiles/imgui-docking/meson.build
+++ b/subprojects/packagefiles/imgui-docking/meson.build
@@ -2,12 +2,15 @@ project(
   'imgui',
   'cpp',
   license: 'MIT',
-  version: '1.91.6',
-  meson_version: '>=0.50.0',
+  version: '1.92.3',
+  meson_version: '>=0.54.0',
 )
 
 if host_machine.system() == 'darwin'
-  add_languages('objcpp')
+  add_languages(
+    'objcpp',
+    native: false,
+  )
 endif
 
 include_dirs = include_directories('.', 'backends')
@@ -93,11 +96,20 @@ endif
 sdl2_renderer_dep = dependency(
   'sdl2',
   version: '>=2.0.17',
-  required: get_option('sdl_renderer'),
+  required: get_option('sdl2_renderer'),
 )
 if sdl2_renderer_dep.found()
   sources += 'backends/imgui_impl_sdlrenderer2.cpp'
   dependencies += sdl2_renderer_dep
+endif
+sdl3_renderer_dep = dependency(
+  'sdl3',
+  version: '>=3.1.3',
+  required: get_option('sdl3_renderer'),
+)
+if sdl3_renderer_dep.found()
+  sources += 'backends/imgui_impl_sdlrenderer3.cpp'
+  dependencies += sdl3_renderer_dep
 endif
 vulkan_dep = dependency(
   'vulkan',
@@ -130,6 +142,14 @@ sdl2_dep = dependency(
 if sdl2_dep.found()
   sources += 'backends/imgui_impl_sdl2.cpp'
   dependencies += sdl2_dep
+endif
+sdl3_dep = dependency(
+  'sdl3',
+  required: get_option('sdl3'),
+)
+if sdl3_dep.found()
+  sources += 'backends/imgui_impl_sdl3.cpp'
+  dependencies += sdl3_dep
 endif
 osx_dep = dependency(
   'appleframeworks',
@@ -190,3 +210,5 @@ imgui_dep = declare_dependency(
   include_directories: include_dirs,
   link_with: imgui,
 )
+
+meson.override_dependency('imgui-docking', imgui_dep)

--- a/subprojects/packagefiles/imgui-docking/meson_options.txt
+++ b/subprojects/packagefiles/imgui-docking/meson_options.txt
@@ -30,7 +30,12 @@ option(
     value: 'auto',
 )
 option(
-    'sdl_renderer',
+    'sdl2_renderer',
+    type: 'feature',
+    value: 'auto',
+)
+option(
+    'sdl3_renderer',
     type: 'feature',
     value: 'auto',
 )
@@ -53,6 +58,11 @@ option(
 )
 option(
     'sdl2',
+    type: 'feature',
+    value: 'auto',
+)
+option(
+    'sdl3',
     type: 'feature',
     value: 'auto',
 )


### PR DESCRIPTION
Things done:
  - updated imgui-docking to 1.92.3
  - added sdl3 and sdl3 renderer backend support
  - updated to new meson syntax

Based on https://github.com/mesonbuild/wrapdb/pull/2395 

I needed it in my new engine project

> P.S those next comments were before the rework, please ignore