### PR TITLE
c-capnproto: new wrap for 0.4.0

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -407,6 +407,14 @@
       "1.20.1-1"
     ]
   },
+  "c-capnproto": {
+    "dependency_names": [
+      "c-capnproto"
+    ],
+    "versions": [
+      "0.4.1-1"
+    ]
+  },
   "c-flags": {
     "dependency_names": [
       "c-flags"

--- a/subprojects/c-capnproto.wrap
+++ b/subprojects/c-capnproto.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = c-capnproto-0.4.1
+source_url = https://github.com/HaoZeke/c-capnproto/archive/refs/tags/v0.4.1.tar.gz
+source_filename = c-capnproto-0.4.1.tar.gz
+source_hash = 33b8d08f47914308db229a6004e9019fdec32a9e7cd147c908c62421e9b268c1
+
+[provide]
+dependency_names = c-capnproto


### PR DESCRIPTION
Pure-C Cap'n Proto runtime and the `capnpc-c` schema plugin, a maintained
fork of `opensourcerouting/c-capnproto`.

Upstream is Meson-native, so no packagefiles are needed; the project
calls `meson.override_dependency('c-capnproto', libcapnp_dep)`.

`tools/sanity_checks.py` passes locally.

The plugin is not declared in `program_names`: 0.4.0 does not call
`meson.override_find_program`, so declaring it would not match. I will
add that upstream and declare it in a later revision.