### PR TITLE
capnp-fortran: new wrap for 0.3.0

### DIFF
--- a/ci_config.json
+++ b/ci_config.json
@@ -160,6 +160,21 @@
   "cairomm": {
     "ignore_upstream_meson": "1.18.0"
   },
+  "capnp-fortran": {
+    "_comment": "Fortran; gfortran is what the runners need",
+    "alpine_packages": [
+      "gfortran"
+    ],
+    "brew_packages": [
+      "gfortran"
+    ],
+    "debian_packages": [
+      "gfortran"
+    ],
+    "msys_packages": [
+      "fc"
+    ]
+  },
   "cexception": {
     "build_options": [
       "cexception:werror=false"

--- a/releases.json
+++ b/releases.json
@@ -439,6 +439,14 @@
       "1.18.0-1"
     ]
   },
+  "capnp-fortran": {
+    "dependency_names": [
+      "capnp-fortran"
+    ],
+    "versions": [
+      "0.3.0-1"
+    ]
+  },
   "catch": {
     "versions": [
       "2.2.2-1",

--- a/subprojects/capnp-fortran.wrap
+++ b/subprojects/capnp-fortran.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = capnp-fortran-0.3.0
+source_url = https://github.com/HaoZeke/capnp-fortran/archive/refs/tags/v0.3.0.tar.gz
+source_filename = capnp-fortran-0.3.0.tar.gz
+source_hash = c873f0ad032d12d5a7a8419f56c7e7fee96d71c806599eaa0feca3a105e7df88
+
+[provide]
+dependency_names = capnp-fortran


### PR DESCRIPTION
A native modern-Fortran Cap'n Proto implementation: wire format, packed
and canonical codecs, RPC, and the `capnpc-fortran` schema plugin.

Upstream is Meson-native, so no packagefiles are needed; the project
calls `meson.override_dependency('capnp-fortran', capnp_fortran_dep)`.
Meson tracks the Fortran module directory of a linked target itself, so
a consumer reaches `use capnp` without naming an include path.

`tools/sanity_checks.py` passes locally.

The `ci_config.json` entry follows openblas, the other Fortran wrap:
gfortran for Alpine, Homebrew and Debian, `mingw-w64-ucrt-x86_64-fc` for
MSYS, and `build_on.windows = false` since there is no native Windows
Fortran compiler. This is the project's first exposure to the macOS and
MSYS toolchains, so I am expecting to iterate if CI disagrees.