### PR TITLE
zxc: new wrap for 0.13.2

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -5167,6 +5167,14 @@
       "1.3.3-1"
     ]
   },
+  "zxc": {
+    "dependency_names": [
+      "libzxc"
+    ],
+    "versions": [
+      "0.13.2-1"
+    ]
+  },
   "zycore": {
     "dependency_names": [
       "zycore"

--- a/subprojects/zxc.wrap
+++ b/subprojects/zxc.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = zxc-0.13.2
+source_url = https://github.com/hellobertrand/zxc/archive/refs/tags/v0.13.2.tar.gz
+source_filename = zxc-0.13.2.tar.gz
+source_hash = 957acf0e2c0f230b6acc0a4d48c3ee4734117b290a8c8ef1a9cf29686924a0ac
+
+[provide]
+dependency_names = libzxc


### PR DESCRIPTION
Adds a wrap for [zxc](https://github.com/hellobertrand/zxc), a high-performance asymmetric lossless compression library written in C (BSD-3-Clause).

Key points
- Native Meson build: meson.build is maintained upstream, so this wrap ships no patch_directory / packagefiles.
- Provides the libzxc dependency (via meson.override_dependency).
- Runtime SIMD dispatch (SSE2 / AVX2 / AVX-512 on x86-64, NEON on ARM) with a scalar fallback.
- Requires Meson >= 0.63.0 (uses c_std in default_options).
- Builds and tests clean on Linux, macOS and Windows