### PR TITLE
create_release: add `patch_fallback_url`; point `source_fallback_url` at nginx

### DIFF
--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -182,7 +182,7 @@ class CreateRelease:
         filename = Path(self.tempdir, self.wrap_section['source_filename'])
         filename.write_bytes(response.content)
         self.upload(filename, 'application/zip')
-        self.wrap_section['source_fallback_url'] = f'https://github.com/mesonbuild/wrapdb/releases/download/{self.tag}/{filename.name}'
+        self.wrap_section['source_fallback_url'] = f'https://wrapdb.mesonbuild.com/v2/{self.tag}/get_source/{filename.name}'
 
     def finalize(self) -> None:
         if not self.repo or not self.token:


### PR DESCRIPTION
`patch_url` points to a redirect on `wrapdb.mesonbuild.com`, which is convenient if we ever want to add additional mirrors or if we have to move off of GitHub.  However, it also means wraps will fail to build if `wrapdb.mesonbuild.com` goes down, unless the patch is already cached locally.  Avoid this by adding a `patch_fallback_url` pointing directly to the GitHub download.

Conversely, `source_fallback_url` points directly at the source mirror in the GitHub release, which means we can't retroactively add additional mirrors or move existing releases off of GitHub.  Instead, point it to the new `get_source` API endpoint on `wrapdb.mesonbuild.com`.  This introduces a failure if `wrapdb.mesonbuild.com` goes down, but only in the fallback path when the canonical source URL is unavailable.  That seems like a worthwhile trade for the added flexibility.