### PR TITLE
microsoft-gsl: Update to 2.4.1

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -3073,9 +3073,10 @@
   },
   "microsoft-gsl": {
     "dependency_names": [
-      "microsoft_gsl"
+      "msft_gsl"
     ],
     "versions": [
+      "4.2.1-1",
       "4.2.0-1",
       "4.0.0-1",
       "3.1.0-1",

--- a/subprojects/microsoft-gsl.wrap
+++ b/subprojects/microsoft-gsl.wrap
@@ -1,10 +1,9 @@
 [wrap-file]
-directory = GSL-4.2.0
-
-source_url = https://github.com/microsoft/GSL/archive/v4.2.0.zip
-source_filename = GSL-4.2.0.zip
-source_hash = f694e7b0f3debc0c55fe138efb5dd9f5c402989c0dc04e8a74afc9c155cb66b9
+directory = GSL-4.2.1
+source_url = https://github.com/microsoft/GSL/archive/v4.2.1.zip
+source_filename = GSL-4.2.1.zip
+source_hash = c9291d95f5f6e5c561990d06a589b01d89e553d0f366f0ce723dd1788e7a6076
 patch_directory = microsoft-gsl
 
 [provide]
-microsoft_gsl = microsoft_gsl_dep
+dependency_names = msft_gsl

--- a/subprojects/packagefiles/microsoft-gsl/include/meson.build
+++ b/subprojects/packagefiles/microsoft-gsl/include/meson.build
@@ -1,0 +1,19 @@
+gsl_hdrs = files(
+  'gsl/algorithm',
+  'gsl/assert',
+  'gsl/byte',
+  'gsl/gsl',
+  'gsl/narrow',
+  'gsl/pointers',
+  'gsl/span',
+  'gsl/span_ext',
+  'gsl/util',
+  'gsl/zstring',
+)
+
+gsl_inc = include_directories('.')
+
+install_headers(
+  gsl_hdrs,
+  preserve_path: true,
+)

--- a/subprojects/packagefiles/microsoft-gsl/meson.build
+++ b/subprojects/packagefiles/microsoft-gsl/meson.build
@@ -1,10 +1,29 @@
 project(
   'microsoft-gsl',
   'cpp',
-  version: '4.2.0',
+  version: '4.2.1',
   license: 'MIT',
+  meson_version: '>=0.63.0',
 )
 
+subdir('include')
+
 microsoft_gsl_dep = declare_dependency(
-  include_directories: include_directories('include'),
+  include_directories: gsl_inc,
 )
+
+meson.override_dependency('msft_gsl', microsoft_gsl_dep)
+
+pkgconfig = import(
+  'pkgconfig',
+  required: false,
+)
+
+if pkgconfig.found()
+  pkgconfig.generate(
+    name: 'msft_gsl',
+    description: 'Guidelines Support Library',
+    url: 'https://github.com/microsoft/GSL',
+    install_dir: get_option('datadir') / 'pkgconfig',
+  )
+endif


### PR DESCRIPTION
- Added pkgconfig file generation
- Install headers
- Use `meson.override_dependency('msft_gsl')` !! Breaking `dependency('microsoft_gsl')`, but codesearch shows most existing users use the subproject variable instead of the dependency