### PR TITLE
ci: fail zstd installation step if zstd can't be installed

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -253,7 +253,10 @@ jobs:
       # https://github.com/actions/partner-runner-images/issues/99
       - name: Install zstandard
         if: matrix.platform == 'arm64'
-        run: choco install zstandard
+        run: |
+          choco install -y zstandard
+          # choco exits 0 if it can't fetch package info
+          zstd -V
 
       - name: Install packages
         run: |
@@ -299,7 +302,10 @@ jobs:
       # https://github.com/actions/partner-runner-images/issues/99
       - name: Install zstandard
         if: matrix.platform == 'arm64'
-        run: choco install zstandard
+        run: |
+          choco install -y zstandard
+          # choco exits 0 if it can't fetch package info
+          zstd -V
 
       - name: Install packages
         run: |
@@ -347,7 +353,10 @@ jobs:
       # https://github.com/actions/partner-runner-images/issues/99
       - name: Install zstandard
         if: matrix.platform == 'CLANGARM64'
-        run: choco install zstandard
+        run: |
+          choco install -y zstandard
+          # choco exits 0 if it can't fetch package info
+          zstd -V
 
       - uses: msys2/setup-msys2@v2
         with:


### PR DESCRIPTION
choco apparently exits 0 if it can't fetch package info:

    Failed to fetch results from V2 feed at 'https://community.chocolatey.org/api/v2/Packages(Id='zstandard',Version='1.5.7.20250308')' with following message : Response status code does not indicate success: 504 (Gateway Timeout).
    Need to add specific handling for exception type NuGetResolverInputException
    Unable to find package 'zstandard'. Existing packages must be restored before performing an install or update.

    Chocolatey installed 0/0 packages.
    See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Explicitly check that zstd was installed to avoid a confusing failure later in the "Restore sources" step:

    Error: Failed to restore cache entry. Exiting as fail-on-cache-miss is set.

Also use `install -y` as the choco docs recommend.