### PR TITLE
ci: unset `XDG_RUNTIME_DIR` on Alpine

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -163,6 +163,9 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Sanity Checks
+        env:
+          # don't inherit nonexistent runtime dir from runner image
+          XDG_RUNTIME_DIR:
         run: |
           # Work around PEP 668 nonsense…
           sudo rm -vf /usr/lib*/python3.*/EXTERNALLY-MANAGED

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -209,6 +209,8 @@ jobs:
         env:
           CC: clang
           CXX: clang++
+          # don't inherit nonexistent runtime dir from runner image
+          XDG_RUNTIME_DIR:
         run: |
           # Work around PEP 668 nonsense…
           sudo rm -vf /usr/lib*/python3.*/EXTERNALLY-MANAGED


### PR DESCRIPTION
Otherwise we inherit it from the Ubuntu runner image, where it's set to a directory `/run/user/1001` that doesn't exist inside the container.  This breaks the tests for `wayland.wrap`:

    Assertion failed: mkdtemp(xdg_runtime_dir) && "test error: mkdtemp failed" (../subprojects/wayland-1.26.0/tests/test-runner.c: set_xdg_runtime_dir: 186)