### PR TITLE
sanity_checks: ports cannot have upstream `meson.build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ name and the value is a dictionary containing with the following keys:
 | `skip_program_check`    | (Optional) List of platform-specific program names that are not always provided by the project.                                                                                                                                                                                                      |
 | `test_options`          | (Optional) List of arguments that will be passed to `meson test` command (e.g. `--timeout-multiplier`, `--no-suite`).                                                                                                                                                                                |
 | `skip_tests`            | (Optional) If set to `true` tests will not be run. This is useful when tests are known to fail because of upstream issues, or require a specific environment hard to set up.                                                                                                                         |
+| `ignore_upstream_meson` | (Optional) Allow wrap to override an upstream Meson config, but only in the specified upstream version. This is useful when adding a wrap with buggy upstream Meson code while awaiting upstream fixes.                                                                                              |
 
 ### Running sanity test locally
 

--- a/ci_config.json
+++ b/ci_config.json
@@ -118,6 +118,9 @@
     "fatal_warnings": false,
     "skip_tests": true
   },
+  "cairomm": {
+    "ignore_upstream_meson": "1.18.0"
+  },
   "cexception": {
     "build_options": [
       "cexception:werror=false"
@@ -226,6 +229,9 @@
       "curl:ca_bundle=",
       "curl:ca_path="
     ]
+  },
+  "cwalk": {
+    "ignore_upstream_meson": "1.2.9"
   },
   "dlfcn-win32": {
     "_comment": "- Requires Windows",
@@ -774,6 +780,9 @@
       "libunistring"
     ]
   },
+  "libsigcplusplus-3": {
+    "ignore_upstream_meson": "3.6.0"
+  },
   "libtirpc": {
     "_comment": "Linux only and libobsd is broken",
     "alpine_packages": [
@@ -1284,6 +1293,9 @@
       "quickjs-ng:tests=enabled",
       "quickjs-ng:examples=enabled"
     ]
+  },
+  "rang": {
+    "ignore_upstream_meson": "3.2"
   },
   "rdkafka": {
     "_comment": "- broken CI finds bad version of OpenSSL on Windows",

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -153,6 +153,7 @@ class ProjectCIConfig(T.TypedDict):
     skip_program_check: T.NotRequired[list[str]]
     skip_tests: T.NotRequired[bool]
     test_options: T.NotRequired[list[str]]
+    ignore_upstream_meson: T.NotRequired[str]
 
     alpine_packages: T.NotRequired[list[str]]
     brew_packages: T.NotRequired[list[str]]


### PR DESCRIPTION
When a port is updated, check its upstream source archive for a `meson.build` file and fail if present.  WrapDB wraps should not maintain a downstream Meson config that overrides an upstream one.

As a special exception, allow overriding the config in the first upstream release added to WrapDB.  This has been allowed in the past and is a pragmatic way to add new wraps while fixes propagate to slow-moving upstreams.

Switch `cmocka` to its upstream Meson config.  There are other wraps that override upstream but they're all waiting on their next releases for fixes.