### PR TITLE
apache-orc: note that most CI is failing

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -28,8 +28,9 @@
     "libxml2:iconv=disabled"
   ],
   "apache-orc": {
+    "_comment": "Currently only passes on macOS and Ubuntu",
     "test_options": [
-      "--timeout-multiplier=2"
+      "--timeout-multiplier=4"
     ],
     "alpine_packages": [
       "tzdata"


### PR DESCRIPTION
for ease of review of bot PRs.  Increase test timeout so we see the actual failures on Alpine.