### PR TITLE
Use Dependabot to update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns: ["*"]
+    labels: []
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Periodically, GitHub Actions switches to a new version of Node, causing a stream of major-version updates to individual Actions.  (Node version updates constitute breaking changes for self-hosted runners, though not for GitHub-hosted ones.)  These updates have to be applied in due course, otherwise GitHub will start spewing warnings to a workflow's summary page.  Currently we apply the updates manually as they're released; instead, have Dependabot do it for us in a monthly batch PR.

**Note**: Updates always require manually auditing the action's README or changelog for breaking changes.

Previous discussion in https://github.com/mesonbuild/wrapdb/pull/581 and https://github.com/mesonbuild/wrapdb/pull/1203.  Since then, Dependabot has learned to batch PRs and not to spam forks, which I believe addresses the prior logistical objections.