### PR TITLE
Fix include path for protobuf-c

### DIFF
--- a/subprojects/packagefiles/protobuf-c/protobuf-c/meson.build
+++ b/subprojects/packagefiles/protobuf-c/protobuf-c/meson.build
@@ -28,6 +28,6 @@ pkgconfig.generate(
 depinc = include_directories('.')
 libprotobuf_c_dep = declare_dependency(
   compile_args: api,
-  include_directories: depinc,
+  include_directories: [depinc, include_directories('..')],
   link_with: libprotobuf_c,
 )


### PR DESCRIPTION
The C code generated by `protoc-c` includes the header as:
```c
#include <protobuf-c/protobuf-c.h>
```

However, when protobuf-c is used as a meson subproject, the declared dependency only exports the current directory (`.`) in its include paths. This means the `protobuf-c/` prefix in the include path cannot be resolved, causing compilation errors like:
```
fatal error: protobuf-c/protobuf-c.h: No such file or directory
```
the solution is to add the parent directory to the include paths in the dependency declaration:
```meson
include_directories: [depinc, include_directories('..')],
```
Now the include path resolves correctly: