### PR TITLE
ci: define a "needs fixes" PR label and automatically remove it on push

### DIFF
--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -1,0 +1,27 @@
+# Privileged workflow to label PRs
+
+name: Label PR
+
+on:
+  pull_request_target:
+    branches: [master]
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  label:
+    name: Process
+    runs-on: ubuntu-slim
+    steps:
+      - name: Remove needs-fixes label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit -R "${{ github.repository }}" \
+              "${{ github.event.number }}" \
+              --remove-label "needs fixes"


### PR DESCRIPTION
Add a privileged Actions job that removes any `needs fixes` label on a PR whenever that PR's branch is pushed.  This allows reviewers to set the label after giving review feedback, making it clear in the PR list which PRs don't need to be looked at again.