### PR TITLE
Add mechanism to deprecate a wrap in `releases.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ key is the wrap name and the value is a dictionary containing with the following
 | `versions`        | Sorted list (newest first) of release tags in the format `<upstream version>-<revision>` where the revision starts at 1 and is incremented when a change is made in the meson port.         |
 | `dependency_names`| List of dependency names (e.g. pkg-config name such as `glib-2.0`) provided by the wrap. It must match names from wrap's `[provide]` section, may be omitted if none.                      |
 | `program_names`   | List of program names (e.g. `glib-compile-resources`) provided by the wrap. It must match names from wrap's `[provide]` section, may be omitted if none.                                   |
+| `deprecated`      | (Optional) Object describing a wrap that is no longer maintained.  If there's an API-compatible replacement, the `replacement` field names it; if there's an API-incompatible replacement, `successor` names it; otherwise `reason` explains why the wrap is unmaintained. |
 
 ### CI Configure Meta
 

--- a/releases.json
+++ b/releases.json
@@ -1790,6 +1790,9 @@
     ]
   },
   "json": {
+    "deprecated": {
+      "replacement": "nlohmann_json"
+    },
     "versions": [
       "3.2.0-1",
       "2.1.1-1",
@@ -2854,6 +2857,9 @@
     "dependency_names": [
       "luajit"
     ],
+    "deprecated": {
+      "reason": "project does not perform formal releases"
+    },
     "program_names": [
       "luajit"
     ],
@@ -3312,6 +3318,9 @@
     ]
   },
   "onqtam-doctest": {
+    "deprecated": {
+      "replacement": "doctest"
+    },
     "versions": [
       "2.4.0-1",
       "2.3.7-1"
@@ -3461,6 +3470,9 @@
       "libpcre",
       "libpcreposix"
     ],
+    "deprecated": {
+      "successor": "pcre2"
+    },
     "versions": [
       "8.45-5",
       "8.45-4",

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -138,10 +138,6 @@ PER_PROJECT_PERMITTED_FILES: dict[str, set[str]] = {
         'meson.build.tmpl',
         'README.md',
     },
-    'pcre': {
-        'pcre.def',
-        'pcreposix.def'
-    },
     'protobuf': {
         'symlink_or_copy.py',
     },

--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -174,7 +174,8 @@ SOURCE_FILENAME_PREFIXES = {
 MIT_LICENSE_BLOCKS = {'expat', 'freeglut', 'glew', 'google-brotli'}
 FORMAT_CHECK_FILES = {'meson.build', 'meson_options.txt', 'meson.options'}
 SUBPROJECTS_METADATA_FILES = {'subprojects/.gitignore'}
-PERMITTED_KEYS = {'versions', 'dependency_names', 'program_names'}
+PERMITTED_KEYS = {'versions', 'dependency_names', 'program_names', 'deprecated'}
+PERMITTED_DEPRECATION_KEYS = {'reason', 'replacement', 'successor'}
 IGNORE_SETUP_WARNINGS = None  # or re.compile(r'something')
 
 
@@ -229,6 +230,10 @@ class TestReleases(unittest.TestCase):
         for name, info in self.releases.items():
             for k in info.keys():
                 self.assertIn(k, PERMITTED_KEYS)
+            if 'deprecated' in info:
+                self.assertEqual(len(info['deprecated']), 1)
+                for k in info['deprecated']:
+                    self.assertIn(k, PERMITTED_DEPRECATION_KEYS)
 
         try:
             Releases.format(check=True)
@@ -367,6 +372,8 @@ class TestReleases(unittest.TestCase):
                         with self.subTest(step='check_new_release'):
                             has_new_releases = True
                             self.log_context(name)
+                            self.assertNotIn('deprecated', self.releases[name],
+                                             f'Found new release for deprecated wrap {name}')
                             if not self.skip_build:
                                 self.check_new_release(name, deps=deps, progs=progs)
                                 with self.subTest(f'If this works now, please remove it from broken_{platform.system().lower()}!'):

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -140,6 +140,15 @@ class ProjectReleases(T.TypedDict):
     dependency_names: T.NotRequired[list[str]]
     program_names: T.NotRequired[list[str]]
     versions: list[str]
+    deprecated: T.NotRequired[ProjectDeprecated]
+
+class ProjectDeprecated(T.TypedDict):
+    # for wraps with no replacement
+    reason: T.NotRequired[str]
+    # for wraps with an API-compatible replacement
+    replacement: T.NotRequired[str]
+    # for wraps with an API-incompatible replacement
+    successor: T.NotRequired[str]
 
 class Releases(T.Dict[str, ProjectReleases], _JSONFile):
     FILENAME = 'releases.json'

--- a/tools/versions.py
+++ b/tools/versions.py
@@ -35,13 +35,6 @@ from utils import Releases, read_wrap, wrap_path
 WRAP_URL_TEMPLATE = (
     'https://github.com/mesonbuild/wrapdb/blob/master/subprojects/{0}.wrap'
 )
-# wraps that exist but whose versions should not be reported or updated
-DEPRECATED_WRAPS = set([
-    # replaced with nlohmann_json
-    'json',
-    # replaced with doctest
-    'onqtam-doctest'
-])
 
 
 class AnityaPackageList(T.TypedDict):
@@ -114,7 +107,7 @@ def get_wrap_versions() -> dict[str, str]:
     return {
         name: info['versions'][0].split('-')[0]
         for name, info in Releases.load().items()
-        if name not in DEPRECATED_WRAPS
+        if 'deprecated' not in info
     }
 
 


### PR DESCRIPTION
We have two formally-deprecated wraps, `json` and `onqtam-doctest`, plus a wrap `luajit` that doesn't perform formal releases and should not have been accepted.  Add a mechanism for declaring these in `releases.json` so Meson can warn about it.