### PR TITLE
crow: add 1.3.0 wrap

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -157,6 +157,19 @@
       "cppzmq:examples=true"
     ]
   },
+  "crow": {
+    "build_options": [
+      "crow:examples=true",
+      "crow:tests=enabled",
+      "crow:ssl=auto",
+      "crow:compression=enabled",
+      "catch2:tests=false"
+    ],
+    "alpine_packages": [
+      "openssl-dev",
+      "openssl"
+    ]
+  },
   "curl": {
     "_comment": [
       "don't bother installing samba: not usable by the testuite due to smbd non-standard install name",

--- a/releases.json
+++ b/releases.json
@@ -665,6 +665,14 @@
       "1.3.0-1"
     ]
   },
+  "crow": {
+    "dependency_names": [
+      "Crow"
+    ],
+    "versions": [
+      "1.3.0-1"
+    ]
+  },
   "ctre": {
     "dependency_names": [
       "ctre"

--- a/subprojects/crow.wrap
+++ b/subprojects/crow.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = Crow-1.3.0
+source_url = https://github.com/CrowCpp/Crow/archive/refs/tags/v1.3.0.tar.gz
+source_filename = Crow-1.3.0.tar.gz
+source_hash = a485c2d27d98b85655f4b8b5628aeab847bae10a41b89b07a8fb7aae52c0298f
+patch_directory = crow
+
+[provide]
+dependency_names = Crow

--- a/subprojects/packagefiles/crow/examples/meson.build
+++ b/subprojects/packagefiles/crow/examples/meson.build
@@ -1,0 +1,149 @@
+if not get_option('examples')
+  subdir_done()
+endif
+
+executable(
+  'helloworld',
+  'helloworld.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+
+if zlib_dep.found()
+  executable(
+    'example_compression',
+    'example_compression.cpp',
+    dependencies: crow_dep,
+    override_options: crow_private_options,
+    cpp_args: crow_private_args,
+  )
+endif
+
+if openssl_dep.found()
+  executable(
+    'example_ssl',
+    'ssl/example_ssl.cpp',
+    dependencies: crow_dep,
+    override_options: crow_private_options,
+    cpp_args: crow_private_args,
+  )
+endif
+
+executable(
+  'example_websocket',
+  'websocket/example_ws.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+# TODO: meson does not support writing file into subdir
+# configure_file(copy: true, input: 'websocket/templates/ws.html', output: 'templates/ws.html')
+
+executable(
+  'basic_example',
+  'example.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+
+executable(
+  'example_chat',
+  'example_chat.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+# TODO: meson does not support writing file into subdir
+# configure_file(copy: true, input: 'example_chat.html', output: 'templates/example_chat.html')
+
+executable(
+  'example_static_file',
+  'example_static_file.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+
+executable(
+  'example_catchall',
+  'example_catchall.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+
+executable(
+  'example_json_map',
+  'example_json_map.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+
+executable(
+  'example_blueprint',
+  'example_blueprint.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+
+executable(
+  'example_middleware',
+  'example_middleware.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+
+executable(
+  'example_cors',
+  'middlewares/example_cors.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+
+executable(
+  'example_cookies',
+  'middlewares/example_cookies.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+
+executable(
+  'example_session',
+  'middlewares/example_session.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+
+executable(
+  'example_file_upload',
+  'example_file_upload.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+
+executable(
+  'example_unix_socket',
+  'example_unix_socket.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+
+if meson.get_compiler('cpp').get_argument_syntax() == 'msvc'
+  executable(
+    'example_vs',
+    'example_vs.cpp',
+    dependencies: crow_dep,
+    override_options: crow_private_options,
+    cpp_args: crow_private_args,
+  )
+endif

--- a/subprojects/packagefiles/crow/meson.build
+++ b/subprojects/packagefiles/crow/meson.build
@@ -1,0 +1,92 @@
+project(
+  'Crow',
+  'cpp',
+  version: '1.3.0',
+  license: 'BSD-3-Clause',
+  meson_version: '>=0.54.0',
+)
+
+# equvalent to add_warnings_optimizations macro in compiler_options.cmake
+crow_private_options = ['cpp_std=c++17', 'warning_level=3', 'werror=false']
+crow_private_args = meson.get_compiler('cpp').get_supported_arguments(
+  '-Wsuggest-override',
+  '-Wshadow',
+  '/bigobj',
+  '-Wa,-mbig-obj',
+  '/permissive-',
+  get_option('debug') ? ['/Ob0', '/RTC1'] : [],
+)
+
+crow_public_args = []
+crow_deps = []
+
+if get_option('return_ok_on_http_options')
+  crow_public_args += 'CROW_RETURNS_OK_ON_HTTP_OPTIONS_REQUEST'
+endif
+
+boost_dep = dependency(
+  'boost',
+  modules: ['date_time'],
+  required: get_option('boost'),
+)
+if boost_dep.found()
+  crow_deps += boost_dep
+  crow_public_args += '-DCROW_USE_BOOST'
+  summary('asio', 'Boost.Asio')
+else
+  asio_dep = dependency(
+    'asio',
+    required: true,
+  )
+  crow_deps += asio_dep
+  crow_public_args += '-DASIO_NO_DEPRECATED'
+  summary('asio', 'Standalone Asio')
+endif
+
+if host_machine.system() == 'windows' and meson.get_compiler('cpp').get_argument_syntax() != 'msvc'
+  # actually this is a dependency of asio and boost.asio rather than crow specific.
+  crow_deps += [
+    meson.get_compiler('cpp').find_library('ws2_32'),
+    meson.get_compiler('cpp').find_library('mswsock'),
+  ]
+endif
+
+openssl_dep = dependency(
+  'openssl',
+  required: get_option('ssl'),
+)
+if openssl_dep.found()
+  crow_deps += openssl_dep
+  crow_public_args += '-DCROW_ENABLE_SSL'
+endif
+summary(
+  'ssl',
+  openssl_dep.found(),
+  bool_yn: true,
+)
+
+zlib_dep = dependency(
+  'zlib',
+  required: get_option('compression'),
+)
+if zlib_dep.found()
+  crow_deps += zlib_dep
+  crow_public_args += '-DCROW_ENABLE_COMPRESSION'
+endif
+summary(
+  'compression',
+  zlib_dep.found(),
+  bool_yn: true,
+)
+
+crow_inc = include_directories('include')
+
+crow_dep = declare_dependency(
+  include_directories: crow_inc,
+  dependencies: crow_deps,
+  compile_args: crow_public_args,
+)
+meson.override_dependency('Crow', crow_dep)
+
+subdir('examples')
+subdir('tests')

--- a/subprojects/packagefiles/crow/meson_options.txt
+++ b/subprojects/packagefiles/crow/meson_options.txt
@@ -1,0 +1,38 @@
+option(
+    'examples',
+    type: 'boolean',
+    value: false,
+    description: 'Build the examples in the project',
+)
+option(
+    'tests',
+    type: 'feature',
+    value: 'disabled',
+    description: 'Build the tests in the project',
+)
+# option('fuzzer', type: 'feature', value: 'false', description: 'Instrument and build Crow fuzzer')
+# option('amalgamate', type: 'boolean', value: false, 'Combine all headers into one')
+option(
+    'boost',
+    type: 'feature',
+    value: 'disabled',
+    description: 'Use Boost.Asio for Crow',
+)
+option(
+    'ssl',
+    type: 'feature',
+    value: 'disabled',
+    description: 'Enable Crow\'s SSL feature for supporting https',
+)
+option(
+    'compression',
+    type: 'feature',
+    value: 'disabled',
+    description: 'Enable Crow\'s Compression feature for supporting compressed http content',
+)
+option(
+    'return_ok_on_http_options',
+    type: 'boolean',
+    value: false,
+    description: 'Returns HTTP status code OK (200) instead of 204 for OPTIONS request',
+)

--- a/subprojects/packagefiles/crow/tests/external_definition/meson.build
+++ b/subprojects/packagefiles/crow/tests/external_definition/meson.build
@@ -1,0 +1,7 @@
+executable(
+  'test_external_definition',
+  'main.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)

--- a/subprojects/packagefiles/crow/tests/img/meson.build
+++ b/subprojects/packagefiles/crow/tests/img/meson.build
@@ -1,0 +1,10 @@
+configure_file(
+  copy: true,
+  input: 'cat.jpg',
+  output: 'cat.jpg',
+)
+configure_file(
+  copy: true,
+  input: 'filewith.badext',
+  output: 'filewith.badext',
+)

--- a/subprojects/packagefiles/crow/tests/meson.build
+++ b/subprojects/packagefiles/crow/tests/meson.build
@@ -1,0 +1,49 @@
+catch2_dep = dependency(
+  'catch2-with-main',
+  required: get_option('tests'),
+  default_options: ['cpp_std=c++17'],
+)
+if not catch2_dep.found()
+  summary(
+    'tests',
+    false,
+    bool_yn: true,
+  )
+  subdir_done()
+endif
+summary(
+  'tests',
+  true,
+  bool_yn: true,
+)
+
+test_srcs = [
+  'unittest.cpp',
+  'query_string_tests.cpp',
+  'unit_tests/test_http_response.cpp',
+  'unit_tests/test_json.cpp',
+  'unit_tests/test_mustache.cpp',
+  'unit_tests/test_utility.cpp',
+  'unit_tests/test_websocket.cpp',
+]
+
+unittest = executable(
+  'unittest',
+  test_srcs,
+  dependencies: [crow_dep, catch2_dep],
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+subdir('template')
+subdir('multi_file')
+subdir('external_definition')
+subdir('ssl')
+subdir('img')
+
+fs = import('fs')
+test(
+  'crow_test',
+  unittest,
+  timeout: 90,
+  workdir: fs.parent(meson.current_build_dir()),
+)

--- a/subprojects/packagefiles/crow/tests/multi_file/meson.build
+++ b/subprojects/packagefiles/crow/tests/multi_file/meson.build
@@ -1,0 +1,8 @@
+executable(
+  'test_multi_file',
+  'main.cpp',
+  'secondary.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)

--- a/subprojects/packagefiles/crow/tests/ssl/meson.build
+++ b/subprojects/packagefiles/crow/tests/ssl/meson.build
@@ -1,0 +1,28 @@
+# original CMakeLists.txt excludes MSVC only here
+# but upstream does not test mingw and it seems to fail on mingw too.
+if host_machine.system() == 'windows' or not openssl_dep.found() or not find_program(
+  'openssl',
+  required: false,
+).found()
+  summary(
+    'ssltest',
+    false,
+    bool_yn: true,
+  )
+  subdir_done()
+endif
+summary(
+  'ssltest',
+  true,
+  bool_yn: true,
+)
+
+ssltest = executable(
+  'ssltest',
+  'ssltest.cpp',
+  dependencies: [crow_dep, catch2_dep],
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+
+test('ssl_test', ssltest)

--- a/subprojects/packagefiles/crow/tests/template/meson.build
+++ b/subprojects/packagefiles/crow/tests/template/meson.build
@@ -1,0 +1,44 @@
+mustachetest_exe = executable(
+  'mustachetest',
+  'mustachetest.cpp',
+  dependencies: crow_dep,
+  override_options: crow_private_options,
+  cpp_args: crow_private_args,
+)
+
+# original CMakeLists.txt excludes MSVC only here
+# but upstream does not test mingw and it seems to fail on mingw too.
+# if meson.get_compiler('cpp').get_argument_syntax() != 'msvc'
+if host_machine.system() != 'windows'
+  py_prog = find_program('python3')
+  json_files = [
+    'comments.json',
+    'crow_extra_mustache_tests.json',
+    'delimiters.json',
+    'interpolation.json',
+    'inverted.json',
+    'partials.json',
+    'sections.json',
+    '~lambdas.json',
+  ]
+  foreach f : json_files
+    configure_file(
+      copy: true,
+      input: f,
+      output: f,
+    )
+  endforeach
+  configure_file(
+    copy: true,
+    input: 'test.py',
+    output: 'test.py',
+  )
+
+  test(
+    'template_test',
+    py_prog,
+    args: ['test.py'],
+    workdir: meson.current_build_dir(),
+    depends: mustachetest_exe,
+  )
+endif


### PR DESCRIPTION
https://github.com/CrowCpp/Crow

- translated to meson everything except tests/fuzz (requires environment variable and I don't know about ossfuzz), crow_amalgamate (I think it's not needed when using as subproject), and installation.
- all options are disabled by default because it's disabled by default in original CMakeLists.txt.
- `crow:ssl=auto` in CI config because openssl is not available on VisualStudio x86 CI.
- `catch2:tests=false` in CI config because it doesn't compile on MinGW (upstream issue?)
