### PR TITLE
libcppbor: add 1.0.0

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -165,6 +165,12 @@
     "_comment": "Upstream doesn't officially support 32-bit platforms and warns about it",
     "fatal_warnings": false
   },
+  "cppbor": {
+    "_comment": "MSVC x86 build fails due to missing openssl.",
+    "alpine_packages": [
+      "openssl-dev"
+    ]
+  },
   "cpputest": {
     "build_options": [
       "cpputest:enable_cpputest_extensions=true",

--- a/releases.json
+++ b/releases.json
@@ -674,6 +674,14 @@
       "0.3.3-1"
     ]
   },
+  "cppbor": {
+    "dependency_names": [
+      "cppbor"
+    ],
+    "versions": [
+      "1.0.0-1"
+    ]
+  },
   "cpputest": {
     "dependency_names": [
       "cpputest"

--- a/subprojects/cppbor.wrap
+++ b/subprojects/cppbor.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = libcppbor-1.0.0
+source_url = https://gitlab.com/viperscience/libcppbor/-/archive/1.0.0/libcppbor-1.0.0.tar.gz
+source_filename = libcppbor-1.0.0.tar.gz
+source_hash = 6fc328fe45f16f4d8ae9778d2d988d722ee6cc1222b27e6422060334dcd2e6c5
+
+[provide]
+dependency_names = cppbor


### PR DESCRIPTION
Adding the Modern C++ CBOR Parser and Generator: libcppbor (version 1.0.0).

Libcppbor is a fork of the [Google Android Repository](https://android.googlesource.com/platform/system/libcppbor/) but focused on providing a more cross-platform friendly version of Libcppbor that may easily be pulled into non-android specific C++ projects.

CI builds are known to be failing for Windows MSVC x86 due to missing openssl dependency. If anyone has suggestions for how to fix that version of the CI build please describe. It is not really a targeted platform, so I think its ok to ignore for now.