### PR TITLE
Adds freetype compilation unit when toggled

### DIFF
--- a/subprojects/packagefiles/imgui/meson.build
+++ b/subprojects/packagefiles/imgui/meson.build
@@ -26,6 +26,12 @@ sources = files(
 cpp = meson.get_compiler('cpp')
 dependencies = []
 
+if get_option('freetype')
+    sources += files('misc/freetype/imgui_freetype.cpp')
+    add_project_arguments('-DIMGUI_ENABLE_FREETYPE', language: 'cpp')
+    dependencies += dependency('freetype2')
+endif
+
 # renderer backends
 dependencies += cpp.find_library(
   'd3dcompiler',

--- a/subprojects/packagefiles/imgui/meson_options.txt
+++ b/subprojects/packagefiles/imgui/meson_options.txt
@@ -88,3 +88,10 @@ option(
     type: 'feature',
     value: 'auto',
 )
+
+# freetype
+option(
+    'freetype',
+    type: 'boolean',
+    value: false,
+)


### PR DESCRIPTION
Adds the `misc/freetype/imgui_freetype.cpp` compilation unit with its dependencies to the `imgui` lib when the option `freetype` is set.

that enables this kind of configuration in your project

`dependency('imgui', default_options: ['freetype=true'])`