### PR TITLE
sanity_checks: forbid commit hash in `source_url`

### DIFF
--- a/tools/sanity_checks.py
+++ b/tools/sanity_checks.py
@@ -445,6 +445,8 @@ class TestReleases(unittest.TestCase):
     def check_source_url(self, name: str, wrap_section: configparser.SectionProxy, version: str) -> None:
         source_url = wrap_section['source_url']
         self.assertNotIn('ftp.gnu.org', source_url, 'use ftpmirror.gnu.org instead')
+        if re.search(r'/[0-9a-f]{40}', source_url):
+            raise Exception('Commit hash found in source_url.  Source must come from a release artifact or tag.')
 
         if name == 'sqlite3':
             segs = version.split('.')


### PR DESCRIPTION
We have wraps that get around the version check by appending the version number to the URL, even though the URL points to a Git commit.  Add a check for this.  (The check can still be circumvented by a motivated contributor, but is useful nonetheless as review feedback.)

Also call `check_source_url()` only on updated wraps, so we can remove the historical `netstring-c` and `luajit` exceptions to the version check.