### PR TITLE
Add geo-utils-cpp 1.2.2

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1308,6 +1308,14 @@
       "0.20.6-1"
     ]
   },
+  "geo-utils-cpp": {
+    "dependency_names": [
+      "geo-utils-cpp"
+    ],
+    "versions": [
+      "1.2.2-1"
+    ]
+  },
   "gflags": {
     "dependency_names": [
       "gflags"

--- a/subprojects/geo-utils-cpp.wrap
+++ b/subprojects/geo-utils-cpp.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = geo-utils-cpp-1.2.2
+source_url = https://github.com/gistrec/geo-utils-cpp/archive/refs/tags/v1.2.2.tar.gz
+source_filename = geo-utils-cpp-1.2.2.tar.gz
+source_hash = 2ecc7726c73d7565e7820feafd944fc3d1800f586ca79e8b8b7fdb67a7ae2274
+
+[provide]
+dependency_names = geo-utils-cpp


### PR DESCRIPTION
Adds [geo-utils-cpp](https://github.com/gistrec/geo-utils-cpp) 1.2.0 — a header-only C++17 library for spherical lat/lng geometry (distance, bearing, polygon area, point-in-polygon, snap-to-route, encoded polylines). Apache-2.0, no dependencies.

The port is a minimal header-only wrap (`declare_dependency` + `override_dependency` + header install); upstream's self-verifying `examples/gps_track.cpp` is built and registered as a smoke test so the wrap exercises the headers on CI.

`tools/sanity_checks.py` passes locally (macOS arm64, AppleClang 17): the wrap downloads, the dependency resolves as `geo-utils-cpp`, the smoke test compiles and runs.