### PR TITLE
ci: disable fail-fast in `build_all`

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -101,6 +101,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: prelude
     strategy:
+      fail-fast: false
       matrix:
         include: ${{ fromJson(needs.prelude.outputs.matrix-ubuntu) }}
     steps:
@@ -132,6 +133,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: prelude
     strategy:
+      fail-fast: false
       matrix:
         include: ${{ fromJson(needs.prelude.outputs.matrix-alpine) }}
     steps:
@@ -178,6 +180,7 @@ jobs:
     runs-on: windows-latest
     needs: prelude
     strategy:
+      fail-fast: false
       matrix:
         platform: ['x64', 'x86']
     steps:
@@ -248,6 +251,7 @@ jobs:
     runs-on: windows-latest
     needs: prelude
     strategy:
+      fail-fast: false
       matrix:
         platform: ['UCRT64', 'CLANG64']
     steps:
@@ -297,6 +301,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: prelude
     strategy:
+      fail-fast: false
       matrix:
         include:
           - platform: arm64


### PR DESCRIPTION
`build_all` jobs will basically always fail, since we intentionally don't keep CI green on platforms where a wrap should work but doesn't.  If there's value in `build_all`, that value is reduced by terminating most of the jobs partway through.