### PR TITLE
capnp-janet: new wrap for 0.2.5

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -439,6 +439,14 @@
       "1.18.0-1"
     ]
   },
+  "capnp-janet": {
+    "dependency_names": [
+      "capnp-janet"
+    ],
+    "versions": [
+      "0.2.5-1"
+    ]
+  },
   "catch": {
     "versions": [
       "2.2.2-1",

--- a/subprojects/capnp-janet.wrap
+++ b/subprojects/capnp-janet.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = capnp-janet-0.2.5
+source_url = https://github.com/HaoZeke/capnp-janet/archive/refs/tags/v0.2.5.tar.gz
+source_filename = capnp-janet-0.2.5.tar.gz
+source_hash = f8274cb7802a6caeaa6aeb1d64acae0e78c824af7ce5a37888c3b718a7712267
+
+[provide]
+dependency_names = capnp-janet


### PR DESCRIPTION
A Cap'n Proto implementation in C with a Janet native module on top. The
wrap provides the C runtime; the Janet binding is built by the same
project but is not what a Meson consumer depends on.

Upstream is Meson-native, so no packagefiles are needed; the project
calls `meson.override_dependency('capnp-janet', capnp_janet_dep)`.

`tools/sanity_checks.py` passes locally.

No `ci_config.json` entry: the runtime is C99 with no external
dependencies, and the optional live-peer interop targets are skipped
when capnp-C++ is absent.