### PR TITLE
ci: add gcc to Alpine to fix clang on Alpine 3.24

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -144,8 +144,9 @@ jobs:
           # next two lines: https://github.com/jirutka/setup-alpine/pull/22
           arch: ${{ matrix.platform }}
           apk-tools-url: ${{ matrix.apk-tools-url }}
+          # gcc for https://gitlab.alpinelinux.org/alpine/aports/-/work_items/18257
           packages: >
-            binutils clang libc-dev fortify-headers make patch cmake git linux-headers pkgconf py3-pip samurai sudo
+            binutils clang gcc libc-dev fortify-headers make patch cmake git linux-headers pkgconf py3-pip samurai sudo
           # https://github.com/jirutka/setup-alpine/pull/28
           volumes: ${{ github.workspace }} ${{ runner.temp }}
 

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -186,8 +186,9 @@ jobs:
           arch: ${{ matrix.platform }}
           # https://github.com/jirutka/setup-alpine/pull/22
           apk-tools-url: ${{ matrix.apk-tools-url }}
+          # gcc for https://gitlab.alpinelinux.org/alpine/aports/-/work_items/18257
           packages: >
-            binutils clang libc-dev fortify-headers make patch cmake git linux-headers pkgconf py3-pip samurai sudo
+            binutils clang gcc libc-dev fortify-headers make patch cmake git linux-headers pkgconf py3-pip samurai sudo
           # https://github.com/jirutka/setup-alpine/pull/28
           volumes: ${{ github.workspace }} ${{ runner.temp }}
 


### PR DESCRIPTION
The clang packages dropped the gcc dependency but they still need it.

https://gitlab.alpinelinux.org/alpine/aports/-/work_items/18257