### PR TITLE
nginx: add v2 `get_source` endpoint

### DIFF
--- a/nginx/default
+++ b/nginx/default
@@ -11,6 +11,7 @@
 server {
   location /v2 {
     rewrite ^.*/v2/releases.json$ https://raw.githubusercontent.com/mesonbuild/wrapdb/master/releases.json permanent;
+    rewrite ^.*/v2/([^/]+)/get_source/([^/]+)$ https://github.com/mesonbuild/wrapdb/releases/download/$1/$2 permanent;
     rewrite ^.*/v2/([^/]+)/get_patch$ https://github.com/mesonbuild/wrapdb/releases/download/$1/$1_patch.zip permanent;
     rewrite ^.*/v2/([^/]+)/([^/]+).wrap$ https://github.com/mesonbuild/wrapdb/releases/download/$1/$2.wrap permanent;
   }


### PR DESCRIPTION
wrapdb.mesonbuild.com abstracts over the GitHub URLs for wrap files and patch zips, but not for mirrored sources: `create_release.py` generates `source_fallback_url`s which point directly to the wrap's GitHub release.  As a result, GitHub isn't just an implementation detail: we can't retroactively add additional mirrors, and the existing mirror will break if we ever have to move off GitHub.  Add a `get_source` endpoint similar to `get_patch` so `create_release.py` can start using it.

While we're here, disallow trailing garbage in v2 URLs to improve hygiene.  (I'm not aware of anything currently sending trailing garbage, but if such code exists this will obviously break it.)

cc @tp-m